### PR TITLE
Release 0.1.1 with trusted publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.1.1 - 2026-08-15
+
+- Publish through npm trusted publishing with OIDC provenance.
+- Make npm registry readback the canonical, checksummed GitHub release artifact.
+
 ## 0.1.0 - 2026-08-15
 
 - Initial `@workflow/world` implementation backed by celld Durable Objects.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ewhauser/world-celld",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "celld (self-hosted Durable Objects) World implementation for the Vercel Workflow DevKit",
   "keywords": [
     "celld",


### PR DESCRIPTION
## Summary

- bump the package to 0.1.1
- document the first OIDC trusted-publisher/provenance release
- ship the canonical npm registry tarball as the immutable GitHub release artifact

## Validation

- `pnpm check`
- `pnpm audit --prod --audit-level high`
- `actionlint`
- `uvx zizmor --persona=pedantic .`