### PR TITLE
Fix flaky harness teardown

### DIFF
--- a/src/testing/http-harness.ts
+++ b/src/testing/http-harness.ts
@@ -75,8 +75,12 @@ export async function startHarness(options: HarnessOptions = {}): Promise<Harnes
     url: `http://127.0.0.1:${port}`,
     fleet,
     close: () =>
-      new Promise<void>((resolve, reject) =>
-        server.close((err) => (err ? reject(err) : resolve())),
-      ),
+      new Promise<void>((resolve, reject) => {
+        // Test clients may retain an active keep-alive connection after their
+        // assertions finish. Stop accepting connections first, then destroy
+        // any that remain so teardown cannot wait indefinitely.
+        server.close((err) => (err ? reject(err) : resolve()));
+        server.closeAllConnections();
+      }),
   };
 }

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -3,6 +3,7 @@
  * node:http, driven by the real remote client. Everything except celld.
  */
 import { WorkflowRunNotFoundError } from '@workflow/errors';
+import { createConnection } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { rpcStringify } from '../src/codec.js';
 import { createRemoteEnv } from '../src/remote/namespaces.js';
@@ -33,6 +34,37 @@ function rpc(path: string, body: unknown, token?: string): Promise<Response> {
     body: rpcStringify(body),
   });
 }
+
+describe('test harness lifecycle', () => {
+  it('closes with an incomplete client connection still open', async () => {
+    const isolated = await startHarness({ secret: SECRET });
+    const target = new URL(isolated.url);
+    const socket = createConnection({ host: target.hostname, port: Number(target.port) });
+    let close: Promise<void> | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        socket.once('connect', resolve);
+        socket.once('error', reject);
+      });
+      socket.write(`GET /v1/health HTTP/1.1\r\nHost: ${target.host}\r\n`);
+
+      close = isolated.close();
+      await expect(
+        Promise.race([
+          close,
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => reject(new Error('harness close timed out')), 1_000);
+          }),
+        ]),
+      ).resolves.toBeUndefined();
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      socket.destroy();
+      await (close ?? isolated.close());
+    }
+  });
+});
 
 describe('router auth and shape', () => {
   it('serves /v1/health unauthenticated', async () => {


### PR DESCRIPTION
## Summary

- stop the harness HTTP server before force-closing retained active connections
- add a regression test that leaves an incomplete HTTP connection open and requires deterministic shutdown

## Root cause

The failed main run completed the `hooks` assertions, then timed out in `afterEach` because `server.close()` was waiting for an open client connection.

## Validation

- 5 consecutive complete Node 22 runs: 170/170 tests each
- `pnpm check`
- `pnpm audit --audit-level low`
- `actionlint`
- `uvx zizmor --persona=pedantic .`
- targeted Node 22 router and live-queue suites