### PR TITLE
Add terminal workflow retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Add configurable terminal-run retention with durable cleanup alarms,
+  cross-cell ownership fences, payload-free tombstones, operational controls,
+  and MinIO correctness and performance coverage.
+
 ## 0.1.1 - 2026-08-15
 
 - Publish through npm trusted publishing with OIDC provenance.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ self-hosted alternative to platform-specific Workflow backends.
 - Workflow run, step, event, and hook persistence
 - Durable streams
 - Delayed work, retries, deduplication, and dead-letter storage
+- Configurable cleanup of terminal workflow payloads
 - An authenticated HTTP connection between a Node application and a celld fleet
 - An in-process fleet for local development and conformance testing
 
@@ -64,6 +65,8 @@ const world = createCelldWorld({
   fleetUrl: 'http://fleet.internal:8080',
   secret: process.env.CELLD_WORLD_SECRET!,
   baseUrl: 'https://workflow.example.com',
+  // Keep completed, failed, and cancelled run payloads for 30 days.
+  runRetentionMs: 30 * 24 * 60 * 60 * 1000,
 });
 ```
 
@@ -135,15 +138,16 @@ cell that owns the data.
 Application options can be passed to `createCelldWorld()` unless an environment
 variable is shown below.
 
-| Option         | Environment variable  | Default                  |
-| -------------- | --------------------- | ------------------------ |
-| `fleetUrl`     | `CELLD_FLEET_URL`     | required                 |
-| `secret`       | `CELLD_WORLD_SECRET`  | required with `fleetUrl` |
-| `baseUrl`      | `WORKFLOW_BASE_URL`   | `http://localhost:$PORT` |
-| `deploymentId` | `CELLD_DEPLOYMENT_ID` | `celld-default`          |
-| `queueShards`  | —                     | `1`                      |
-| `readPollMs`   | —                     | `250`                    |
-| `rpcTimeoutMs` | —                     | `30000`                  |
+| Option           | Environment variable     | Default                  |
+| ---------------- | ------------------------ | ------------------------ |
+| `fleetUrl`       | `CELLD_FLEET_URL`        | required                 |
+| `secret`         | `CELLD_WORLD_SECRET`     | required with `fleetUrl` |
+| `baseUrl`        | `WORKFLOW_BASE_URL`      | `http://localhost:$PORT` |
+| `deploymentId`   | `CELLD_DEPLOYMENT_ID`    | `celld-default`          |
+| `queueShards`    | —                        | `1`                      |
+| `runRetentionMs` | `CELLD_RUN_RETENTION_MS` | `0` (disabled)           |
+| `readPollMs`     | —                        | `250`                    |
+| `rpcTimeoutMs`   | —                        | `30000`                  |
 
 The deployed worker also accepts these celld variables:
 
@@ -158,12 +162,45 @@ The deployed worker also accepts these celld variables:
 `queueShards` is part of queue placement and is pinned when a queue cell is
 first used. Drain pending work before changing it.
 
+## Terminal run retention
+
+When `runRetentionMs` is greater than zero, a terminal transition atomically
+records the run's `expiredAt` and arms its cell alarm. The complete run, event,
+step, hook, and stream data remains readable until that deadline. Active and
+pending runs are never eligible for automatic cleanup.
+
+At expiration, the run cell fences new writes and removes the run's derived
+indexes, stream chunks, pending and dead-letter queue messages, and durable run
+payloads. Cleanup is a persisted, idempotent state machine: an interrupted
+phase records its error and re-arms itself with capped backoff.
+
+The final state is a metadata-only tombstone, not an empty cell. It prevents a
+delayed queue delivery or stale RPC from recreating an expired run. Reads and
+writes against that run return `RunExpiredError`, and the run no longer appears
+in listings. Tombstones contain no workflow input, output, event, step, hook,
+stream, or queue payload.
+
+The returned World exposes authenticated operational methods:
+
+```ts
+const status = await world.retention.getStatus(runId);
+await world.retention.schedule(runId); // requires runRetentionMs > 0
+await world.retention.cleanupNow(runId);
+await world.retention.rearm(runId); // recover a missed or abandoned alarm
+```
+
+The retention deadline is pinned when the run becomes terminal. Changing the
+configuration affects newly terminal runs; call `schedule()` explicitly for
+an existing terminal run that has no cleanup record.
+
 ## Operational notes
 
 - Delivery is at least once. Workflow steps and other external side effects
   must be idempotent.
 - Queue cells expose `stats`, `listDeadLetters`, `redriveDeadLetter`,
   `purgeDeadLetters`, and `rearmAlarm` through the authenticated RPC endpoint.
+- Run cells expose retention status, scheduling, immediate cleanup, and alarm
+  recovery through `world.retention`.
 - A new application URL applies to newly enqueued messages. Existing messages
   retain the callback URL with which they were created.
 - Fleet restarts can interrupt in-flight callbacks; expired claims are
