### PR TITLE
Patch vulnerable Hono test dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@hono/node-server@<1.19.15': 1.19.15
+  hono@<4.12.34: 4.12.34
   nanoid@>=5.0.0 <5.1.16: 5.1.16
   undici@>=7.0.0 <7.29.0: 7.29.0
 
@@ -456,11 +458,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+  '@hono/node-server@1.19.15':
+    resolution: {integrity: sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2295,8 +2297,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hono@4.13.2:
@@ -3787,9 +3789,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/node-server@1.19.13(hono@4.12.25)':
+  '@hono/node-server@1.19.15(hono@4.12.34)':
     dependencies:
-      hono: 4.12.25
+      hono: 4.12.34
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4856,12 +4858,12 @@ snapshots:
 
   '@workflow/world-testing@4.1.11(@swc/core@1.15.3)(supports-color@8.1.1)(typescript@5.9.3)(vitest@4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)))':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.25)
+      '@hono/node-server': 1.19.15(hono@4.12.34)
       '@workflow/cli': 4.3.0(supports-color@8.1.1)
       '@workflow/core': 4.6.0(supports-color@8.1.1)
       '@workflow/world': 4.2.1
       chalk: 5.6.2
-      hono: 4.12.25
+      hono: 4.12.34
       jsonlines: 0.1.1
       vitest: 4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0))
       workflow: 4.6.0(@swc/core@1.15.3)(supports-color@8.1.1)(typescript@5.9.3)
@@ -5775,7 +5777,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.25: {}
+  hono@4.12.34: {}
 
   hono@4.13.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,11 @@
 packages:
   - '.'
   - 'examples/*'
-# Converge compatible ranges on the first releases patched for the advisories
-# that affect the demo app's Workflow transitive dependencies.
+# Converge compatible ranges on the first releases patched for advisories in
+# the demo and test tooling's Workflow transitive dependencies.
 overrides:
+  '@hono/node-server@<1.19.15': 1.19.15
+  'hono@<4.12.34': 4.12.34
   'nanoid@>=5.0.0 <5.1.16': 5.1.16
   'undici@>=7.0.0 <7.29.0': 7.29.0
 # Give the ecosystem time to detect and remove compromised releases before


### PR DESCRIPTION
## Summary

- override `@workflow/world-testing`'s pinned Hono dependencies to patched compatible versions
- resolve all seven open Dependabot advisories without changing production package dependencies

## Resolved versions

- `hono`: 4.12.25 → 4.12.34
- `@hono/node-server`: 1.19.13 → 1.19.15

## Validation

- `pnpm check` (169 tests)
- `pnpm audit --audit-level low` (no known vulnerabilities)
- `actionlint`
- `uvx zizmor --persona=pedantic .`