### PR TITLE
fix: exclude generated changelog from formatting

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["src/vendor/**"],
+  "ignorePatterns": ["src/vendor/**", "CHANGELOG.md"],
   "printWidth": 100,
   "singleQuote": true
 }


### PR DESCRIPTION
## Summary

- exclude `CHANGELOG.md` from oxfmt's formatting surface
- leave Release Please as the sole owner of generated changelog formatting
- unblock the generated `0.2.0` release PR and future release PRs

## Root cause

Release Please's GitHub changelog generator emits valid Markdown using asterisks and compact heading/list spacing. oxfmt normalizes that output, so the generated release PR failed `pnpm format:check` even though its version and release metadata were correct. Formatting the generated file manually would recur on every release.

## Validation

- reproduced PR #14's exact generated changelog in an isolated worktree; `oxfmt --check .` passes with this exclusion
- `pnpm check` — formatting, strict linting, typecheck, build, 176 tests, worker bundle check, and package inspection
- `git diff --check`
- GitHub verifies commit `af8d3a69d27ca92487484593a25fd0ced48c3862` has a valid SSH signature
