### PR TITLE
fix: split Release Please release and PR phases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,55 @@ jobs:
       tarball: ${{ steps.metadata.outputs.tarball }}
       sha: ${{ steps.metadata.outputs.sha }}
     steps:
-      - name: Create or update release
-        id: release_please
+      - name: Create release
+        id: release
         if: github.event_name == 'push'
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check current release tag
+        id: current_release
+        if: github.event_name == 'push' && steps.release.outputs.release_created != 'true'
+        env:
+          GH_REPO: ${{ github.repository }}
+        run: |
+          node --input-type=module <<'EOF'
+          import { execFileSync } from 'node:child_process';
+          import { appendFileSync, readFileSync } from 'node:fs';
+
+          const packageManifest = JSON.parse(readFileSync('package.json', 'utf8'));
+          const releaseManifest = JSON.parse(readFileSync('.release-please-manifest.json', 'utf8'));
+          if (packageManifest.version !== releaseManifest['.']) {
+            throw new Error(
+              `package version ${packageManifest.version} does not match release manifest ${releaseManifest['.']}`,
+            );
+          }
+          const tag = `v${packageManifest.version}`;
+          const remoteTags = execFileSync('git', [
+            'ls-remote',
+            `https://github.com/${process.env.GH_REPO}.git`,
+            `refs/tags/${tag}`,
+            `refs/tags/${tag}^{}`,
+          ], { encoding: 'utf8' }).trim();
+          appendFileSync(process.env.GITHUB_OUTPUT, `tag_exists=${remoteTags ? 'true' : 'false'}\n`);
+          EOF
+      - name: Create or update release PR
+        id: release_pr
+        if: >-
+          github.event_name == 'push' &&
+          steps.release.outputs.release_created != 'true' &&
+          steps.current_release.outputs.tag_exists == 'true'
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
       - name: Resolve release metadata
         id: metadata
         env:
@@ -47,11 +89,11 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           MANUAL_VERSION: ${{ inputs.version }}
-          RELEASE_CREATED: ${{ steps.release_please.outputs.release_created }}
-          RELEASE_PR: ${{ steps.release_please.outputs.pr }}
-          RELEASE_SHA: ${{ steps.release_please.outputs.sha }}
-          RELEASE_TAG: ${{ steps.release_please.outputs.tag_name }}
-          RELEASE_VERSION: ${{ steps.release_please.outputs.version }}
+          RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
+          RELEASE_PR: ${{ steps.release_pr.outputs.pr }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_SHA: ${{ github.sha }}
         run: |


### PR DESCRIPTION
## Summary

- split Release Please into a release-only phase and a PR-only phase
- generate the next release PR only after the manifest's current version has a real Git tag
- preserve draft releases and the existing npm OIDC publication gate
- keep manual recovery pinned to the draft release's exact target commit

## Root cause

After release PR #14 merged, Release Please created the `v0.2.0` draft successfully. The same action invocation then tried to generate the next release PR. Draft mode intentionally does not create the tag before npm publication, so GitHub rejected `v0.2.0` as the generated changelog's `previous_tag`.

The failed run did not publish anything: `v0.2.0` remains a draft without assets or a Git tag, and npm does not contain `@ewhauser/world-celld@0.2.0`.

## Behavior after this change

On a release-PR merge, the first action creates only the draft release and the existing downstream jobs build, publish, verify, and finalize it. On ordinary pushes, the second action creates or updates a release PR only when the current manifest version has already been tagged. An interrupted draft therefore waits safely for the explicit recovery workflow instead of trying to generate notes from a nonexistent tag.

## Validation

- `pnpm check` — formatting, strict linting, typecheck, build, 176 tests, worker bundle check, and package inspection
- `actionlint`
- `zizmor 1.29.0 --persona=pedantic` — no findings
- release-only `release-please@17.6.0 github-release --dry-run` against current `main` — safely reports zero new releases for the existing draft
- extracted tag-guard step reports `tag_exists=false` for the current untagged `0.2.0` draft
- extracted recovery step resolves `v0.2.0` to exact commit `35f53a690764b222e12f0b52a5ac16aeb3e3119a`
- GitHub verifies commit `8218393d5abd8a7424904d46bb8084f0f83e50c6` has a valid SSH signature