@@ -176,7 +213,7 @@ pnpm format
 pnpm check
 ```
 
-`pnpm check` runs formatting, linting, type checking, tests, the build, and the
+`pnpm check` runs formatting, linting, type checking, the build, tests, and the
 worker and npm-package checks. The package check inspects the exact tarball and
 installs it in a clean temporary consumer with lifecycle scripts disabled.
 Oxlint runs its correctness, suspicious, and performance categories with
@@ -193,12 +230,12 @@ pnpm test:integration
 ### Local MinIO performance and loss test
 
 The opt-in performance harness starts a fresh MinIO bucket and a single celld
-node with Docker Compose, sends concurrent queue traffic, and verifies that
-every accepted message reaches a successful callback. A configurable portion
-of callbacks returns one `503` first, so the same run also exercises durable
-redelivery. The result includes enqueue and delivery throughput plus p50, p95,
-p99, and maximum latency for all deliveries, first-attempt successes, and
-retried messages. It is saved to `.perf-results/minio-latest.json`.
+node with Docker Compose. Its queue workload verifies that every accepted
+message reaches a successful callback, including forced `503` redeliveries. A
+second workload creates terminal runs with streams and delayed queue messages,
+then verifies complete payload cleanup without resurrection. Results include
+queue and cleanup throughput plus p50, p95, p99, and maximum latency and are
+saved under `.perf-results/`.
 
 > MinIO Community is **not a supported celld production store**. It does not
 > implement the conditional writes celld needs for ownership fencing. This

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm check:worker-bundle && pnpm pack:check",
+    "check": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm build && pnpm test && pnpm check:worker-bundle && pnpm pack:check",
     "clean": "rm -rf dist",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",

--- a/src/apply-event.ts
+++ b/src/apply-event.ts
@@ -44,6 +44,7 @@ import {
   WorkflowRunSchema,
 } from '@workflow/world';
 import { compact } from './util.js';
+import type { ScheduleCleanupRequest } from './retention.js';
 
 /** Storage key for the run entity. */
 const RUN_KEY = 'run';
@@ -93,6 +94,8 @@ export interface ApplyEventRequest {
    * (hook_created only). `null` means the token is unclaimed.
    */
   tokenHolder?: { runId: string; hookId: string } | null;
+  /** Internal world-celld retention policy captured with the event. */
+  cleanup?: ScheduleCleanupRequest;
 }
 
 export type ApplyEventErrorCode =

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,10 @@ export interface IndexNamespace {
   get(key: string): Promise<string | null>;
   put(key: string, value: string): Promise<void>;
   delete(key: string): Promise<void>;
+  putOwned(runId: string, key: string, value: string): Promise<{ stored: boolean }>;
+  expireRun(
+    request: import('./retention.js').ExpireRunIndexesRequest,
+  ): Promise<import('./retention.js').ExpireRunIndexesResult>;
   list(options?: { prefix?: string; cursor?: string; limit?: number; reverse?: boolean }): Promise<{
     keys: Array<{ name: string }>;
     list_complete: boolean;
@@ -66,6 +70,12 @@ export interface CelldWorldConfig {
   baseUrl?: string;
   /** Number of queue cells to spread enqueues over. Default: 1 */
   queueShards?: number;
+  /**
+   * Keep terminal run payloads for this many milliseconds before replacing
+   * them with metadata-only tombstones. Zero disables automatic cleanup.
+   * Default: process.env.CELLD_RUN_RETENTION_MS || 0
+   */
+  runRetentionMs?: number;
   /** Poll interval (ms) while waiting for new chunks on a live stream. Default: 250 */
   readPollMs?: number;
   /** Per-attempt fleet RPC deadline in milliseconds. Default: 30000 */
@@ -79,11 +89,19 @@ export interface ResolvedCelldConfig {
   deploymentId: string;
   baseUrl?: string;
   queueShards: number;
+  runRetentionMs: number;
   readPollMs: number;
   rpcTimeoutMs: number;
 }
 
 export function resolveConfig(config?: CelldWorldConfig): ResolvedCelldConfig {
+  const retentionRaw = config?.runRetentionMs ?? process.env.CELLD_RUN_RETENTION_MS ?? 0;
+  const runRetentionMs =
+    typeof retentionRaw === 'number' ? retentionRaw : Number.parseInt(retentionRaw, 10);
+  if (!Number.isSafeInteger(runRetentionMs) || runRetentionMs < 0) {
+    throw new Error('world-celld: runRetentionMs must be a non-negative safe integer');
+  }
+
   return {
     fleetUrl: config?.fleetUrl ?? process.env.CELLD_FLEET_URL,
     secret: config?.secret ?? process.env.CELLD_WORLD_SECRET,
@@ -91,6 +109,7 @@ export function resolveConfig(config?: CelldWorldConfig): ResolvedCelldConfig {
     deploymentId: config?.deploymentId ?? process.env.CELLD_DEPLOYMENT_ID ?? 'celld-default',
     baseUrl: config?.baseUrl,
     queueShards: config?.queueShards ?? 1,
+    runRetentionMs,
     readPollMs: config?.readPollMs ?? 250,
     rpcTimeoutMs: config?.rpcTimeoutMs ?? 30_000,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { createRemoteEnv } from './remote/namespaces.js';
 import { createQueue } from './queue.js';
 import { createStorage } from './storage.js';
 import { createStreamer } from './streamer.js';
+import type { CleanupRecord } from './retention.js';
 
 export type { CelldWorldConfig, CelldWorldEnv, IndexNamespace } from './config.js';
 export type {
@@ -20,8 +21,18 @@ export type {
 } from './queue.js';
 export type { WorkflowRunDONamespace, WorkflowRunDOStub } from './storage.js';
 export type { StreamDONamespace, StreamDOStub } from './streamer.js';
+export type { CleanupPhase, CleanupRecord, RunTombstone } from './retention.js';
 
-export function createCelldWorld(config?: CelldWorldConfig): World {
+export interface CelldRetentionAdmin {
+  getStatus(runId: string): Promise<CleanupRecord | null>;
+  schedule(runId: string): Promise<CleanupRecord | null>;
+  cleanupNow(runId: string): Promise<CleanupRecord | null>;
+  rearm(runId: string): Promise<CleanupRecord | null>;
+}
+
+export type CelldWorld = World & { retention: CelldRetentionAdmin };
+
+export function createCelldWorld(config?: CelldWorldConfig): CelldWorld {
   const resolved = resolveConfig(config);
 
   // Check for global test environment first (for @workflow/world-testing)
@@ -62,6 +73,8 @@ export function createCelldWorld(config?: CelldWorldConfig): World {
       WORKFLOW_INDEX: env.WORKFLOW_INDEX,
     },
     deploymentId: resolved.deploymentId,
+    runRetentionMs: resolved.runRetentionMs,
+    queueShards: resolved.queueShards,
   });
 
   const queue = createQueue({
@@ -80,10 +93,33 @@ export function createCelldWorld(config?: CelldWorldConfig): World {
     readPollMs: resolved.readPollMs,
   });
 
+  const runStub = (runId: string) => env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName(runId));
+  const retention: CelldRetentionAdmin = {
+    getStatus: (runId) => runStub(runId).getCleanupStatus(),
+    schedule: (runId) => {
+      if (resolved.runRetentionMs === 0) {
+        throw new Error(
+          'world-celld: runRetentionMs must be greater than zero to schedule cleanup',
+        );
+      }
+      return runStub(runId).scheduleCleanup({
+        retentionMs: resolved.runRetentionMs,
+        queueShards: resolved.queueShards,
+      });
+    },
+    cleanupNow: (runId) =>
+      runStub(runId).cleanupNow({
+        retentionMs: Math.max(1, resolved.runRetentionMs),
+        queueShards: resolved.queueShards,
+      }),
+    rearm: (runId) => runStub(runId).rearmCleanup(),
+  };
+
   return {
     ...storage,
     ...queue,
     ...streamer,
+    retention,
     // Enables resilient start: runs are created at the current spec version,
     // so the queue message carries runInput and run_started can bootstrap the
     // run when run_created has not landed yet.

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -18,6 +18,7 @@
  */
 import { setTimeout as delay } from 'node:timers/promises';
 import { WorkflowWorldError } from '@workflow/errors';
+import { RunExpiredError } from '@workflow/errors';
 import {
   MessageId,
   parseQueueName,
@@ -79,6 +80,8 @@ export interface EnqueueRequest {
   pathname: Pathname;
   /** `stringify(message)` — the exact bytes POSTed to the app on delivery. */
   body: string;
+  /** Owning workflow run; absent only for health-check messages. */
+  runId?: string;
   idempotencyKey?: string;
   delaySeconds?: number;
   /**
@@ -96,11 +99,15 @@ export interface QueueCellConfig {
 
 export type EnqueueOutcome =
   | { ok: true; messageId: string; deduped: boolean }
-  | { ok: false; code: 'CONFIG_MISMATCH'; message: string };
+  | { ok: false; code: 'CONFIG_MISMATCH' | 'RUN_EXPIRED'; message: string };
 
 /** RPC surface of QueueDO used by the queue producer. */
 export interface QueueCellStub {
   enqueue(request: EnqueueRequest): Promise<EnqueueOutcome>;
+  expireRun(
+    runId: string,
+    expiredAt: number,
+  ): Promise<import('./retention.js').ExpireQueueRunResult>;
 }
 
 export interface QueueCellNamespace {
@@ -315,6 +322,12 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
   return {
     async queue(queueName, message, opts) {
       const { kind } = parseQueueName(queueName);
+      const runId =
+        'runId' in message
+          ? message.runId
+          : 'workflowRunId' in message
+            ? message.workflowRunId
+            : undefined;
 
       if (isTestMode()) {
         // Dedup on idempotencyKey while a message with the same key is in
@@ -349,6 +362,7 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
         queueName,
         pathname: QUEUE_PATHNAMES[kind],
         body: stringify(message),
+        runId,
         idempotencyKey: opts?.idempotencyKey,
         delaySeconds: opts?.delaySeconds,
         config: {
@@ -358,6 +372,9 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
       });
 
       if (!outcome.ok) {
+        if (outcome.code === 'RUN_EXPIRED') {
+          throw new RunExpiredError(outcome.message);
+        }
         throw new WorkflowWorldError(outcome.message, { status: 409 });
       }
 

--- a/src/remote/namespaces.ts
+++ b/src/remote/namespaces.ts
@@ -16,13 +16,42 @@ interface MethodSpec {
 }
 
 const RUNS: MethodSpec = {
-  methods: ['applyEvent', 'getRun', 'getStep', 'getEvent', 'listEvents', 'listSteps', 'listHooks'],
-  mutating: new Set(['applyEvent']),
+  methods: [
+    'applyEvent',
+    'getRun',
+    'getStep',
+    'getEvent',
+    'listEvents',
+    'listSteps',
+    'listHooks',
+    'getCleanupStatus',
+    'scheduleCleanup',
+    'cleanupNow',
+    'rearmCleanup',
+  ],
+  mutating: new Set(['applyEvent', 'scheduleCleanup', 'cleanupNow', 'rearmCleanup']),
 };
 
 const STREAMS: MethodSpec = {
-  methods: ['writeChunk', 'closeStream', 'getChunks', 'getInfo', 'registerStream', 'listStreams'],
-  mutating: new Set(['writeChunk', 'closeStream', 'registerStream']),
+  methods: [
+    'writeChunk',
+    'closeStream',
+    'getChunks',
+    'getInfo',
+    'registerStream',
+    'listStreams',
+    'expireRegistry',
+    'finalizeRegistry',
+    'expireStream',
+  ],
+  mutating: new Set([
+    'writeChunk',
+    'closeStream',
+    'registerStream',
+    'expireRegistry',
+    'finalizeRegistry',
+    'expireStream',
+  ]),
 };
 
 const QUEUE: MethodSpec = {
@@ -33,8 +62,15 @@ const QUEUE: MethodSpec = {
     'redriveDeadLetter',
     'purgeDeadLetters',
     'rearmAlarm',
+    'expireRun',
   ],
-  mutating: new Set(['enqueue', 'redriveDeadLetter', 'purgeDeadLetters', 'rearmAlarm']),
+  mutating: new Set([
+    'enqueue',
+    'redriveDeadLetter',
+    'purgeDeadLetters',
+    'rearmAlarm',
+    'expireRun',
+  ]),
 };
 
 function makeStub<T>(transport: RpcTransport, binding: string, name: string, spec: MethodSpec): T {
@@ -69,6 +105,9 @@ function makeIndexNamespace(transport: RpcTransport): IndexNamespace {
     get: (key) => call<string | null>('get', [key], true),
     put: (key, value) => call<void>('put', [key, value], false),
     delete: (key) => call<void>('delete', [key], false),
+    putOwned: (runId, key, value) =>
+      call<{ stored: boolean }>('putOwned', [runId, key, value], false),
+    expireRun: (request) => call('expireRun', [request], false),
     list: (options) => call('list', [options], true),
     reserveHookToken: (token: string, owner: HookTokenOwner) =>
       call('reserveHookToken', [token, owner], false),

--- a/src/retention.ts
+++ b/src/retention.ts
@@ -1,0 +1,125 @@
+import type { TerminalWorkflowRunStatus, WorkflowRun } from '@workflow/world';
+
+export const CLEANUP_RECORD_KEY = 'retention:cleanup';
+export const TOMBSTONE_KEY = 'retention:tombstone';
+export const INDEX_MARKER_PREFIX = 'retention:index:';
+export const HOOK_MARKER_PREFIX = 'retention:hook:';
+
+export type CleanupPhase = 'retained' | 'index' | 'streams' | 'queues' | 'payload' | 'tombstoned';
+
+export interface CleanupRecord {
+  version: 1;
+  runId: string;
+  workflowName: string;
+  createdAt: Date;
+  completedAt: Date;
+  terminalStatus: TerminalWorkflowRunStatus;
+  dueAt: Date;
+  queueShards: number;
+  phase: CleanupPhase;
+  attempts: number;
+  lastError?: string;
+  lastAttemptAt?: Date;
+  tombstonedAt?: Date;
+  deletedPayloadKeys: number;
+  deletedStreams: number;
+  deletedQueueMessages: number;
+}
+
+export interface RunTombstone {
+  version: 1;
+  runId: string;
+  terminalStatus: TerminalWorkflowRunStatus;
+  completedAt: Date;
+  expiredAt: Date;
+  tombstonedAt: Date;
+}
+
+export type RunReadOutcome<T> =
+  | { ok: true; value: T }
+  | { ok: false; code: 'RUN_EXPIRED'; message: string; tombstone: RunTombstone };
+
+export interface HookIndexReference {
+  hookId: string;
+  token: string;
+}
+
+export interface ExpireRunIndexesRequest {
+  runId: string;
+  keys: string[];
+  hooks: HookIndexReference[];
+  expiredAt: number;
+}
+
+export interface ExpireRunIndexesResult {
+  deleted: number;
+}
+
+export interface ExpireRunStreamsResult {
+  streams: string[];
+}
+
+export interface ExpireStreamResult {
+  deleted: boolean;
+  chunks: number;
+}
+
+export interface ExpireQueueRunResult {
+  deleted: number;
+}
+
+export interface ScheduleCleanupRequest {
+  retentionMs: number;
+  queueShards: number;
+}
+
+export function sortableTimestamp(date: Date): string {
+  return date.getTime().toString().padStart(13, '0');
+}
+
+export function workflowRunIndexKey(
+  run: Pick<WorkflowRun, 'workflowName' | 'createdAt' | 'runId'>,
+) {
+  return `run:${run.workflowName}:${sortableTimestamp(run.createdAt)}:${run.runId}`;
+}
+
+export function globalRunIndexKey(run: Pick<WorkflowRun, 'createdAt' | 'runId'>) {
+  return `runall:${sortableTimestamp(run.createdAt)}:${run.runId}`;
+}
+
+export function correlationIndexKey(
+  correlationId: string,
+  createdAt: Date,
+  eventId: string,
+  runId: string,
+): string {
+  return `correlation:${encodeURIComponent(correlationId)}:${sortableTimestamp(createdAt)}:${eventId}:${runId}`;
+}
+
+export function indexMarkerKey(indexKey: string): string {
+  return `${INDEX_MARKER_PREFIX}${encodeURIComponent(indexKey)}`;
+}
+
+export function hookMarkerKey(reference: HookIndexReference): string {
+  return `${HOOK_MARKER_PREFIX}${encodeURIComponent(reference.hookId)}:${encodeURIComponent(reference.token)}`;
+}
+
+export function cleanupTombstone(record: CleanupRecord, now: Date): RunTombstone {
+  return {
+    version: 1,
+    runId: record.runId,
+    terminalStatus: record.terminalStatus,
+    completedAt: record.completedAt,
+    expiredAt: record.dueAt,
+    tombstonedAt: now,
+  };
+}
+
+export function expiredRead<T>(tombstone: RunTombstone): RunReadOutcome<T> {
+  return {
+    ok: false,
+    code: 'RUN_EXPIRED',
+    message: `Workflow run "${tombstone.runId}" expired at ${tombstone.expiredAt.toISOString()}`,
+    tombstone,
+  };
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -42,6 +42,12 @@ import { monotonicFactory } from 'ulid';
 import type { ApplyEventFailure, ApplyEventOutcome, ApplyEventRequest } from './apply-event.js';
 import type { HookTokenOwner, IndexNamespace } from './config.js';
 import { compact } from './util.js';
+import {
+  correlationIndexKey,
+  globalRunIndexKey,
+  type RunReadOutcome,
+  workflowRunIndexKey,
+} from './retention.js';
 
 /**
  * RPC surface of WorkflowRunDO used by the storage layer. Declared
@@ -49,24 +55,32 @@ import { compact } from './util.js';
  */
 export interface WorkflowRunDOStub {
   applyEvent(request: ApplyEventRequest): Promise<ApplyEventOutcome>;
-  getRun(): Promise<WorkflowRun | null>;
-  getStep(stepId: string): Promise<Step | null>;
-  getEvent(eventId: string): Promise<Event | null>;
+  getRun(): Promise<RunReadOutcome<WorkflowRun | null>>;
+  getStep(stepId: string): Promise<RunReadOutcome<Step | null>>;
+  getEvent(eventId: string): Promise<RunReadOutcome<Event | null>>;
   listEvents(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Event[]; cursor: string | null; hasMore: boolean }>;
+  }): Promise<RunReadOutcome<{ data: Event[]; cursor: string | null; hasMore: boolean }>>;
   listSteps(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Step[]; cursor: string | null; hasMore: boolean }>;
+  }): Promise<RunReadOutcome<{ data: Step[]; cursor: string | null; hasMore: boolean }>>;
   listHooks(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Hook[]; cursor: string | null; hasMore: boolean }>;
+  }): Promise<RunReadOutcome<{ data: Hook[]; cursor: string | null; hasMore: boolean }>>;
+  getCleanupStatus(): Promise<import('./retention.js').CleanupRecord | null>;
+  scheduleCleanup(
+    request: import('./retention.js').ScheduleCleanupRequest,
+  ): Promise<import('./retention.js').CleanupRecord | null>;
+  cleanupNow(
+    request: import('./retention.js').ScheduleCleanupRequest,
+  ): Promise<import('./retention.js').CleanupRecord | null>;
+  rearmCleanup(): Promise<import('./retention.js').CleanupRecord | null>;
 }
 
 export interface WorkflowRunDONamespace {
@@ -84,18 +98,8 @@ export interface CloudflareStorageConfig {
     WORKFLOW_INDEX: IndexNamespace;
   };
   deploymentId: string;
-}
-
-function sortableTimestamp(date: Date): string {
-  return date.getTime().toString().padStart(13, '0');
-}
-
-function workflowRunIndexKey(run: WorkflowRun): string {
-  return `run:${run.workflowName}:${sortableTimestamp(run.createdAt)}:${run.runId}`;
-}
-
-function globalRunIndexKey(run: WorkflowRun): string {
-  return `runall:${sortableTimestamp(run.createdAt)}:${run.runId}`;
+  runRetentionMs?: number;
+  queueShards?: number;
 }
 
 function hookOwner(hook: Pick<Hook, 'runId' | 'hookId'>): HookTokenOwner {
@@ -170,8 +174,19 @@ const parseStep = (step: Step): Step => StepSchema.parse(compact(step));
 const parseHook = (hook: Hook): Hook => HookSchema.parse(compact(hook));
 const parseEvent = (event: Event): Event => EventSchema.parse(compact(event));
 
+function unwrapRead<T>(outcome: RunReadOutcome<T>): T {
+  if (!outcome.ok) {
+    throw new RunExpiredError(outcome.message);
+  }
+  return outcome.value;
+}
+
 export function createStorage(config: CloudflareStorageConfig): Storage {
   const { env } = config;
+  const cleanup = {
+    retentionMs: config.runRetentionMs ?? 0,
+    queueShards: config.queueShards ?? 1,
+  };
   const ulid = monotonicFactory();
 
   // Helper to get or create a DO for a run
@@ -185,7 +200,7 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
     params?: GetWorkflowRunParams,
   ): Promise<WorkflowRun | WorkflowRunWithoutData> => {
     const stub = getRunDO(runId);
-    const run = await stub.getRun();
+    const run = unwrapRead(await stub.getRun());
 
     if (!run) {
       throw new WorkflowRunNotFoundError(runId);
@@ -237,7 +252,7 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
                 if (matches.length > limit) break;
               }
             } catch (error) {
-              if (!WorkflowRunNotFoundError.is(error)) throw error;
+              if (!WorkflowRunNotFoundError.is(error) && !RunExpiredError.is(error)) throw error;
             }
           }
 
@@ -295,7 +310,7 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
         // before anything is persisted.
         let outcome: ApplyEventOutcome;
         try {
-          outcome = await stub.applyEvent({ runId: effectiveRunId, data, tokenHolder });
+          outcome = await stub.applyEvent({ runId: effectiveRunId, data, tokenHolder, cleanup });
         } catch (error) {
           if (hookReservation && data.eventType === 'hook_created') {
             await env.WORKFLOW_INDEX.releaseHookToken(data.eventData.token, hookReservation);
@@ -318,8 +333,8 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
             createdAt: outcome.run.createdAt.toISOString(),
             status: outcome.run.status,
           });
-          await env.WORKFLOW_INDEX.put(workflowRunIndexKey(outcome.run), meta);
-          await env.WORKFLOW_INDEX.put(globalRunIndexKey(outcome.run), meta);
+          await env.WORKFLOW_INDEX.putOwned(effectiveRunId, workflowRunIndexKey(outcome.run), meta);
+          await env.WORKFLOW_INDEX.putOwned(effectiveRunId, globalRunIndexKey(outcome.run), meta);
         }
         if (outcome.hookToIndex) {
           const serialized = stringify(outcome.hookToIndex);
@@ -339,10 +354,14 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
           });
         }
         if (outcome.event?.correlationId) {
-          const correlationKey = `correlation:${encodeURIComponent(
+          const correlationKey = correlationIndexKey(
             outcome.event.correlationId,
-          )}:${sortableTimestamp(outcome.event.createdAt)}:${outcome.event.eventId}:${effectiveRunId}`;
-          await env.WORKFLOW_INDEX.put(
+            outcome.event.createdAt,
+            outcome.event.eventId,
+            effectiveRunId,
+          );
+          await env.WORKFLOW_INDEX.putOwned(
+            effectiveRunId,
             correlationKey,
             JSON.stringify({ runId: effectiveRunId, eventId: outcome.event.eventId }),
           );
@@ -359,7 +378,7 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
 
       async get(runId: string, eventId: string, _params?: GetEventParams): Promise<Event> {
         const stub = getRunDO(runId);
-        const event = await stub.getEvent(eventId);
+        const event = unwrapRead(await stub.getEvent(eventId));
 
         if (!event) {
           throw new WorkflowWorldError(`Event not found: ${eventId}`, {
@@ -375,11 +394,13 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
         const limit = params?.pagination?.limit ?? 100;
 
         const stub = getRunDO(runId);
-        const result = await stub.listEvents({
-          limit,
-          cursor: params?.pagination?.cursor || undefined,
-          sortOrder: params.pagination?.sortOrder || 'asc',
-        });
+        const result = unwrapRead(
+          await stub.listEvents({
+            limit,
+            cursor: params?.pagination?.cursor || undefined,
+            sortOrder: params.pagination?.sortOrder || 'asc',
+          }),
+        );
 
         return {
           data: result.data.map(parseEvent),
@@ -402,7 +423,8 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
             const raw = await env.WORKFLOW_INDEX.get(name);
             if (!raw) return null;
             const { runId, eventId } = JSON.parse(raw) as { runId: string; eventId: string };
-            return getRunDO(runId).getEvent(eventId);
+            const outcome = await getRunDO(runId).getEvent(eventId);
+            return outcome.ok ? outcome.value : null;
           }),
         );
         return {
@@ -421,7 +443,7 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
           });
         }
         const stub = getRunDO(runId);
-        const step = await stub.getStep(stepId);
+        const step = unwrapRead(await stub.getStep(stepId));
 
         if (!step) {
           throw new WorkflowWorldError(`Step not found: ${stepId}`, {
@@ -439,11 +461,13 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
         const limit = params?.pagination?.limit ?? 20;
 
         const stub = getRunDO(runId);
-        const result = await stub.listSteps({
-          limit,
-          cursor: params?.pagination?.cursor || undefined,
-          sortOrder: params?.pagination?.sortOrder ?? 'asc',
-        });
+        const result = unwrapRead(
+          await stub.listSteps({
+            limit,
+            cursor: params?.pagination?.cursor || undefined,
+            sortOrder: params?.pagination?.sortOrder ?? 'asc',
+          }),
+        );
 
         return {
           data: result.data.map((s) =>
@@ -488,11 +512,13 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
         const limit = params?.pagination?.limit ?? 100;
 
         const stub = getRunDO(runId);
-        const result = await stub.listHooks({
-          limit,
-          cursor: params?.pagination?.cursor || undefined,
-          sortOrder: params?.pagination?.sortOrder ?? 'asc',
-        });
+        const result = unwrapRead(
+          await stub.listHooks({
+            limit,
+            cursor: params?.pagination?.cursor || undefined,
+            sortOrder: params?.pagination?.sortOrder ?? 'asc',
+          }),
+        );
 
         return {
           data: result.data.map((h) => filterHookData(parseHook(h), params?.resolveData ?? 'all')),

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -5,6 +5,7 @@ import type {
   StreamInfoResponse,
   Streamer,
 } from '@workflow/world';
+import type { ExpireRunStreamsResult, ExpireStreamResult } from './retention.js';
 
 export interface CelldStreamerConfig {
   env: {
@@ -24,15 +25,18 @@ export interface CelldStreamerConfig {
  * protocol.
  */
 export interface StreamDOStub {
-  writeChunk(data: Uint8Array): Promise<number>;
-  closeStream(): Promise<void>;
+  writeChunk(runId: string, data: Uint8Array): Promise<number>;
+  closeStream(runId: string): Promise<void>;
   getChunks(params: {
     startIndex: number;
     limit: number;
   }): Promise<{ chunks: Uint8Array[]; done: boolean; tailIndex: number }>;
   getInfo(): Promise<{ tailIndex: number; done: boolean }>;
-  registerStream(name: string): Promise<void>;
+  registerStream(runId: string, name: string): Promise<void>;
   listStreams(): Promise<string[]>;
+  expireRegistry(runId: string, expiredAt: number): Promise<ExpireRunStreamsResult>;
+  finalizeRegistry(runId: string): Promise<void>;
+  expireStream(runId: string, expiredAt: number): Promise<ExpireStreamResult>;
 }
 
 export interface StreamDONamespace {
@@ -76,7 +80,7 @@ export function createStreamer(config: CelldStreamerConfig): Streamer {
   async function registerStreamForRun(name: string, runId: string): Promise<void> {
     const cacheKey = `${runId}\0${name}`;
     if (registeredStreams.has(cacheKey)) return;
-    await getRunRegistryDO(runId).registerStream(name);
+    await getRunRegistryDO(runId).registerStream(runId, name);
     registeredStreams.add(cacheKey);
   }
 
@@ -84,13 +88,13 @@ export function createStreamer(config: CelldStreamerConfig): Streamer {
     async writeToStream(name: string, runId: string | Promise<string>, chunk: string | Uint8Array) {
       const resolvedRunId = await runId;
       await registerStreamForRun(name, resolvedRunId);
-      await getStreamDO(name).writeChunk(toBytes(chunk));
+      await getStreamDO(name).writeChunk(resolvedRunId, toBytes(chunk));
     },
 
     async closeStream(name: string, runId: string | Promise<string>) {
       const resolvedRunId = await runId;
       await registerStreamForRun(name, resolvedRunId);
-      await getStreamDO(name).closeStream();
+      await getStreamDO(name).closeStream(resolvedRunId);
     },
 
     async readFromStream(name: string, startIndex = 0) {

--- a/src/test-mocks.ts
+++ b/src/test-mocks.ts
@@ -25,6 +25,12 @@ import {
   STEP_KEY_PREFIX,
 } from './apply-event.js';
 import { parse } from './vendor/shared/index.js';
+import type {
+  CleanupRecord,
+  ExpireRunIndexesRequest,
+  RunReadOutcome,
+  ScheduleCleanupRequest,
+} from './retention.js';
 
 // In-memory storage for mock Durable Objects
 const durableObjectData = new Map<string, Map<string, unknown>>();
@@ -118,60 +124,85 @@ class MockWorkflowRunDOStub {
     return outcome;
   }
 
-  async getRun(): Promise<WorkflowRun | null> {
+  async getRun(): Promise<RunReadOutcome<WorkflowRun | null>> {
     const run = await this.store.get<WorkflowRun>('run');
-    return run ?? null;
+    return { ok: true, value: run ?? null };
   }
 
-  async getStep(stepId: string): Promise<Step | null> {
+  async getStep(stepId: string): Promise<RunReadOutcome<Step | null>> {
     const step = await this.store.get<Step>(`${STEP_KEY_PREFIX}${stepId}`);
-    return step ?? null;
+    return { ok: true, value: step ?? null };
   }
 
-  async getEvent(eventId: string): Promise<Event | null> {
+  async getEvent(eventId: string): Promise<RunReadOutcome<Event | null>> {
     const event = await this.store.get<Event>(`${EVENT_KEY_PREFIX}${eventId}`);
-    return event ?? null;
+    return { ok: true, value: event ?? null };
   }
 
   async listEvents(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Event[]; cursor: string | null; hasMore: boolean }> {
-    return listByPrefix<Event>(
-      this.store,
-      EVENT_KEY_PREFIX,
-      {
-        limit: params?.limit ?? 100,
-        cursor: params?.cursor,
-        sortOrder: params?.sortOrder ?? 'asc',
-      },
-      (event) => event.eventId,
-    );
+  }): Promise<RunReadOutcome<{ data: Event[]; cursor: string | null; hasMore: boolean }>> {
+    return {
+      ok: true,
+      value: await listByPrefix<Event>(
+        this.store,
+        EVENT_KEY_PREFIX,
+        {
+          limit: params?.limit ?? 100,
+          cursor: params?.cursor,
+          sortOrder: params?.sortOrder ?? 'asc',
+        },
+        (event) => event.eventId,
+      ),
+    };
   }
 
   async listSteps(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Step[]; cursor: string | null; hasMore: boolean }> {
-    return listByCreationTime<Step>(this.store, STEP_CREATED_KEY_PREFIX, STEP_KEY_PREFIX, {
-      limit: params?.limit ?? 20,
-      cursor: params?.cursor,
-      sortOrder: params?.sortOrder ?? 'asc',
-    });
+  }): Promise<RunReadOutcome<{ data: Step[]; cursor: string | null; hasMore: boolean }>> {
+    return {
+      ok: true,
+      value: await listByCreationTime<Step>(this.store, STEP_CREATED_KEY_PREFIX, STEP_KEY_PREFIX, {
+        limit: params?.limit ?? 20,
+        cursor: params?.cursor,
+        sortOrder: params?.sortOrder ?? 'asc',
+      }),
+    };
   }
 
   async listHooks(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Hook[]; cursor: string | null; hasMore: boolean }> {
-    return listByCreationTime<Hook>(this.store, HOOK_CREATED_KEY_PREFIX, HOOK_KEY_PREFIX, {
-      limit: params?.limit ?? 100,
-      cursor: params?.cursor,
-      sortOrder: params?.sortOrder ?? 'asc',
-    });
+  }): Promise<RunReadOutcome<{ data: Hook[]; cursor: string | null; hasMore: boolean }>> {
+    return {
+      ok: true,
+      value: await listByCreationTime<Hook>(this.store, HOOK_CREATED_KEY_PREFIX, HOOK_KEY_PREFIX, {
+        limit: params?.limit ?? 100,
+        cursor: params?.cursor,
+        sortOrder: params?.sortOrder ?? 'asc',
+      }),
+    };
+  }
+
+  async getCleanupStatus(): Promise<CleanupRecord | null> {
+    return null;
+  }
+
+  async scheduleCleanup(_request: ScheduleCleanupRequest): Promise<CleanupRecord | null> {
+    return null;
+  }
+
+  async cleanupNow(_request: ScheduleCleanupRequest): Promise<CleanupRecord | null> {
+    return null;
+  }
+
+  async rearmCleanup(): Promise<CleanupRecord | null> {
+    return null;
   }
 
   async claimInflight(params: { messageId: string; staleMs: number }): Promise<{
@@ -207,6 +238,30 @@ class MockKVNamespace {
 
   async put(key: string, value: string): Promise<void> {
     kvData.set(key, value);
+  }
+
+  async putOwned(runId: string, key: string, value: string): Promise<{ stored: boolean }> {
+    if (kvData.has(`expired:${runId}`)) return { stored: false };
+    kvData.set(key, value);
+    return { stored: true };
+  }
+
+  async expireRun(request: ExpireRunIndexesRequest): Promise<{ deleted: number }> {
+    kvData.set(`expired:${request.runId}`, String(request.expiredAt));
+    let deleted = 0;
+    for (const key of request.keys) {
+      if (kvData.delete(key)) deleted++;
+    }
+    for (const hook of request.hooks) {
+      for (const key of [
+        `hook:${hook.token}`,
+        `hookid:${hook.hookId}`,
+        `hookclaim:${hook.token}`,
+      ]) {
+        if (kvData.delete(key)) deleted++;
+      }
+    }
+    return { deleted };
   }
 
   async delete(key: string): Promise<void> {
@@ -331,8 +386,13 @@ class MockStreamDOStub {
   private chunks: Uint8Array[] = [];
   private closed = false;
   private registry = new Set<string>();
+  private ownerRunId: string | undefined;
+  private expired = false;
 
-  async writeChunk(data: Uint8Array): Promise<number> {
+  async writeChunk(runId: string, data: Uint8Array): Promise<number> {
+    if (this.expired) throw new Error('Stream has expired');
+    if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Stream owner mismatch');
+    this.ownerRunId = runId;
     if (this.closed) {
       throw new Error('Cannot write to a closed stream');
     }
@@ -340,7 +400,10 @@ class MockStreamDOStub {
     return this.chunks.length - 1;
   }
 
-  async closeStream(): Promise<void> {
+  async closeStream(runId: string): Promise<void> {
+    if (this.expired) throw new Error('Stream has expired');
+    if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Stream owner mismatch');
+    this.ownerRunId = runId;
     this.closed = true;
   }
 
@@ -361,12 +424,38 @@ class MockStreamDOStub {
     return { tailIndex: this.chunks.length - 1, done: this.closed };
   }
 
-  async registerStream(name: string): Promise<void> {
+  async registerStream(runId: string, name: string): Promise<void> {
+    if (this.expired) throw new Error('Stream registry has expired');
+    if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Registry owner mismatch');
+    this.ownerRunId = runId;
     this.registry.add(name);
   }
 
   async listStreams(): Promise<string[]> {
+    if (this.expired) throw new Error('Stream registry has expired');
     return Array.from(this.registry).toSorted();
+  }
+
+  async expireRegistry(runId: string): Promise<{ streams: string[] }> {
+    if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Registry owner mismatch');
+    this.ownerRunId = runId;
+    this.expired = true;
+    return { streams: Array.from(this.registry) };
+  }
+
+  async finalizeRegistry(runId: string): Promise<void> {
+    if (this.ownerRunId !== runId || !this.expired) throw new Error('Registry is not expired');
+    this.registry.clear();
+  }
+
+  async expireStream(runId: string): Promise<{ deleted: boolean; chunks: number }> {
+    if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Stream owner mismatch');
+    const chunks = this.chunks.length;
+    this.ownerRunId = runId;
+    this.chunks = [];
+    this.closed = true;
+    this.expired = true;
+    return { deleted: true, chunks };
   }
 }
 
@@ -392,6 +481,10 @@ class MockQueueCellStub implements QueueCellStub {
     }
     recordedEnqueues.push({ ...request, cellName: this.cellName });
     return { ok: true, messageId: request.messageId, deduped: false };
+  }
+
+  async expireRun(): Promise<{ deleted: number }> {
+    return { deleted: 0 };
   }
 }
 

--- a/src/testing/http-harness.ts
+++ b/src/testing/http-harness.ts
@@ -19,6 +19,8 @@ export interface Harness {
 
 export interface HarnessOptions {
   secret?: string;
+  /** Use FakeFleet's manually advanced clock instead of wall-clock time. */
+  virtualClock?: boolean;
   /** Additional cell classes by binding key (e.g. { queue: QueueDO }). */
   extraClasses?: Record<string, new (ctx: unknown, env: unknown) => object>;
   /** env passed to cell constructors (celld `vars`). */
@@ -26,6 +28,7 @@ export interface HarnessOptions {
 }
 
 export async function startHarness(options: HarnessOptions = {}): Promise<Harness> {
+  const cellEnv = { ...options.cellEnv };
   const fleet = new FakeFleet(
     {
       runs: WorkflowRunDO as never,
@@ -34,8 +37,19 @@ export async function startHarness(options: HarnessOptions = {}): Promise<Harnes
       queue: QueueDO as never,
       ...options.extraClasses,
     },
-    options.cellEnv ?? {},
+    cellEnv,
   );
+  cellEnv.clock ??= options.virtualClock ? () => fleet.now : () => Date.now();
+
+  // Durable Object constructors receive both vars and sibling bindings in a
+  // real celld deployment. Populate the same environment for cross-cell
+  // retention cleanup in the in-process fleet.
+  Object.assign(cellEnv, {
+    WORKFLOW_DB: fleet.namespace('runs'),
+    WORKFLOW_STREAMS: fleet.namespace('streams'),
+    WORKFLOW_INDEX: fleet.namespace('index'),
+    WORKFLOW_QUEUE: fleet.namespace('queue'),
+  });
 
   const env: WorkerEnv = {
     WORKFLOW_DB: fleet.namespace('runs'),

--- a/src/worker/durable-objects/IndexDO.ts
+++ b/src/worker/durable-objects/IndexDO.ts
@@ -2,6 +2,7 @@ import type { Hook } from '@workflow/world';
 import type { HookTokenOwner } from '../../config.js';
 import { parse } from '../../vendor/shared/index.js';
 import { DurableObject } from '../do-base.js';
+import type { ExpireRunIndexesRequest, ExpireRunIndexesResult } from '../../retention.js';
 
 interface HookClaim {
   owner: HookTokenOwner;
@@ -38,6 +39,17 @@ export class IndexDO extends DurableObject {
 
   async put(key: string, value: string): Promise<void> {
     await this.ctx.storage.put(key, value);
+  }
+
+  /** Publish a derived index only while its owning run is not expired. */
+  async putOwned(runId: string, key: string, value: string): Promise<{ stored: boolean }> {
+    return await this.ctx.storage.transaction(async (txn) => {
+      if ((await txn.get(`expired:${runId}`)) !== undefined) {
+        return { stored: false };
+      }
+      await txn.put(key, value);
+      return { stored: true };
+    });
   }
 
   async delete(key: string): Promise<void> {
@@ -108,6 +120,13 @@ export class IndexDO extends DurableObject {
     owner: HookTokenOwner,
   ): Promise<void> {
     await this.ctx.storage.transaction(async (txn) => {
+      if ((await txn.get(`expired:${owner.runId}`)) !== undefined) {
+        const claim = await txn.get<HookClaim>(`hookclaim:${token}`);
+        if (claim !== undefined && sameOwner(claim.owner, owner)) {
+          await txn.delete(`hookclaim:${token}`);
+        }
+        return;
+      }
       const indexedHook = await txn.get<string>(`hook:${token}`);
       if (indexedHook !== undefined && !sameOwner(ownerFromHook(indexedHook), owner)) {
         throw new Error(`Hook token ${token} is owned by another hook`);
@@ -154,6 +173,45 @@ export class IndexDO extends DurableObject {
       if (claim !== undefined && sameOwner(claim.owner, owner)) {
         await txn.delete(claimKey);
       }
+    });
+  }
+
+  /**
+   * Fence a run and remove all of its known derived indexes atomically.
+   * Once the fence exists, putOwned() and hook finalization cannot resurrect
+   * entries from a delayed request.
+   */
+  async expireRun(request: ExpireRunIndexesRequest): Promise<ExpireRunIndexesResult> {
+    return await this.ctx.storage.transaction(async (txn) => {
+      await txn.put(`expired:${request.runId}`, request.expiredAt);
+      let deleted = 0;
+
+      for (const key of new Set(request.keys)) {
+        if (await txn.delete(key)) deleted++;
+      }
+
+      for (const hook of request.hooks) {
+        const owner = { runId: request.runId, hookId: hook.hookId };
+        const tokenKey = `hook:${hook.token}`;
+        const idKey = `hookid:${hook.hookId}`;
+        const claimKey = `hookclaim:${hook.token}`;
+        const [byToken, byId, claim] = await Promise.all([
+          txn.get<string>(tokenKey),
+          txn.get<string>(idKey),
+          txn.get<HookClaim>(claimKey),
+        ]);
+        if (byToken !== undefined && sameOwner(ownerFromHook(byToken), owner)) {
+          if (await txn.delete(tokenKey)) deleted++;
+        }
+        if (byId !== undefined && sameOwner(ownerFromHook(byId), owner)) {
+          if (await txn.delete(idKey)) deleted++;
+        }
+        if (claim !== undefined && sameOwner(claim.owner, owner)) {
+          if (await txn.delete(claimKey)) deleted++;
+        }
+      }
+
+      return { deleted };
     });
   }
 }

--- a/src/worker/durable-objects/QueueDO.ts
+++ b/src/worker/durable-objects/QueueDO.ts
@@ -1,5 +1,6 @@
 import { DurableObject } from '../do-base.js';
 import type { EnqueueOutcome, EnqueueRequest } from '../../queue.js';
+import type { ExpireQueueRunResult } from '../../retention.js';
 
 /**
  * Queue cell: the celld replacement for Cloudflare Queues.
@@ -16,6 +17,8 @@ import type { EnqueueOutcome, EnqueueRequest } from '../../queue.js';
  *   inflight:<messageId>         crash-recovery deadline (epoch ms)
  *   key:<idempotencyKey>         active dedup claim -> messageId
  *   dlq:<paddedMs>:<messageId>   DeadLetterRow
+ *   run:<runId>:<messageId>      QueueRunReference for retention cleanup
+ *   expired-run:<runId>          run fence preventing delayed enqueue
  *
  * celld gotchas designed around:
  * - celld#144 (alarm handlers can overlap): the storage-only claim phase runs
@@ -34,6 +37,7 @@ export interface MessageRow {
   pathname: 'flow' | 'step';
   /** Pre-encoded tagged-JSON payload — forwarded byte-identical. */
   body: string;
+  runId?: string;
   /**
    * Delivery target captured at enqueue time. Carried per message (not
    * pinned on the cell) so an app redeploy at a new URL never bricks the
@@ -59,6 +63,18 @@ export interface QueueStats {
   alarmAt: number | null;
 }
 
+interface QueueRunReference {
+  messageId: string;
+  dueKey?: string;
+  dlqKey?: string;
+  idempotencyKey?: string;
+}
+
+interface ExpiredRunFence {
+  expiredAt: number;
+  deleted: number;
+}
+
 const PERMANENT_STATUSES = new Set([404, 409, 410, 422]);
 
 const DEFAULT_MAX_ATTEMPTS = 5;
@@ -77,6 +93,14 @@ function pad(ms: number): string {
 
 function dueKey(atMs: number, messageId: string): string {
   return `due:${pad(atMs)}:${messageId}`;
+}
+
+function runReferenceKey(runId: string, messageId: string): string {
+  return `run:${runId}:${messageId}`;
+}
+
+function expiredRunKey(runId: string): string {
+  return `expired-run:${runId}`;
 }
 
 function backoffSeconds(attempt: number): number {
@@ -118,6 +142,13 @@ export class QueueDO extends DurableObject {
     const now = this.#now();
 
     const outcome = await storage.transaction<EnqueueOutcome>(async (txn) => {
+      if (request.runId && (await txn.get(expiredRunKey(request.runId))) !== undefined) {
+        return {
+          ok: false,
+          code: 'RUN_EXPIRED',
+          message: `Workflow run "${request.runId}" has expired`,
+        };
+      }
       // Pin the shard count from the first enqueue and reject drift loudly:
       // idempotencyKey -> cell affinity (and therefore dedup correctness)
       // depends on every producer agreeing on the shard count. The delivery
@@ -156,14 +187,23 @@ export class QueueDO extends DurableObject {
         queueName: request.queueName,
         pathname: request.pathname,
         body: request.body,
+        runId: request.runId,
         targetBaseUrl: request.config.targetBaseUrl,
         idempotencyKey: request.idempotencyKey,
         attempt: 0,
         enqueuedAt: now,
       };
       const dueAt = now + Math.max(0, request.delaySeconds ?? 0) * 1000;
+      const scheduleKey = dueKey(dueAt, row.messageId);
       await txn.put(`msg:${row.messageId}`, row);
-      await txn.put(dueKey(dueAt, row.messageId), row.messageId);
+      await txn.put(scheduleKey, row.messageId);
+      if (row.runId) {
+        await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+          messageId: row.messageId,
+          dueKey: scheduleKey,
+          idempotencyKey: row.idempotencyKey,
+        });
+      }
       await this.#armAlarmAtMost(txn, dueAt, now);
 
       return { ok: true, messageId: row.messageId, deduped: false };
@@ -214,8 +254,17 @@ export class QueueDO extends DurableObject {
         if (deadline <= now) {
           const messageId = key.slice('inflight:'.length);
           await txn.delete(key);
-          if (await txn.get(`msg:${messageId}`)) {
-            await txn.put(dueKey(now, messageId), messageId);
+          const row = await txn.get<MessageRow>(`msg:${messageId}`);
+          if (row) {
+            const scheduleKey = dueKey(now, messageId);
+            await txn.put(scheduleKey, messageId);
+            if (row.runId) {
+              await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+                messageId: row.messageId,
+                dueKey: scheduleKey,
+                idempotencyKey: row.idempotencyKey,
+              });
+            }
           }
         } else {
           inflightCount++;
@@ -288,8 +337,29 @@ export class QueueDO extends DurableObject {
       }
       if (typeof timeoutSeconds === 'number') {
         await storage.transaction(async (txn) => {
+          if (row.runId && (await txn.get(expiredRunKey(row.runId))) !== undefined) {
+            await txn.delete(`msg:${row.messageId}`);
+            await txn.delete(`inflight:${row.messageId}`);
+            await txn.delete(runReferenceKey(row.runId, row.messageId));
+            if (row.idempotencyKey) {
+              const dedupKey = `key:${row.idempotencyKey}`;
+              if ((await txn.get<string>(dedupKey)) === row.messageId) {
+                await txn.delete(dedupKey);
+              }
+            }
+            await this.#scheduleNextAlarm(txn, now);
+            return;
+          }
           await txn.delete(`inflight:${row.messageId}`);
-          await txn.put(dueKey(now + timeoutSeconds * 1000, row.messageId), row.messageId);
+          const scheduleKey = dueKey(now + timeoutSeconds * 1000, row.messageId);
+          await txn.put(scheduleKey, row.messageId);
+          if (row.runId) {
+            await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+              messageId: row.messageId,
+              dueKey: scheduleKey,
+              idempotencyKey: row.idempotencyKey,
+            });
+          }
           await this.#scheduleNextAlarm(txn, now);
         });
       } else {
@@ -318,6 +388,9 @@ export class QueueDO extends DurableObject {
           await txn.delete(`key:${row.idempotencyKey}`);
         }
       }
+      if (row.runId) {
+        await txn.delete(runReferenceKey(row.runId, row.messageId));
+      }
       await this.#scheduleNextAlarm(txn, this.#now());
     });
   }
@@ -329,11 +402,25 @@ export class QueueDO extends DurableObject {
     const attempt = row.attempt + 1;
 
     await storage.transaction(async (txn) => {
+      if (row.runId && (await txn.get(expiredRunKey(row.runId))) !== undefined) {
+        await txn.delete(`msg:${row.messageId}`);
+        await txn.delete(`inflight:${row.messageId}`);
+        await txn.delete(runReferenceKey(row.runId, row.messageId));
+        if (row.idempotencyKey) {
+          const dedupKey = `key:${row.idempotencyKey}`;
+          if ((await txn.get<string>(dedupKey)) === row.messageId) {
+            await txn.delete(dedupKey);
+          }
+        }
+        await this.#scheduleNextAlarm(txn, now);
+        return;
+      }
       await txn.delete(`inflight:${row.messageId}`);
 
       if (attempt >= maxAttempts) {
         const dead: DeadLetterRow = { ...row, attempt, lastError: reason, failedAt: now };
-        await txn.put(`dlq:${pad(now)}:${row.messageId}`, dead);
+        const deadKey = `dlq:${pad(now)}:${row.messageId}`;
+        await txn.put(deadKey, dead);
         await txn.delete(`msg:${row.messageId}`);
         if (row.idempotencyKey) {
           const holder = await txn.get<string>(`key:${row.idempotencyKey}`);
@@ -341,13 +428,28 @@ export class QueueDO extends DurableObject {
             await txn.delete(`key:${row.idempotencyKey}`);
           }
         }
+        if (row.runId) {
+          await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+            messageId: row.messageId,
+            dlqKey: deadKey,
+            idempotencyKey: row.idempotencyKey,
+          });
+        }
         await this.#scheduleNextAlarm(txn, now);
         return;
       }
 
       const updated: MessageRow = { ...row, attempt, lastError: reason };
+      const scheduleKey = dueKey(now + backoffSeconds(attempt) * 1000, row.messageId);
       await txn.put(`msg:${row.messageId}`, updated);
-      await txn.put(dueKey(now + backoffSeconds(attempt) * 1000, row.messageId), row.messageId);
+      await txn.put(scheduleKey, row.messageId);
+      if (row.runId) {
+        await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+          messageId: row.messageId,
+          dueKey: scheduleKey,
+          idempotencyKey: row.idempotencyKey,
+        });
+      }
       await this.#scheduleNextAlarm(txn, now);
     });
   }
@@ -454,8 +556,16 @@ export class QueueDO extends DurableObject {
         }
 
         await txn.put(`msg:${row.messageId}`, row);
-        await txn.put(dueKey(now, row.messageId), row.messageId);
+        const scheduleKey = dueKey(now, row.messageId);
+        await txn.put(scheduleKey, row.messageId);
         await txn.delete(key);
+        if (row.runId) {
+          await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+            messageId: row.messageId,
+            dueKey: scheduleKey,
+            idempotencyKey: row.idempotencyKey,
+          });
+        }
         await this.#armAlarmAtMost(txn, now, now);
         return { ok: true };
       }
@@ -469,8 +579,12 @@ export class QueueDO extends DurableObject {
     const storage = this.ctx.storage;
     return await storage.transaction(async (txn) => {
       const dlq = await txn.list({ prefix: 'dlq:' });
-      for (const key of dlq.keys()) {
+      for (const [key, value] of dlq) {
         await txn.delete(key);
+        const dead = value as DeadLetterRow;
+        if (dead.runId) {
+          await txn.delete(runReferenceKey(dead.runId, dead.messageId));
+        }
       }
       return { purged: dlq.size };
     });
@@ -483,5 +597,33 @@ export class QueueDO extends DurableObject {
   async rearmAlarm(): Promise<{ alarmAt: number | null }> {
     await this.#rearm();
     return { alarmAt: await this.ctx.storage.getAlarm() };
+  }
+
+  /** Fence a run and purge every live, inflight, and dead-letter message it owns. */
+  async expireRun(runId: string, expiredAt: number): Promise<ExpireQueueRunResult> {
+    const storage = this.ctx.storage;
+    const deleted = await storage.transaction(async (txn) => {
+      const existing = await txn.get<ExpiredRunFence>(expiredRunKey(runId));
+      const references = await txn.list<QueueRunReference>({ prefix: `run:${runId}:` });
+      let count = existing?.deleted ?? 0;
+      for (const [key, reference] of references) {
+        await txn.delete(`msg:${reference.messageId}`);
+        await txn.delete(`inflight:${reference.messageId}`);
+        if (reference.dueKey) await txn.delete(reference.dueKey);
+        if (reference.dlqKey) await txn.delete(reference.dlqKey);
+        if (reference.idempotencyKey) {
+          const dedupKey = `key:${reference.idempotencyKey}`;
+          if ((await txn.get<string>(dedupKey)) === reference.messageId) {
+            await txn.delete(dedupKey);
+          }
+        }
+        await txn.delete(key);
+        count++;
+      }
+      await txn.put<ExpiredRunFence>(expiredRunKey(runId), { expiredAt, deleted: count });
+      await this.#scheduleNextAlarm(txn, this.#now());
+      return count;
+    });
+    return { deleted };
   }
 }

--- a/src/worker/durable-objects/StreamDO.ts
+++ b/src/worker/durable-objects/StreamDO.ts
@@ -1,16 +1,21 @@
 import { DurableObject } from '../do-base.js';
+import type { ExpireRunStreamsResult, ExpireStreamResult } from '../../retention.js';
 
 interface StreamMeta {
   /** Number of chunks written so far (also the next chunk index). */
   count: number;
   /** Whether the stream has been closed (EOF). */
   closed: boolean;
+  ownerRunId?: string;
+  expiredAt?: number;
 }
 
 const META_KEY = 'meta';
 const CHUNK_KEY_PREFIX = 'chunk:';
 /** Registry keys used when this DO instance acts as a per-run stream index. */
 const STREAM_REGISTRY_PREFIX = 'stream:';
+const REGISTRY_OWNER_KEY = 'registry:owner';
+const REGISTRY_EXPIRED_KEY = 'registry:expired';
 
 /**
  * Zero-pad chunk indexes so `storage.list({ prefix })` returns chunks in
@@ -36,19 +41,33 @@ export class StreamDO extends DurableObject {
     return meta ?? { count: 0, closed: false };
   }
 
+  private assertOwner(meta: StreamMeta, runId: string): void {
+    if (meta.expiredAt !== undefined) {
+      throw new Error(`Workflow run "${runId}" has expired`);
+    }
+    if (meta.ownerRunId !== undefined && meta.ownerRunId !== runId) {
+      throw new Error(`Stream is owned by workflow run "${meta.ownerRunId}"`);
+    }
+  }
+
   /**
    * Append a chunk. The index is allocated inside the transaction, so
    * concurrent writers can never collide or skip.
    */
-  async writeChunk(data: Uint8Array): Promise<number> {
+  async writeChunk(runId: string, data: Uint8Array): Promise<number> {
     return await this.ctx.storage.transaction(async (txn) => {
       const meta = (await txn.get<StreamMeta>(META_KEY)) ?? { count: 0, closed: false };
+      this.assertOwner(meta, runId);
       if (meta.closed) {
         throw new Error('Cannot write to a closed stream');
       }
       const index = meta.count;
       await txn.put(chunkKey(index), data);
-      await txn.put<StreamMeta>(META_KEY, { count: index + 1, closed: false });
+      await txn.put<StreamMeta>(META_KEY, {
+        count: index + 1,
+        closed: false,
+        ownerRunId: runId,
+      });
       return index;
     });
   }
@@ -57,10 +76,11 @@ export class StreamDO extends DurableObject {
    * Close the stream (idempotent). Readers observe `done: true` once all
    * previously written chunks have been consumed.
    */
-  async closeStream(): Promise<void> {
+  async closeStream(runId: string): Promise<void> {
     await this.ctx.storage.transaction(async (txn) => {
       const meta = (await txn.get<StreamMeta>(META_KEY)) ?? { count: 0, closed: false };
-      await txn.put<StreamMeta>(META_KEY, { ...meta, closed: true });
+      this.assertOwner(meta, runId);
+      await txn.put<StreamMeta>(META_KEY, { ...meta, ownerRunId: runId, closed: true });
     });
   }
 
@@ -75,6 +95,9 @@ export class StreamDO extends DurableObject {
     tailIndex: number;
   }> {
     const meta = await this.getMeta();
+    if (meta.expiredAt !== undefined) {
+      throw new Error('Stream has expired');
+    }
     const start = Math.max(0, params.startIndex);
     const entries = await this.ctx.storage.list<Uint8Array>({
       prefix: CHUNK_KEY_PREFIX,
@@ -93,21 +116,87 @@ export class StreamDO extends DurableObject {
    */
   async getInfo(): Promise<{ tailIndex: number; done: boolean }> {
     const meta = await this.getMeta();
+    if (meta.expiredAt !== undefined) {
+      throw new Error('Stream has expired');
+    }
     return { tailIndex: meta.count - 1, done: meta.closed };
   }
 
   /**
    * Register a stream name against this per-run registry instance.
    */
-  async registerStream(name: string): Promise<void> {
-    await this.ctx.storage.put(`${STREAM_REGISTRY_PREFIX}${name}`, true);
+  async registerStream(runId: string, name: string): Promise<void> {
+    await this.ctx.storage.transaction(async (txn) => {
+      if ((await txn.get(REGISTRY_EXPIRED_KEY)) !== undefined) {
+        throw new Error(`Workflow run "${runId}" has expired`);
+      }
+      const owner = await txn.get<string>(REGISTRY_OWNER_KEY);
+      if (owner !== undefined && owner !== runId) {
+        throw new Error(`Stream registry is owned by workflow run "${owner}"`);
+      }
+      await txn.put(REGISTRY_OWNER_KEY, runId);
+      await txn.put(`${STREAM_REGISTRY_PREFIX}${name}`, true);
+    });
   }
 
   /**
    * List stream names registered against this per-run registry instance.
    */
   async listStreams(): Promise<string[]> {
+    if ((await this.ctx.storage.get(REGISTRY_EXPIRED_KEY)) !== undefined) {
+      throw new Error('Workflow run streams have expired');
+    }
     const entries = await this.ctx.storage.list<boolean>({ prefix: STREAM_REGISTRY_PREFIX });
     return Array.from(entries.keys()).map((key) => key.slice(STREAM_REGISTRY_PREFIX.length));
+  }
+
+  /** Fence a run's registry before any stream cells are removed. */
+  async expireRegistry(runId: string, expiredAt: number): Promise<ExpireRunStreamsResult> {
+    return await this.ctx.storage.transaction(async (txn) => {
+      const owner = await txn.get<string>(REGISTRY_OWNER_KEY);
+      if (owner !== undefined && owner !== runId) {
+        throw new Error(`Stream registry is owned by workflow run "${owner}"`);
+      }
+      await txn.put(REGISTRY_OWNER_KEY, runId);
+      await txn.put(REGISTRY_EXPIRED_KEY, expiredAt);
+      const entries = await txn.list<boolean>({ prefix: STREAM_REGISTRY_PREFIX });
+      return {
+        streams: Array.from(entries.keys()).map((key) => key.slice(STREAM_REGISTRY_PREFIX.length)),
+      };
+    });
+  }
+
+  /** Remove the registry payload after every referenced stream was fenced. */
+  async finalizeRegistry(runId: string): Promise<void> {
+    await this.ctx.storage.transaction(async (txn) => {
+      const owner = await txn.get<string>(REGISTRY_OWNER_KEY);
+      const expiredAt = await txn.get<number>(REGISTRY_EXPIRED_KEY);
+      if (owner !== runId || expiredAt === undefined) {
+        throw new Error(`Stream registry for workflow run "${runId}" is not expired`);
+      }
+      const entries = await txn.list({ prefix: STREAM_REGISTRY_PREFIX });
+      for (const key of entries.keys()) await txn.delete(key);
+    });
+  }
+
+  /** Delete stream payload while leaving a small ownership tombstone. */
+  async expireStream(runId: string, expiredAt: number): Promise<ExpireStreamResult> {
+    return await this.ctx.storage.transaction(async (txn) => {
+      const meta = (await txn.get<StreamMeta>(META_KEY)) ?? { count: 0, closed: false };
+      if (meta.ownerRunId !== undefined && meta.ownerRunId !== runId) {
+        throw new Error(`Stream is owned by workflow run "${meta.ownerRunId}"`);
+      }
+      const chunks = await txn.list({ prefix: CHUNK_KEY_PREFIX });
+      for (const key of chunks.keys()) {
+        await txn.delete(key);
+      }
+      await txn.put<StreamMeta>(META_KEY, {
+        count: 0,
+        closed: true,
+        ownerRunId: runId,
+        expiredAt,
+      });
+      return { deleted: true, chunks: chunks.size };
+    });
   }
 }

--- a/src/worker/durable-objects/WorkflowRunDO.ts
+++ b/src/worker/durable-objects/WorkflowRunDO.ts
@@ -1,5 +1,6 @@
 import { DurableObject } from '../do-base.js';
 import type { Event, Hook, Step, WorkflowRun } from '@workflow/world';
+import { isTerminalWorkflowRunStatus, WorkflowRunSchema } from '@workflow/world';
 import {
   applyEvent,
   type ApplyEventOutcome,
@@ -13,6 +14,65 @@ import {
   STEP_CREATED_KEY_PREFIX,
   STEP_KEY_PREFIX,
 } from '../../apply-event.js';
+import {
+  CLEANUP_RECORD_KEY,
+  type CleanupRecord,
+  cleanupTombstone,
+  correlationIndexKey,
+  type ExpireQueueRunResult,
+  type ExpireRunIndexesRequest,
+  type ExpireRunIndexesResult,
+  type ExpireRunStreamsResult,
+  type ExpireStreamResult,
+  expiredRead,
+  globalRunIndexKey,
+  HOOK_MARKER_PREFIX,
+  type HookIndexReference,
+  hookMarkerKey,
+  INDEX_MARKER_PREFIX,
+  indexMarkerKey,
+  type RunReadOutcome,
+  type RunTombstone,
+  type ScheduleCleanupRequest,
+  TOMBSTONE_KEY,
+  workflowRunIndexKey,
+} from '../../retention.js';
+
+interface CellId {
+  toString(): string;
+}
+
+interface CellNamespace<T> {
+  idFromName(name: string): CellId;
+  get(id: CellId): T;
+}
+
+interface IndexCleanupStub {
+  expireRun(request: ExpireRunIndexesRequest): Promise<ExpireRunIndexesResult>;
+}
+
+interface StreamCleanupStub {
+  expireRegistry(runId: string, expiredAt: number): Promise<ExpireRunStreamsResult>;
+  finalizeRegistry(runId: string): Promise<void>;
+  expireStream(runId: string, expiredAt: number): Promise<ExpireStreamResult>;
+}
+
+interface QueueCleanupStub {
+  expireRun(runId: string, expiredAt: number): Promise<ExpireQueueRunResult>;
+}
+
+interface WorkflowRunDOEnv {
+  WORKFLOW_INDEX?: CellNamespace<IndexCleanupStub>;
+  WORKFLOW_STREAMS?: CellNamespace<StreamCleanupStub>;
+  WORKFLOW_QUEUE?: CellNamespace<QueueCleanupStub>;
+  /** Test seam; celld deployments use Date.now(). */
+  clock?: () => number;
+}
+
+const PAYLOAD_DELETE_BATCH = 256;
+const STREAM_DELETE_CONCURRENCY = 16;
+const CLEANUP_RETRY_MAX_MS = 60 * 60 * 1000;
+type TerminalRun = Extract<WorkflowRun, { status: 'completed' | 'failed' | 'cancelled' }>;
 
 /**
  * Current schema version for DO storage.
@@ -124,10 +184,11 @@ interface InflightClaim {
 export class WorkflowRunDO extends DurableObject {
   private schemaReady: Promise<void> | null = null;
 
-  /**
-   * Lazily ensure schema migrations have run.
-   * Memoized so it only runs once per DO instantiation.
-   */
+  private now(): number {
+    const clock = (this.env as WorkflowRunDOEnv)?.clock;
+    return typeof clock === 'function' ? clock() : Date.now();
+  }
+
   private ensureSchema(): Promise<void> {
     if (!this.schemaReady) {
       this.schemaReady = ensureSchemaUpToDate(this.ctx.storage);
@@ -135,132 +196,423 @@ export class WorkflowRunDO extends DurableObject {
     return this.schemaReady;
   }
 
-  /**
-   * Apply an event: validate, guard, append the event and mutate the entity
-   * in ONE storage transaction. Guard failures are returned as structured
-   * outcomes (not thrown) because typed errors do not survive the RPC
-   * boundary with their `name` intact.
-   */
+  private async expiredTombstone(
+    storage: Pick<DurableObjectStorage, 'get'>,
+    now = this.now(),
+  ): Promise<RunTombstone | null> {
+    const tombstone = await storage.get<RunTombstone>(TOMBSTONE_KEY);
+    if (tombstone) return tombstone;
+    const cleanup = await storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+    if (!cleanup || (cleanup.phase === 'retained' && cleanup.dueAt.getTime() > now)) return null;
+    return cleanupTombstone(cleanup, cleanup.tombstonedAt ?? cleanup.dueAt);
+  }
+
+  private async read<T>(reader: () => Promise<T>): Promise<RunReadOutcome<T>> {
+    await this.ensureSchema();
+    const tombstone = await this.expiredTombstone(this.ctx.storage);
+    if (tombstone) return expiredRead(tombstone);
+    return { ok: true, value: await reader() };
+  }
+
+  /** Apply an event and capture all retention metadata in the same transaction. */
   async applyEvent(request: ApplyEventRequest): Promise<ApplyEventOutcome> {
     await this.ensureSchema();
     return await this.ctx.storage.transaction(async (txn) => {
+      const now = new Date(this.now());
+      const tombstone = await this.expiredTombstone(txn, now.getTime());
+      if (tombstone) {
+        return {
+          ok: false,
+          code: 'RUN_EXPIRED',
+          message: `Workflow run "${request.runId}" expired at ${tombstone.expiredAt.toISOString()}`,
+        };
+      }
+
       let eventSequence = (await txn.get<number>('event_sequence')) ?? 0;
       const outcome = await applyEvent(storeFrom(txn), {
         ...request,
-        // The sequence is durable, so a newly instantiated DO can never
-        // allocate an event id that sorts before an earlier commit.
         nextEventId: () => `wevt_z${String(++eventSequence).padStart(20, '0')}`,
-        now: new Date(),
+        now,
       });
-      if (outcome.ok) {
-        await txn.put('event_sequence', eventSequence);
+      if (!outcome.ok) return outcome;
+
+      await txn.put('event_sequence', eventSequence);
+      if (outcome.event?.correlationId) {
+        const key = correlationIndexKey(
+          outcome.event.correlationId,
+          outcome.event.createdAt,
+          outcome.event.eventId,
+          request.runId,
+        );
+        await txn.put(indexMarkerKey(key), key);
+      }
+      if (outcome.hookToIndex) {
+        const reference = {
+          hookId: outcome.hookToIndex.hookId,
+          token: outcome.hookToIndex.token,
+        };
+        await txn.put(hookMarkerKey(reference), reference);
+      }
+      for (const reference of outcome.releasedHooks) {
+        await txn.put(hookMarkerKey(reference), reference);
+      }
+
+      const retentionMs = request.cleanup?.retentionMs ?? 0;
+      if (
+        retentionMs > 0 &&
+        outcome.run &&
+        isTerminalWorkflowRunStatus(outcome.run.status) &&
+        !(await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY))
+      ) {
+        const terminalRun = outcome.run as TerminalRun;
+        const dueAt = new Date(terminalRun.completedAt.getTime() + retentionMs);
+        const run = WorkflowRunSchema.parse({ ...terminalRun, expiredAt: dueAt }) as TerminalRun;
+        const cleanup: CleanupRecord = {
+          version: 1,
+          runId: run.runId,
+          workflowName: run.workflowName,
+          createdAt: run.createdAt,
+          completedAt: run.completedAt,
+          terminalStatus: run.status,
+          dueAt,
+          queueShards: request.cleanup?.queueShards ?? 1,
+          phase: 'retained',
+          attempts: 0,
+          deletedPayloadKeys: 0,
+          deletedStreams: 0,
+          deletedQueueMessages: 0,
+        };
+        await txn.put('run', run);
+        await txn.put(CLEANUP_RECORD_KEY, cleanup);
+        await txn.setAlarm(dueAt);
+        outcome.run = run;
       }
       return outcome;
     });
   }
 
-  /**
-   * Get the workflow run
-   */
-  async getRun(): Promise<WorkflowRun | null> {
-    await this.ensureSchema();
-    const run = await this.ctx.storage.get<WorkflowRun>('run');
-    return run ?? null;
+  async getRun(): Promise<RunReadOutcome<WorkflowRun | null>> {
+    return this.read(async () => (await this.ctx.storage.get<WorkflowRun>('run')) ?? null);
   }
 
-  /**
-   * Get a specific step
-   */
-  async getStep(stepId: string): Promise<Step | null> {
-    await this.ensureSchema();
-    const step = await this.ctx.storage.get<Step>(`${STEP_KEY_PREFIX}${stepId}`);
-    return step ?? null;
+  async getStep(stepId: string): Promise<RunReadOutcome<Step | null>> {
+    return this.read(
+      async () => (await this.ctx.storage.get<Step>(`${STEP_KEY_PREFIX}${stepId}`)) ?? null,
+    );
   }
 
-  /**
-   * List steps with real limit/cursor pagination (cursor = last stepId).
-   */
   async listSteps(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Step[]; cursor: string | null; hasMore: boolean }> {
-    await this.ensureSchema();
-    return listByCreationTime<Step>(
-      storeFrom(this.ctx.storage),
-      STEP_CREATED_KEY_PREFIX,
-      STEP_KEY_PREFIX,
-      {
-        limit: params?.limit ?? 20,
-        cursor: params?.cursor,
-        sortOrder: params?.sortOrder ?? 'asc',
-      },
+  }): Promise<RunReadOutcome<{ data: Step[]; cursor: string | null; hasMore: boolean }>> {
+    return this.read(() =>
+      listByCreationTime<Step>(
+        storeFrom(this.ctx.storage),
+        STEP_CREATED_KEY_PREFIX,
+        STEP_KEY_PREFIX,
+        {
+          limit: params?.limit ?? 20,
+          cursor: params?.cursor,
+          sortOrder: params?.sortOrder ?? 'asc',
+        },
+      ),
     );
   }
 
-  /**
-   * Get a specific event
-   */
-  async getEvent(eventId: string): Promise<Event | null> {
-    await this.ensureSchema();
-    const event = await this.ctx.storage.get<Event>(`${EVENT_KEY_PREFIX}${eventId}`);
-    return event ?? null;
+  async getEvent(eventId: string): Promise<RunReadOutcome<Event | null>> {
+    return this.read(
+      async () => (await this.ctx.storage.get<Event>(`${EVENT_KEY_PREFIX}${eventId}`)) ?? null,
+    );
   }
 
-  /**
-   * List events with real limit/cursor pagination. Events are keyed by their
-   * monotonic ULID eventId, so storage order == event order.
-   */
   async listEvents(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Event[]; cursor: string | null; hasMore: boolean }> {
-    await this.ensureSchema();
-    return listByPrefix<Event>(
-      storeFrom(this.ctx.storage),
-      EVENT_KEY_PREFIX,
-      {
-        limit: params?.limit ?? 100,
-        cursor: params?.cursor,
-        sortOrder: params?.sortOrder ?? 'asc',
-      },
-      (event) => event.eventId,
+  }): Promise<RunReadOutcome<{ data: Event[]; cursor: string | null; hasMore: boolean }>> {
+    return this.read(() =>
+      listByPrefix<Event>(
+        storeFrom(this.ctx.storage),
+        EVENT_KEY_PREFIX,
+        {
+          limit: params?.limit ?? 100,
+          cursor: params?.cursor,
+          sortOrder: params?.sortOrder ?? 'asc',
+        },
+        (event) => event.eventId,
+      ),
     );
   }
 
-  /**
-   * List hooks with real limit/cursor pagination (cursor = last hookId).
-   */
   async listHooks(params?: {
     limit?: number;
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
-  }): Promise<{ data: Hook[]; cursor: string | null; hasMore: boolean }> {
-    await this.ensureSchema();
-    return listByCreationTime<Hook>(
-      storeFrom(this.ctx.storage),
-      HOOK_CREATED_KEY_PREFIX,
-      HOOK_KEY_PREFIX,
-      {
-        limit: params?.limit ?? 100,
-        cursor: params?.cursor,
-        sortOrder: params?.sortOrder ?? 'asc',
-      },
+  }): Promise<RunReadOutcome<{ data: Hook[]; cursor: string | null; hasMore: boolean }>> {
+    return this.read(() =>
+      listByCreationTime<Hook>(
+        storeFrom(this.ctx.storage),
+        HOOK_CREATED_KEY_PREFIX,
+        HOOK_KEY_PREFIX,
+        {
+          limit: params?.limit ?? 100,
+          cursor: params?.cursor,
+          sortOrder: params?.sortOrder ?? 'asc',
+        },
+      ),
     );
   }
 
-  /**
-   * Claim a queue-message dedup slot. Used on DO instances dedicated to a
-   * single idempotency key (`claim:<queueName>:<idempotencyKey>`).
-   *
-   * - Unclaimed -> claim and proceed.
-   * - Claimed by the SAME messageId -> redelivery of the same message
-   *   (previous attempt failed transiently) -> proceed.
-   * - Claimed by a DIFFERENT messageId -> concurrent duplicate -> reject,
-   *   unless the claim is stale (holder crashed / went to the DLQ without
-   *   releasing), in which case the claim is stolen.
-   */
+  async getCleanupStatus(): Promise<CleanupRecord | null> {
+    await this.ensureSchema();
+    return (await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY)) ?? null;
+  }
+
+  /** Explicitly schedule an existing terminal run, used for opt-in backfills. */
+  async scheduleCleanup(request: ScheduleCleanupRequest): Promise<CleanupRecord | null> {
+    await this.ensureSchema();
+    if (request.retentionMs <= 0) return this.getCleanupStatus();
+    return await this.ctx.storage.transaction(async (txn) => {
+      const existing = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (existing) return existing;
+      if (await txn.get<RunTombstone>(TOMBSTONE_KEY)) return null;
+      const current = await txn.get<WorkflowRun>('run');
+      if (!current || !isTerminalWorkflowRunStatus(current.status)) return null;
+      const terminalRun = current as TerminalRun;
+      const dueAt = new Date(terminalRun.completedAt.getTime() + request.retentionMs);
+      const run = WorkflowRunSchema.parse({ ...terminalRun, expiredAt: dueAt }) as TerminalRun;
+      const cleanup: CleanupRecord = {
+        version: 1,
+        runId: run.runId,
+        workflowName: run.workflowName,
+        createdAt: run.createdAt,
+        completedAt: run.completedAt,
+        terminalStatus: run.status,
+        dueAt,
+        queueShards: request.queueShards,
+        phase: 'retained',
+        attempts: 0,
+        deletedPayloadKeys: 0,
+        deletedStreams: 0,
+        deletedQueueMessages: 0,
+      };
+      await txn.put('run', run);
+      await txn.put(CLEANUP_RECORD_KEY, cleanup);
+      await txn.setAlarm(dueAt.getTime() <= this.now() ? this.now() + 1 : dueAt);
+      return cleanup;
+    });
+  }
+
+  async cleanupNow(request: ScheduleCleanupRequest): Promise<CleanupRecord | null> {
+    await this.ensureSchema();
+    if (!(await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY))) {
+      await this.scheduleCleanup({ ...request, retentionMs: Math.max(1, request.retentionMs) });
+    }
+    await this.ctx.storage.transaction(async (txn) => {
+      const cleanup = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (!cleanup || cleanup.phase === 'tombstoned') return;
+      const dueAt = new Date(this.now());
+      const run = await txn.get<WorkflowRun>('run');
+      if (run) await txn.put('run', WorkflowRunSchema.parse({ ...run, expiredAt: dueAt }));
+      await txn.put(CLEANUP_RECORD_KEY, { ...cleanup, dueAt });
+      await txn.setAlarm(this.now() + 1);
+    });
+    try {
+      await this.executeCleanup();
+    } catch (error) {
+      await this.recordCleanupFailure(error);
+    }
+    return this.getCleanupStatus();
+  }
+
+  async rearmCleanup(): Promise<CleanupRecord | null> {
+    await this.ensureSchema();
+    const cleanup = await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+    if (!cleanup) return null;
+    if (cleanup.phase === 'tombstoned') {
+      await this.ctx.storage.deleteAlarm();
+    } else {
+      await this.ctx.storage.setAlarm(Math.max(this.now() + 1, cleanup.dueAt.getTime()));
+    }
+    return cleanup;
+  }
+
+  async alarm(): Promise<void> {
+    await this.ensureSchema();
+    try {
+      await this.executeCleanup();
+    } catch (error) {
+      await this.recordCleanupFailure(error);
+    }
+  }
+
+  private namespace<T>(name: keyof WorkflowRunDOEnv): CellNamespace<T> {
+    const namespace = (this.env as WorkflowRunDOEnv)?.[name];
+    if (!namespace || typeof namespace === 'function') {
+      throw new Error(`world-celld retention missing binding ${name}`);
+    }
+    return namespace as CellNamespace<T>;
+  }
+
+  private async setCleanupPhase(
+    expected: CleanupRecord['phase'],
+    next: CleanupRecord['phase'],
+    updates: Partial<CleanupRecord> = {},
+  ): Promise<void> {
+    await this.ctx.storage.transaction(async (txn) => {
+      const cleanup = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (!cleanup || cleanup.phase !== expected) return;
+      await txn.put(CLEANUP_RECORD_KEY, {
+        ...cleanup,
+        ...updates,
+        phase: next,
+        attempts: 0,
+        lastError: undefined,
+      });
+    });
+  }
+
+  private async executeCleanup(): Promise<void> {
+    for (;;) {
+      const cleanup = await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (!cleanup) {
+        await this.ctx.storage.deleteAlarm();
+        return;
+      }
+      if (cleanup.phase === 'tombstoned') {
+        await this.ctx.storage.deleteAlarm();
+        return;
+      }
+      if (cleanup.phase === 'retained') {
+        if (cleanup.dueAt.getTime() > this.now()) {
+          await this.ctx.storage.setAlarm(cleanup.dueAt);
+          return;
+        }
+        await this.setCleanupPhase('retained', 'index');
+        continue;
+      }
+
+      if (cleanup.phase === 'index') {
+        const [indexMarkers, hookMarkers] = await Promise.all([
+          this.ctx.storage.list<string>({ prefix: INDEX_MARKER_PREFIX }),
+          this.ctx.storage.list<HookIndexReference>({ prefix: HOOK_MARKER_PREFIX }),
+        ]);
+        const indexNamespace = this.namespace<IndexCleanupStub>('WORKFLOW_INDEX');
+        const index = indexNamespace.get(indexNamespace.idFromName('index'));
+        await index.expireRun({
+          runId: cleanup.runId,
+          keys: [
+            workflowRunIndexKey(cleanup),
+            globalRunIndexKey(cleanup),
+            ...indexMarkers.values(),
+          ],
+          hooks: Array.from(hookMarkers.values()),
+          expiredAt: cleanup.dueAt.getTime(),
+        });
+        await this.setCleanupPhase('index', 'streams');
+        continue;
+      }
+
+      if (cleanup.phase === 'streams') {
+        const streamsNamespace = this.namespace<StreamCleanupStub>('WORKFLOW_STREAMS');
+        const registry = streamsNamespace.get(
+          streamsNamespace.idFromName(`run-streams:${cleanup.runId}`),
+        );
+        const { streams } = await registry.expireRegistry(cleanup.runId, cleanup.dueAt.getTime());
+        let deletedStreams = streams.length === 0 ? cleanup.deletedStreams : 0;
+        for (let offset = 0; offset < streams.length; offset += STREAM_DELETE_CONCURRENCY) {
+          const batch = streams.slice(offset, offset + STREAM_DELETE_CONCURRENCY);
+          const results = await Promise.all(
+            batch.map((name) => {
+              const stream = streamsNamespace.get(streamsNamespace.idFromName(`stream:${name}`));
+              return stream.expireStream(cleanup.runId, cleanup.dueAt.getTime());
+            }),
+          );
+          deletedStreams += results.filter((result) => result.deleted).length;
+        }
+        await this.ctx.storage.transaction(async (txn) => {
+          const current = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+          if (current?.phase === 'streams') {
+            await txn.put(CLEANUP_RECORD_KEY, { ...current, deletedStreams });
+          }
+        });
+        await registry.finalizeRegistry(cleanup.runId);
+        await this.setCleanupPhase('streams', 'queues');
+        continue;
+      }
+
+      if (cleanup.phase === 'queues') {
+        const queues = this.namespace<QueueCleanupStub>('WORKFLOW_QUEUE');
+        let deletedQueueMessages = 0;
+        for (let shard = 0; shard < cleanup.queueShards; shard++) {
+          const queue = queues.get(queues.idFromName(`q:${shard}`));
+          const result = await queue.expireRun(cleanup.runId, cleanup.dueAt.getTime());
+          deletedQueueMessages += result.deleted;
+        }
+        await this.setCleanupPhase('queues', 'payload', { deletedQueueMessages });
+        continue;
+      }
+
+      if (cleanup.phase === 'payload') {
+        const finished = await this.deletePayloadBatch();
+        if (!finished) return;
+      }
+    }
+  }
+
+  private async deletePayloadBatch(): Promise<boolean> {
+    return await this.ctx.storage.transaction(async (txn) => {
+      const cleanup = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (!cleanup || cleanup.phase !== 'payload') return true;
+      const entries = await txn.list({ limit: PAYLOAD_DELETE_BATCH + 3 });
+      const keys = Array.from(entries.keys())
+        .filter(
+          (key) => key !== CLEANUP_RECORD_KEY && key !== TOMBSTONE_KEY && key !== 'schema_version',
+        )
+        .slice(0, PAYLOAD_DELETE_BATCH);
+      const now = new Date(this.now());
+      await txn.put(TOMBSTONE_KEY, cleanupTombstone(cleanup, now));
+      for (const key of keys) await txn.delete(key);
+
+      if (keys.length > 0) {
+        await txn.put(CLEANUP_RECORD_KEY, {
+          ...cleanup,
+          deletedPayloadKeys: cleanup.deletedPayloadKeys + keys.length,
+          lastError: undefined,
+        });
+        await txn.setAlarm(this.now() + 1);
+        return false;
+      }
+
+      await txn.put(CLEANUP_RECORD_KEY, {
+        ...cleanup,
+        phase: 'tombstoned',
+        attempts: 0,
+        lastError: undefined,
+        tombstonedAt: now,
+      });
+      await txn.deleteAlarm();
+      return true;
+    });
+  }
+
+  private async recordCleanupFailure(error: unknown): Promise<void> {
+    await this.ctx.storage.transaction(async (txn) => {
+      const cleanup = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (!cleanup || cleanup.phase === 'tombstoned') return;
+      const attempts = cleanup.attempts + 1;
+      const delay = Math.min(CLEANUP_RETRY_MAX_MS, 1000 * 2 ** Math.min(attempts - 1, 12));
+      await txn.put(CLEANUP_RECORD_KEY, {
+        ...cleanup,
+        attempts,
+        lastError: error instanceof Error ? error.message : String(error),
+        lastAttemptAt: new Date(this.now()),
+      });
+      await txn.setAlarm(this.now() + delay);
+    });
+  }
+
   async claimInflight(params: {
     messageId: string;
     staleMs: number;
@@ -268,7 +620,7 @@ export class WorkflowRunDO extends DurableObject {
     await this.ensureSchema();
     return await this.ctx.storage.transaction(async (txn) => {
       const existing = await txn.get<InflightClaim>('claim');
-      const now = Date.now();
+      const now = this.now();
       if (
         existing &&
         existing.messageId !== params.messageId &&
@@ -281,9 +633,6 @@ export class WorkflowRunDO extends DurableObject {
     });
   }
 
-  /**
-   * Release a queue-message dedup claim after the message was fully handled.
-   */
   async releaseInflight(): Promise<void> {
     await this.ensureSchema();
     await this.ctx.storage.delete('claim');

--- a/src/worker/router.ts
+++ b/src/worker/router.ts
@@ -41,6 +41,10 @@ const BINDINGS: Record<string, { env: keyof WorkerEnv; methods: ReadonlySet<stri
       'listEvents',
       'listSteps',
       'listHooks',
+      'getCleanupStatus',
+      'scheduleCleanup',
+      'cleanupNow',
+      'rearmCleanup',
     ]),
   },
   streams: {
@@ -52,6 +56,9 @@ const BINDINGS: Record<string, { env: keyof WorkerEnv; methods: ReadonlySet<stri
       'getInfo',
       'registerStream',
       'listStreams',
+      'expireRegistry',
+      'finalizeRegistry',
+      'expireStream',
     ]),
   },
   index: {
@@ -60,6 +67,8 @@ const BINDINGS: Record<string, { env: keyof WorkerEnv; methods: ReadonlySet<stri
       'get',
       'put',
       'delete',
+      'putOwned',
+      'expireRun',
       'list',
       'reserveHookToken',
       'finalizeHookIndexes',
@@ -76,6 +85,7 @@ const BINDINGS: Record<string, { env: keyof WorkerEnv; methods: ReadonlySet<stri
       'redriveDeadLetter',
       'purgeDeadLetters',
       'rearmAlarm',
+      'expireRun',
     ]),
   },
 };

--- a/test/event-ordering-regression.test.ts
+++ b/test/event-ordering-regression.test.ts
@@ -46,6 +46,11 @@ describe('WorkflowRunDO event ordering regression', () => {
     expect(started.ok).toBe(true);
 
     const events = await secondInstance.listEvents({ sortOrder: 'asc' });
-    expect(events.data.map((event) => event.eventType)).toEqual(['run_created', 'run_started']);
+    expect(events.ok).toBe(true);
+    if (!events.ok) throw new Error(events.message);
+    expect(events.value.data.map((event) => event.eventType)).toEqual([
+      'run_created',
+      'run_started',
+    ]);
   });
 });

--- a/test/index-do.test.ts
+++ b/test/index-do.test.ts
@@ -65,4 +65,24 @@ describe('IndexDO', () => {
     expect(page.list_complete).toBe(true);
     expect(page.cursor).toBeUndefined();
   });
+
+  it('atomically deletes owned indexes and fences delayed publication', async () => {
+    await index.putOwned('wrun_expired', 'run:wf:1:wrun_expired', 'run');
+    await index.putOwned('wrun_expired', 'correlation:c:1:e:wrun_expired', 'event');
+
+    expect(
+      await index.expireRun({
+        runId: 'wrun_expired',
+        keys: ['run:wf:1:wrun_expired', 'correlation:c:1:e:wrun_expired'],
+        hooks: [],
+        expiredAt: 123,
+      }),
+    ).toEqual({ deleted: 2 });
+    expect(await index.get('run:wf:1:wrun_expired')).toBeNull();
+    expect(await index.get('correlation:c:1:e:wrun_expired')).toBeNull();
+    expect(await index.putOwned('wrun_expired', 'run:wf:2:wrun_expired', 'late')).toEqual({
+      stored: false,
+    });
+    expect(await index.get('run:wf:2:wrun_expired')).toBeNull();
+  });
 });

--- a/test/integration/fleet.test.ts
+++ b/test/integration/fleet.test.ts
@@ -23,6 +23,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createCelldWorld } from '../../src/index.js';
 import { callDO } from '../../src/remote/rpc-client.js';
 import type { QueueStats } from '../../src/worker/durable-objects/QueueDO.js';
+import { RunExpiredError } from '@workflow/errors';
 
 const FLEET_URL = process.env.CELLD_FLEET_URL;
 const SECRET = process.env.CELLD_WORLD_SECRET;
@@ -120,6 +121,51 @@ describe.skipIf(!FLEET_URL || !SECRET)('celld fleet integration', () => {
     if (!('input' in run) || !run.input) throw new Error('expected run input');
     expect(run.input[0]).toBeInstanceOf(Uint8Array);
     expect(Array.from(run.input[0] as Uint8Array)).toEqual([0, 1, 2, 253, 254, 255]);
+  });
+
+  it('expires terminal payloads across run, stream, index, and queue cells', async () => {
+    const w = createCelldWorld({
+      fleetUrl: transport.fleetUrl,
+      secret: transport.secret,
+      baseUrl: callbackBaseUrl,
+      deploymentId: 'integration-retention',
+      runRetentionMs: 500,
+    });
+    const streamName = `it-retention-${randomUUID()}`;
+    const created = await w.events.create(null, {
+      eventType: 'run_created',
+      eventData: {
+        deploymentId: 'integration-retention',
+        workflowName: `it-retention-${randomUUID()}`,
+        input: ['payload'],
+      },
+    });
+    const runId = created.run!.runId;
+    await w.writeToStream(streamName, runId, 'stream-payload');
+    await w.closeStream(streamName, runId);
+    await w.queue(
+      `__wkf_workflow_retention_${randomUUID().slice(0, 8)}`,
+      { runId },
+      { delaySeconds: 3_600, idempotencyKey: `retention:${runId}` },
+    );
+    await w.events.create(runId, {
+      eventType: 'run_completed',
+      eventData: { output: ['done'] },
+    });
+
+    const status = await waitFor(
+      async () => {
+        const current = await w.retention.getStatus(runId);
+        return current?.phase === 'tombstoned' ? current : null;
+      },
+      30_000,
+      'terminal retention cleanup',
+    );
+    expect(status.deletedStreams).toBe(1);
+    expect(status.deletedQueueMessages).toBe(1);
+    expect(status.deletedPayloadKeys).toBeGreaterThan(0);
+    await expect(w.runs.get(runId)).rejects.toSatisfy((error) => RunExpiredError.is(error));
+    await expect(w.writeToStream(streamName, runId, 'late')).rejects.toThrow(/expired/);
   });
 
   it('paginated event listing asc and desc (list options spike)', async () => {

--- a/test/perf/minio.test.ts
+++ b/test/perf/minio.test.ts
@@ -7,6 +7,8 @@ import { createCelldWorld } from '../../src/index.js';
 import { callDO } from '../../src/remote/rpc-client.js';
 import { parse } from '../../src/vendor/shared/index.js';
 import type { QueueStats } from '../../src/worker/durable-objects/QueueDO.js';
+import { RunExpiredError } from '@workflow/errors';
+import type { CleanupRecord } from '../../src/retention.js';
 
 function positiveInteger(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -121,6 +123,32 @@ interface PerfResult {
   budgets: Record<string, number>;
 }
 
+interface RetentionPerfResult {
+  schemaVersion: 1;
+  recordedAt: string;
+  backend: { name: 'minio'; version: string; celldVersion: string };
+  workload: { runs: number; concurrency: number; queueShards: number; retentionMs: number };
+  correctness: {
+    created: number;
+    tombstoned: number;
+    expiredReads: number;
+    deletedPayloadKeys: number;
+    deletedStreams: number;
+    deletedQueueMessages: number;
+    pending: number;
+    inflight: number;
+    deadLetters: number;
+  };
+  performance: {
+    setupDurationMs: number;
+    cleanupDurationMs: number;
+    setupRunsPerSecond: number;
+    cleanupRunsPerSecond: number;
+    terminalWriteLatencyMs: LatencySummary;
+    cleanupLagMs: LatencySummary;
+  };
+}
+
 describe('MinIO single-node queue performance and loss', () => {
   const fleetUrl = process.env.CELLD_FLEET_URL ?? '';
   const secret = process.env.CELLD_WORLD_SECRET ?? '';
@@ -135,6 +163,11 @@ describe('MinIO single-node queue performance and loss', () => {
   const minDeliveryPerSecond = nonNegativeNumber('PERF_MIN_DELIVERY_PER_SECOND');
   const maxDeliveryP99Ms = nonNegativeNumber('PERF_MAX_DELIVERY_P99_MS');
   const resultPath = process.env.PERF_RESULT_PATH ?? '.perf-results/minio-latest.json';
+  const retentionRuns = positiveInteger('PERF_RETENTION_RUNS', 100);
+  const retentionConcurrency = positiveInteger('PERF_RETENTION_CONCURRENCY', 16);
+  const retentionMs = positiveInteger('PERF_RUN_RETENTION_MS', 1_000);
+  const retentionResultPath =
+    process.env.PERF_RETENTION_RESULT_PATH ?? '.perf-results/minio-retention-latest.json';
   const runId = randomUUID();
   const startedAt = new Map<number, number>();
   const accepted = new Map<number, string>();
@@ -368,5 +401,146 @@ describe('MinIO single-node queue performance and loss', () => {
       maxDeliveryP99Ms === 0 || deliveryP99Ms <= maxDeliveryP99Ms,
       `delivery p99 ${deliveryP99Ms}ms exceeds ${maxDeliveryP99Ms}ms`,
     ).toBe(true);
+  });
+
+  it('reclaims terminal run payloads without loss or resurrection', async () => {
+    const world = createCelldWorld({
+      fleetUrl,
+      secret,
+      baseUrl: process.env.CELLD_CALLBACK_BASE_URL,
+      deploymentId: `retention-perf-${runId}`,
+      queueShards,
+      runRetentionMs: retentionMs,
+      rpcTimeoutMs: timeoutMs,
+    });
+    const runIds: string[] = [];
+    const terminalWriteLatencies: number[] = [];
+    const setupStart = performance.now();
+
+    await runPool(retentionRuns, retentionConcurrency, async (sequence) => {
+      const created = await world.events.create(null, {
+        eventType: 'run_created',
+        eventData: {
+          deploymentId: `retention-perf-${runId}`,
+          workflowName: `retention-perf-${sequence}`,
+          input: [`payload-${sequence}`, 'x'.repeat(payloadBytes)],
+        },
+      });
+      const workflowRunId = created.run!.runId;
+      runIds.push(workflowRunId);
+      const streamName = `retention-${workflowRunId}`;
+      await world.writeToStream(streamName, workflowRunId, `stream-${sequence}`);
+      await world.closeStream(streamName, workflowRunId);
+      await world.queue(
+        `__wkf_workflow_retention_${runId.replaceAll('-', '')}`,
+        { runId: workflowRunId },
+        { delaySeconds: 3_600, idempotencyKey: `retention:${workflowRunId}` },
+      );
+      const terminalStart = performance.now();
+      await world.events.create(workflowRunId, {
+        eventType: 'run_completed',
+        eventData: { output: [`done-${sequence}`] },
+      });
+      terminalWriteLatencies.push(performance.now() - terminalStart);
+    });
+
+    const setupEnd = performance.now();
+    let completedStatuses: CleanupRecord[] = [];
+    const cleaned = await waitUntil(async () => {
+      const statuses = await Promise.all(runIds.map((id) => world.retention.getStatus(id)));
+      completedStatuses = statuses.filter(
+        (status): status is CleanupRecord => status?.phase === 'tombstoned',
+      );
+      return completedStatuses.length === runIds.length;
+    }, timeoutMs);
+    const finishedAt = performance.now();
+    if (!cleaned) {
+      throw new Error(`retention cleanup timed out after ${finishedAt - setupEnd}ms`);
+    }
+
+    const expiredReads = (
+      await Promise.all(
+        runIds.map(async (id) => {
+          try {
+            await world.runs.get(id);
+            return false;
+          } catch (error) {
+            return RunExpiredError.is(error);
+          }
+        }),
+      )
+    ).filter(Boolean).length;
+    const queueStats = await Promise.all(
+      Array.from({ length: queueShards }, (_, shard) =>
+        callDO<QueueStats>({ fleetUrl, secret }, 'queue', `q:${shard}`, 'stats', []),
+      ),
+    );
+    const cleanupLag = completedStatuses.map(
+      (status) => status.tombstonedAt!.getTime() - status.dueAt.getTime(),
+    );
+    const cleanupStart = Math.min(...completedStatuses.map((status) => status.dueAt.getTime()));
+    const cleanupEnd = Math.max(
+      ...completedStatuses.map((status) => status.tombstonedAt!.getTime()),
+    );
+    const setupDurationMs = setupEnd - setupStart;
+    const cleanupDurationMs = Math.max(0, cleanupEnd - cleanupStart);
+    const pending = queueStats.reduce((sum, entry) => sum + entry.pending, 0);
+    const inflight = queueStats.reduce((sum, entry) => sum + entry.inflight, 0);
+    const deadLetters = queueStats.reduce((sum, entry) => sum + entry.deadLetters, 0);
+
+    const result: RetentionPerfResult = {
+      schemaVersion: 1,
+      recordedAt: new Date().toISOString(),
+      backend: {
+        name: 'minio',
+        version: process.env.PERF_MINIO_VERSION ?? 'unknown',
+        celldVersion: process.env.PERF_CELLD_VERSION ?? 'unknown',
+      },
+      workload: {
+        runs: retentionRuns,
+        concurrency: retentionConcurrency,
+        queueShards,
+        retentionMs,
+      },
+      correctness: {
+        created: runIds.length,
+        tombstoned: completedStatuses.length,
+        expiredReads,
+        deletedPayloadKeys: completedStatuses.reduce(
+          (sum, status) => sum + status.deletedPayloadKeys,
+          0,
+        ),
+        deletedStreams: completedStatuses.reduce((sum, status) => sum + status.deletedStreams, 0),
+        deletedQueueMessages: completedStatuses.reduce(
+          (sum, status) => sum + status.deletedQueueMessages,
+          0,
+        ),
+        pending,
+        inflight,
+        deadLetters,
+      },
+      performance: {
+        setupDurationMs: Number(setupDurationMs.toFixed(2)),
+        cleanupDurationMs,
+        setupRunsPerSecond: rate(runIds.length, setupDurationMs),
+        cleanupRunsPerSecond: rate(completedStatuses.length, cleanupDurationMs),
+        terminalWriteLatencyMs: summarizeLatency(terminalWriteLatencies),
+        cleanupLagMs: summarizeLatency(cleanupLag),
+      },
+    };
+
+    await mkdir(path.dirname(retentionResultPath), { recursive: true });
+    await writeFile(retentionResultPath, `${JSON.stringify(result, null, 2)}\n`);
+    console.log(`\nworld-celld MinIO retention result\n${JSON.stringify(result, null, 2)}`);
+
+    expect(runIds).toHaveLength(retentionRuns);
+    expect(completedStatuses).toHaveLength(retentionRuns);
+    expect(expiredReads).toBe(retentionRuns);
+    expect(result.correctness.deletedPayloadKeys).toBeGreaterThan(0);
+    expect(result.correctness.deletedStreams).toBe(retentionRuns);
+    expect(result.correctness.deletedQueueMessages).toBe(retentionRuns);
+    expect(pending).toBe(0);
+    expect(inflight).toBe(0);
+    expect(deadLetters).toBe(0);
   });
 });

--- a/test/perf/minio/compose.yaml
+++ b/test/perf/minio/compose.yaml
@@ -114,6 +114,10 @@ services:
       PERF_MIN_DELIVERY_PER_SECOND: '${PERF_MIN_DELIVERY_PER_SECOND:-0}'
       PERF_MAX_DELIVERY_P99_MS: '${PERF_MAX_DELIVERY_P99_MS:-0}'
       PERF_RESULT_PATH: /workspace/.perf-results/minio-latest.json
+      PERF_RETENTION_RUNS: '${PERF_RETENTION_RUNS:-100}'
+      PERF_RETENTION_CONCURRENCY: '${PERF_RETENTION_CONCURRENCY:-16}'
+      PERF_RUN_RETENTION_MS: '${PERF_RUN_RETENTION_MS:-1000}'
+      PERF_RETENTION_RESULT_PATH: /workspace/.perf-results/minio-retention-latest.json
       PERF_CELLD_VERSION: v0.2.1
       PERF_MINIO_VERSION: RELEASE.2025-09-07T16-13-09Z
     command: pnpm vitest run --config vitest.perf.config.ts

--- a/test/queue-do.test.ts
+++ b/test/queue-do.test.ts
@@ -392,6 +392,87 @@ describe('QueueDO', () => {
     expect((await queue.stats()).deadLetters).toBe(0);
   });
 
+  it('purges every message state for an expired run and fences late enqueue', async () => {
+    const runId = 'wrun_queue_cleanup';
+    await queue.enqueue(
+      enqueueReq({
+        messageId: 'msg_pending',
+        runId,
+        idempotencyKey: 'pending-key',
+        delaySeconds: 60,
+      }),
+    );
+    await queue.enqueue(
+      enqueueReq({
+        messageId: 'msg_inflight',
+        runId,
+        idempotencyKey: 'inflight-key',
+        delaySeconds: 60,
+      }),
+    );
+    await queue.enqueue(
+      enqueueReq({
+        messageId: 'msg_dead',
+        runId,
+        idempotencyKey: 'dead-key',
+        delaySeconds: 60,
+      }),
+    );
+
+    const data = storage();
+    for (const key of Array.from(data.keys())) {
+      if (key.startsWith('due:') && key.endsWith(':msg_inflight')) data.delete(key);
+      if (key.startsWith('due:') && key.endsWith(':msg_dead')) data.delete(key);
+    }
+    data.set('inflight:msg_inflight', fleet.now + 30_000);
+    const dead = data.get('msg:msg_dead') as MessageRow;
+    data.delete('msg:msg_dead');
+    const deadKey = `dlq:${String(fleet.now).padStart(13, '0')}:msg_dead`;
+    data.set(deadKey, { ...dead, failedAt: fleet.now });
+    data.set(`run:${runId}:msg_dead`, {
+      messageId: 'msg_dead',
+      dlqKey: deadKey,
+      idempotencyKey: 'dead-key',
+    });
+
+    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 3 });
+    expect(await queue.stats()).toMatchObject({ pending: 0, inflight: 0, deadLetters: 0 });
+    expect(Array.from(data.keys()).filter((key) => key.startsWith(`run:${runId}:`))).toEqual([]);
+    expect(data.has(`expired-run:${runId}`)).toBe(true);
+    expect(data.has('key:pending-key')).toBe(false);
+    expect(data.has('key:inflight-key')).toBe(false);
+    expect(data.has('key:dead-key')).toBe(false);
+
+    const late = await queue.enqueue(enqueueReq({ messageId: 'msg_late', runId }));
+    expect(late).toMatchObject({ ok: false, code: 'RUN_EXPIRED' });
+  });
+
+  it('does not let an in-flight retry resurrect an expired run', async () => {
+    let finishDelivery!: (response: Response) => void;
+    fetchStub.mockImplementation(
+      () => new Promise<Response>((resolve) => (finishDelivery = resolve)),
+    );
+    const runId = 'wrun_expire_during_delivery';
+    await queue.enqueue(
+      enqueueReq({
+        messageId: 'msg_expiring',
+        runId,
+        idempotencyKey: 'expiring-key',
+      }),
+    );
+
+    const delivery = tick();
+    await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledOnce());
+    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 1 });
+    finishDelivery(jsonResponse(500, { error: 'late failure' }));
+    await delivery;
+
+    expect(await queue.stats()).toMatchObject({ pending: 0, inflight: 0, deadLetters: 0 });
+    expect(storage().has('msg:msg_expiring')).toBe(false);
+    expect(storage().has('key:expiring-key')).toBe(false);
+    expect(Array.from(storage().keys()).some((key) => key.endsWith(':msg_expiring'))).toBe(false);
+  });
+
   it('rearmAlarm derives the alarm from pending work (abandonment recovery)', async () => {
     await queue.enqueue(enqueueReq({ messageId: 'msg_p', delaySeconds: 60 }));
     // Simulate celld abandoning the alarm.

--- a/test/retention.test.ts
+++ b/test/retention.test.ts
@@ -1,0 +1,183 @@
+import { HookNotFoundError, RunExpiredError } from '@workflow/errors';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createCelldWorld } from '../src/index.js';
+import { startHarness, type Harness } from '../src/testing/http-harness.js';
+import type { IndexDO } from '../src/worker/durable-objects/IndexDO.js';
+import type { QueueDO } from '../src/worker/durable-objects/QueueDO.js';
+
+async function createCompletedRun(world: ReturnType<typeof createCelldWorld>, suffix: string) {
+  const created = await world.events.create(null, {
+    eventType: 'run_created',
+    eventData: {
+      deploymentId: 'retention-tests',
+      workflowName: `retention-${suffix}`,
+      input: [`input-${suffix}`],
+    },
+  });
+  const runId = created.run!.runId;
+  await world.events.create(runId, { eventType: 'run_started' });
+  await world.events.create(runId, {
+    eventType: 'step_created',
+    correlationId: `step-${suffix}`,
+    eventData: { stepName: 'retained-step', input: [`step-input-${suffix}`] },
+  });
+  return runId;
+}
+
+async function finishRun(world: ReturnType<typeof createCelldWorld>, runId: string) {
+  await world.events.create(runId, {
+    eventType: 'run_completed',
+    eventData: { output: ['done'] },
+  });
+}
+
+async function driveCleanup(
+  harness: Harness,
+  world: ReturnType<typeof createCelldWorld>,
+  runId: string,
+) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    harness.fleet.advance(10);
+    await harness.fleet.fireDueAlarms();
+    const status = await world.retention.getStatus(runId);
+    if (status?.phase === 'tombstoned') return status;
+  }
+  throw new Error('cleanup did not reach tombstoned state');
+}
+
+describe('terminal workflow retention', () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    delete process.env.CELLD_QUEUE_MODE;
+    await harness?.close();
+    harness = undefined;
+  });
+
+  it('purges payloads, indexes, streams, and queued work without allowing resurrection', async () => {
+    process.env.CELLD_QUEUE_MODE = 'cells';
+    harness = await startHarness({ secret: 'retention-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-secret',
+      deploymentId: 'retention-tests',
+      baseUrl: 'http://127.0.0.1:1',
+      runRetentionMs: 1_000,
+    });
+
+    const runId = await createCompletedRun(world, 'complete');
+    await world.writeToStream('retention-stream', runId, 'payload');
+    await world.closeStream('retention-stream', runId);
+    await world.events.create(runId, {
+      eventType: 'hook_created',
+      correlationId: 'retention-hook',
+      eventData: { token: 'retention-token' },
+    });
+    await world.queue(
+      '__wkf_workflow_retention',
+      { runId },
+      { delaySeconds: 3_600, idempotencyKey: `wake:${runId}` },
+    );
+    await finishRun(world, runId);
+
+    const retained = await world.runs.get(runId);
+    expect(retained.status).toBe('completed');
+    expect(retained.expiredAt).toBeInstanceOf(Date);
+    expect((await world.getStreamInfo('retention-stream', runId)).done).toBe(true);
+
+    harness.fleet.advance(1_001);
+    const status = await driveCleanup(harness, world, runId);
+    expect(status).toMatchObject({
+      phase: 'tombstoned',
+      deletedStreams: 1,
+      deletedQueueMessages: 1,
+    });
+    expect(status.deletedPayloadKeys).toBeGreaterThan(0);
+
+    await expect(world.runs.get(runId)).rejects.toSatisfy((error) => RunExpiredError.is(error));
+    await expect(world.events.create(runId, { eventType: 'run_started' })).rejects.toSatisfy(
+      (error) => RunExpiredError.is(error),
+    );
+    await expect(world.getStreamInfo('retention-stream', runId)).rejects.toThrow(/expired/);
+    await expect(world.writeToStream('retention-stream', runId, 'late')).rejects.toThrow(/expired/);
+    await expect(
+      world.queue('__wkf_workflow_retention', { runId }, { idempotencyKey: `late:${runId}` }),
+    ).rejects.toSatisfy((error) => RunExpiredError.is(error));
+    await expect(world.hooks.getByToken('retention-token')).rejects.toSatisfy((error) =>
+      HookNotFoundError.is(error),
+    );
+
+    const listed = await world.runs.list({ workflowName: 'retention-complete' });
+    expect(listed.data).toEqual([]);
+    const queue = harness.fleet.namespace('queue').get({ toString: () => 'q:0' }) as QueueDO;
+    expect(await queue.stats()).toMatchObject({ pending: 0, inflight: 0, deadLetters: 0 });
+
+    const runKeys = Array.from(harness.fleet.cell('runs', runId).storage.data.keys()).toSorted();
+    expect(runKeys).toEqual(['retention:cleanup', 'retention:tombstone', 'schema_version']);
+    expect(
+      Array.from(
+        harness.fleet.cell('streams', `run-streams:${runId}`).storage.data.keys(),
+      ).toSorted(),
+    ).toEqual(['registry:expired', 'registry:owner']);
+    expect(
+      Array.from(harness.fleet.cell('streams', 'stream:retention-stream').storage.data.keys()),
+    ).toEqual(['meta']);
+  });
+
+  it('keeps retention disabled by default', async () => {
+    harness = await startHarness({ secret: 'retention-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-secret',
+      deploymentId: 'retention-tests',
+    });
+    const runId = await createCompletedRun(world, 'disabled');
+    await finishRun(world, runId);
+
+    harness.fleet.advance(365 * 24 * 60 * 60 * 1_000);
+    await harness.fleet.fireDueAlarms();
+
+    expect(await world.retention.getStatus(runId)).toBeNull();
+    expect((await world.runs.get(runId)).status).toBe('completed');
+    expect(() => world.retention.schedule(runId)).toThrow(/runRetentionMs/);
+
+    await world.retention.cleanupNow(runId);
+    const status = await driveCleanup(harness, world, runId);
+    expect(status.phase).toBe('tombstoned');
+    await expect(world.runs.get(runId)).rejects.toSatisfy((error) => RunExpiredError.is(error));
+  });
+
+  it('persists a failed phase and retries it idempotently', async () => {
+    harness = await startHarness({ secret: 'retention-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-secret',
+      deploymentId: 'retention-tests',
+      runRetentionMs: 100,
+    });
+    const runId = await createCompletedRun(world, 'retry');
+    await finishRun(world, runId);
+
+    const indexSlot = harness.fleet.cell('index', 'index');
+    indexSlot.storage.failNextMutation(
+      (mutation) => mutation.operation === 'delete' && mutation.key.startsWith('run:'),
+      new Error('injected index cleanup failure'),
+    );
+    harness.fleet.advance(101);
+    await harness.fleet.fireDueAlarms();
+
+    expect(await world.retention.getStatus(runId)).toMatchObject({
+      phase: 'index',
+      attempts: 1,
+      lastError: 'injected index cleanup failure',
+    });
+
+    harness.fleet.advance(1_000);
+    const status = await driveCleanup(harness, world, runId);
+    expect(status.phase).toBe('tombstoned');
+
+    const index = harness.fleet.namespace('index').get({ toString: () => 'index' }) as IndexDO;
+    const entries = await index.list({ prefix: 'run:retention-retry:' });
+    expect(entries.keys).toEqual([]);
+  });
+});

--- a/test/storage-regressions.test.ts
+++ b/test/storage-regressions.test.ts
@@ -70,20 +70,20 @@ describe('Storage regressions', () => {
       },
     };
     const index = mockEnv.WORKFLOW_INDEX;
-    const put = index.put.bind(index);
+    const putOwned = index.putOwned.bind(index);
     let failNextRunIndexWrite = true;
-    index.put = async (key, value) => {
+    index.putOwned = async (ownerRunId, key, value) => {
       if (failNextRunIndexWrite && key.startsWith('run:')) {
         failNextRunIndexWrite = false;
         throw new Error('injected index outage');
       }
-      await put(key, value);
+      return putOwned(ownerRunId, key, value);
     };
 
     try {
       await expect(storage.events.create(runId, event)).rejects.toThrow('injected index outage');
     } finally {
-      index.put = put;
+      index.putOwned = putOwned;
     }
 
     expect((await storage.runs.get(runId)).status).toBe('running');

--- a/test/streamer.test.ts
+++ b/test/streamer.test.ts
@@ -208,6 +208,9 @@ describe('Streamer (StreamDO RPC integration)', () => {
         getInfo: vi.fn<StreamDOStub['getInfo']>(fail),
         registerStream: vi.fn<StreamDOStub['registerStream']>(fail),
         listStreams: vi.fn<StreamDOStub['listStreams']>(fail),
+        expireRegistry: vi.fn<StreamDOStub['expireRegistry']>(fail),
+        finalizeRegistry: vi.fn<StreamDOStub['finalizeRegistry']>(fail),
+        expireStream: vi.fn<StreamDOStub['expireStream']>(fail),
       };
       const failingEnv = {
         WORKFLOW_STREAMS: {
@@ -286,6 +289,12 @@ describe('Streamer (StreamDO RPC integration)', () => {
         getInfo: vi.fn<StreamDOStub['getInfo']>(async () => ({ tailIndex: -1, done: false })),
         registerStream: vi.fn<StreamDOStub['registerStream']>(),
         listStreams: vi.fn<StreamDOStub['listStreams']>(async () => []),
+        expireRegistry: vi.fn<StreamDOStub['expireRegistry']>(async () => ({ streams: [] })),
+        finalizeRegistry: vi.fn<StreamDOStub['finalizeRegistry']>(),
+        expireStream: vi.fn<StreamDOStub['expireStream']>(async () => ({
+          deleted: true,
+          chunks: 0,
+        })),
       };
       const boundedStreamer = createStreamer({
         env: {


### PR DESCRIPTION
## Summary

- add configurable retention deadlines for terminal workflow runs
- clean up run payloads, derived indexes, hooks, streams, and queued messages through a durable, retryable phase machine
- leave metadata-only tombstones and cross-cell fences so delayed RPCs and queue callbacks cannot recreate expired state
- expose authenticated retention status, scheduling, immediate cleanup, and alarm rearming through `world.retention`
- add unit, conformance, live-fleet, and MinIO cleanup/performance coverage
- document configuration, lifecycle semantics, operations, and benchmark controls

## Why

Terminal workflow payloads were retained indefinitely. celld hibernation releases runtime resources but preserves durable SQLite state, so worlds need an explicit lifecycle for deleting inputs, outputs, events, steps, hooks, streams, and queue payloads after a configured retention period.

This repository is pre-production, so this change intentionally does not add migration or backfill compatibility for old queue and stream layouts.

## Validation

- `pnpm check`
  - formatting and strict type-aware lint
  - TypeScript typecheck and build
  - 176 tests
  - worker bundle validation
  - clean npm package validation
- `pnpm test:integration`: harness prerequisite passed; 10 live-celld tests skipped because no fleet URL/credentials were configured
- Docker-backed MinIO workload was not run because Docker and Docker Desktop are not installed on the test machine
