### PR TITLE
perf: reduce runs.list RPC fanout

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import type { WorkflowRunDONamespace } from './storage.js';
 import type { StreamDONamespace } from './streamer.js';
 import type { QueueCellNamespace } from './queue.js';
 
-/** Storage-layer KV interface (satisfied by IndexDO over HTTP, or a mock). */
+/** Storage-layer index interface (satisfied by IndexDO over HTTP, or a mock). */
 export interface IndexNamespace {
   get(key: string): Promise<string | null>;
   put(key: string, value: string): Promise<void>;
@@ -12,7 +12,11 @@ export interface IndexNamespace {
     request: import('./retention.js').ExpireRunIndexesRequest,
   ): Promise<import('./retention.js').ExpireRunIndexesResult>;
   list(options?: { prefix?: string; cursor?: string; limit?: number; reverse?: boolean }): Promise<{
-    keys: Array<{ name: string }>;
+    /**
+     * IndexDO includes values so callers do not need one follow-up RPC per key.
+     * `value` remains optional for compatibility with KV-like custom adapters.
+     */
+    keys: Array<{ name: string; value?: string }>;
     list_complete: boolean;
     cursor?: string;
   }>;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -33,6 +33,7 @@ import type {
 import {
   EventSchema,
   HookSchema,
+  isTerminalWorkflowRunStatus,
   SPEC_VERSION_CURRENT,
   StepSchema,
   WorkflowRunSchema,
@@ -181,6 +182,30 @@ function unwrapRead<T>(outcome: RunReadOutcome<T>): T {
   return outcome.value;
 }
 
+/** Bound cross-run fanout so large list pages cannot create an RPC burst. */
+const RUN_LIST_CONCURRENCY = 8;
+
+interface RunIndexMetadata {
+  runId: string;
+  /** Optional so indexes written by older deployments remain readable. */
+  status?: WorkflowRun['status'];
+}
+
+/**
+ * Run statuses only move pending -> running -> terminal, and terminal statuses
+ * are immutable. An older index value may therefore safely exclude a filter
+ * only when it is already terminal, or when the caller asks for pending and
+ * the index has advanced beyond pending. Earlier non-terminal metadata cannot
+ * exclude a later status because a post-commit index write may need replay.
+ */
+function indexStatusExcludes(
+  indexed: WorkflowRun['status'] | undefined,
+  requested: WorkflowRun['status'] | undefined,
+): boolean {
+  if (indexed === undefined || requested === undefined || indexed === requested) return false;
+  return isTerminalWorkflowRunStatus(indexed) || requested === 'pending';
+}
+
 export function createStorage(config: CloudflareStorageConfig): Storage {
   const { env } = config;
   const cleanup = {
@@ -241,19 +266,55 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
             break;
           }
 
-          for (const key of kvList.keys) {
-            const meta = await env.WORKFLOW_INDEX.get(key.name);
-            if (!meta) continue;
-            const { runId } = JSON.parse(meta) as { runId: string };
-            try {
-              const run = await runsGet(runId, { resolveData: params?.resolveData });
-              if (!params?.status || run.status === params.status) {
-                matches.push({ key: key.name, run });
-                if (matches.length > limit) break;
+          // IndexDO returns values with the page. Resolve missing values in
+          // bounded batches as a compatibility fallback for older/custom
+          // KV-like adapters instead of restoring serial per-key reads.
+          const candidates: Array<{ key: string; metadata: RunIndexMetadata }> = [];
+          for (let offset = 0; offset < kvList.keys.length; offset += RUN_LIST_CONCURRENCY) {
+            const batch = kvList.keys.slice(offset, offset + RUN_LIST_CONCURRENCY);
+            const values = await Promise.all(
+              batch.map(async (key) => ({
+                key: key.name,
+                value: key.value ?? (await env.WORKFLOW_INDEX.get(key.name)),
+              })),
+            );
+            for (const { key, value } of values) {
+              if (!value) continue;
+              const metadata = JSON.parse(value) as RunIndexMetadata;
+              // Use monotonic status metadata as a conservative prefilter,
+              // then still verify every candidate against the authoritative
+              // RunDO below. Earlier metadata cannot exclude a later status.
+              if (indexStatusExcludes(metadata.status, params?.status)) {
+                continue;
               }
-            } catch (error) {
-              if (!WorkflowRunNotFoundError.is(error) && !RunExpiredError.is(error)) throw error;
+              candidates.push({ key, metadata });
             }
+          }
+
+          // Fetch enough candidates to prove the requested page and hasMore,
+          // retaining index order while limiting concurrent cross-run RPCs.
+          for (let offset = 0; offset < candidates.length && matches.length <= limit;) {
+            const needed = limit + 1 - matches.length;
+            const batch = candidates.slice(offset, offset + Math.min(RUN_LIST_CONCURRENCY, needed));
+            const resolved = await Promise.all(
+              batch.map(async ({ key, metadata }) => {
+                try {
+                  const run = await runsGet(metadata.runId, {
+                    resolveData: params?.resolveData,
+                  });
+                  return !params?.status || run.status === params.status ? { key, run } : null;
+                } catch (error) {
+                  if (!WorkflowRunNotFoundError.is(error) && !RunExpiredError.is(error)) {
+                    throw error;
+                  }
+                  return null;
+                }
+              }),
+            );
+            for (const match of resolved) {
+              if (match) matches.push(match);
+            }
+            offset += batch.length;
           }
 
           exhausted = kvList.list_complete;

--- a/src/test-mocks.ts
+++ b/src/test-mocks.ts
@@ -275,7 +275,7 @@ class MockKVNamespace {
     limit?: number;
     reverse?: boolean;
   }): Promise<{
-    keys: Array<{ name: string }>;
+    keys: Array<{ name: string; value: string }>;
     list_complete: boolean;
     cursor?: string;
   }> {
@@ -299,7 +299,7 @@ class MockKVNamespace {
     const listComplete = matchingKeys.length <= limit;
 
     return {
-      keys: page.map((name) => ({ name })),
+      keys: page.map((name) => ({ name, value: kvData.get(name)! })),
       list_complete: listComplete,
       cursor: listComplete ? undefined : page.at(-1),
     };

--- a/src/worker/durable-objects/IndexDO.ts
+++ b/src/worker/durable-objects/IndexDO.ts
@@ -26,10 +26,10 @@ function ownerFromHook(raw: string): HookTokenOwner {
  * reservation, publication, and release use storage transactions so
  * concurrent runs cannot both acquire the same token.
  *
- * The RPC surface matches the storage-layer KVNamespace interface bit-for-bit
- * (including MockKVNamespace's pagination contract: cursor = last returned
- * key, `list_complete` reflects whether further keys exist), so the vendored
- * storage.ts works against it unchanged.
+ * The pagination contract matches KVNamespace (cursor = last returned key and
+ * `list_complete` reflects whether further keys exist). Unlike KVNamespace,
+ * list() also returns each stored value so callers do not need an additional
+ * RPC for every listed key.
  */
 export class IndexDO extends DurableObject {
   async get(key: string): Promise<string | null> {
@@ -62,7 +62,7 @@ export class IndexDO extends DurableObject {
     limit?: number;
     reverse?: boolean;
   }): Promise<{
-    keys: Array<{ name: string }>;
+    keys: Array<{ name: string; value: string }>;
     list_complete: boolean;
     cursor?: string;
   }> {
@@ -72,7 +72,7 @@ export class IndexDO extends DurableObject {
     // Fetch one extra key to learn whether the listing is complete without
     // advancing past the page (the "exact limit + list_complete" contract
     // storage.ts relies on).
-    const entries = await this.ctx.storage.list({
+    const entries = await this.ctx.storage.list<string>({
       prefix,
       ...(options?.reverse
         ? { reverse: true, end: options.cursor }
@@ -80,14 +80,13 @@ export class IndexDO extends DurableObject {
       limit: limit + 1,
     });
 
-    const names = Array.from(entries.keys());
-    const page = names.slice(0, limit);
-    const listComplete = names.length <= limit;
+    const page = Array.from(entries).slice(0, limit);
+    const listComplete = entries.size <= limit;
 
     return {
-      keys: page.map((name) => ({ name })),
+      keys: page.map(([name, value]) => ({ name, value })),
       list_complete: listComplete,
-      cursor: listComplete ? undefined : page.at(-1),
+      cursor: listComplete ? undefined : page.at(-1)?.[0],
     };
   }
 

--- a/test/index-do.test.ts
+++ b/test/index-do.test.ts
@@ -1,7 +1,7 @@
 /**
- * IndexDO pagination-contract tests: must match MockKVNamespace bit-for-bit
- * (cursor = last returned key, list_complete reflects remaining keys) so the
- * vendored storage.ts pagination comments stay true.
+ * IndexDO pagination-contract tests: cursor = last returned key and
+ * list_complete reflects remaining keys. Pages also carry stored values so
+ * run listing does not need one follow-up RPC per key.
  */
 import { beforeEach, describe, expect, it } from 'vitest';
 import { IndexDO } from '../src/worker/durable-objects/IndexDO.js';
@@ -31,7 +31,11 @@ describe('IndexDO', () => {
     await index.put('hook:t1', 'x');
 
     const all = await index.list({ prefix: 'run:' });
-    expect(all.keys.map((k) => k.name)).toEqual(['run:a:1', 'run:a:2', 'run:b:1']);
+    expect(all.keys).toEqual([
+      { name: 'run:a:1', value: 'x' },
+      { name: 'run:a:2', value: 'x' },
+      { name: 'run:b:1', value: 'x' },
+    ]);
     expect(all.list_complete).toBe(true);
     expect(all.cursor).toBeUndefined();
   });
@@ -42,16 +46,22 @@ describe('IndexDO', () => {
     }
 
     const page1 = await index.list({ prefix: 'run:', limit: 2 });
-    expect(page1.keys.map((k) => k.name)).toEqual(['run:wf:1', 'run:wf:2']);
+    expect(page1.keys).toEqual([
+      { name: 'run:wf:1', value: '1' },
+      { name: 'run:wf:2', value: '2' },
+    ]);
     expect(page1.list_complete).toBe(false);
     expect(page1.cursor).toBe('run:wf:2');
 
     const page2 = await index.list({ prefix: 'run:', limit: 2, cursor: page1.cursor });
-    expect(page2.keys.map((k) => k.name)).toEqual(['run:wf:3', 'run:wf:4']);
+    expect(page2.keys).toEqual([
+      { name: 'run:wf:3', value: '3' },
+      { name: 'run:wf:4', value: '4' },
+    ]);
     expect(page2.list_complete).toBe(false);
 
     const page3 = await index.list({ prefix: 'run:', limit: 2, cursor: page2.cursor });
-    expect(page3.keys.map((k) => k.name)).toEqual(['run:wf:5']);
+    expect(page3.keys).toEqual([{ name: 'run:wf:5', value: '5' }]);
     expect(page3.list_complete).toBe(true);
     expect(page3.cursor).toBeUndefined();
   });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -193,6 +193,159 @@ describe('full stack: vendored storage over the wire', () => {
     expect(listed.data.some((r) => r.runId === runId)).toBe(true);
   });
 
+  it('lists runs with N+1 public RPCs, bounded run fanout, and value-bearing index pages', async () => {
+    let publicRpcs = 0;
+    let activeRunReads = 0;
+    let maxActiveRunReads = 0;
+    const paths = new Map<string, number>();
+    const countedFetch: typeof fetch = async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      publicRpcs++;
+      paths.set(url.pathname, (paths.get(url.pathname) ?? 0) + 1);
+
+      const isRunRead = url.pathname.endsWith('/getRun');
+      if (isRunRead) {
+        activeRunReads++;
+        maxActiveRunReads = Math.max(maxActiveRunReads, activeRunReads);
+        // Make overlap deterministic so the assertion distinguishes serial,
+        // bounded, and unbounded implementations.
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      try {
+        return await fetch(input, init);
+      } finally {
+        if (isRunRead) activeRunReads--;
+      }
+    };
+    const env = createRemoteEnv({
+      fleetUrl: harness.url,
+      secret: SECRET,
+      fetchImpl: countedFetch,
+    });
+    const storage = createStorage({
+      env: { WORKFLOW_DB: env.WORKFLOW_DB, WORKFLOW_INDEX: env.WORKFLOW_INDEX },
+      deploymentId: 'wire-test',
+    });
+    const runIds: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      const created = await storage.events.create(null, {
+        eventType: 'run_created',
+        eventData: {
+          deploymentId: 'wire-test',
+          workflowName: 'wire-list-fanout',
+          input: [i],
+        },
+      });
+      runIds.push(created.run.runId);
+    }
+
+    let indexLists = 0;
+    let indexGets = 0;
+    let runStorageGets = 0;
+    const restorers: Array<() => void> = [];
+    const indexStorage = harness.fleet.cell('index', 'index').storage;
+    const originalIndexList = indexStorage.list.bind(indexStorage);
+    const originalIndexGet = indexStorage.get.bind(indexStorage);
+    indexStorage.list = async <T>(options) => {
+      indexLists++;
+      return originalIndexList<T>(options);
+    };
+    indexStorage.get = async <T>(key: string) => {
+      indexGets++;
+      return originalIndexGet<T>(key);
+    };
+    restorers.push(() => {
+      indexStorage.list = originalIndexList;
+      indexStorage.get = originalIndexGet;
+    });
+    for (const runId of runIds) {
+      const runStorage = harness.fleet.cell('runs', runId).storage;
+      const originalGet = runStorage.get.bind(runStorage);
+      runStorage.get = async <T>(key: string) => {
+        runStorageGets++;
+        return originalGet<T>(key);
+      };
+      restorers.push(() => {
+        runStorage.get = originalGet;
+      });
+    }
+
+    try {
+      // Reproduce the legacy 2N+1 protocol against the same cells so the
+      // before/after counts include identical router and storage layers.
+      publicRpcs = 0;
+      paths.clear();
+      const legacyPage = await env.WORKFLOW_INDEX.list({
+        prefix: 'run:wire-list-fanout:',
+        limit: 50,
+      });
+      for (const key of legacyPage.keys) {
+        const raw = await env.WORKFLOW_INDEX.get(key.name);
+        if (!raw) continue;
+        const { runId } = JSON.parse(raw) as { runId: string };
+        await env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName(runId)).getRun();
+      }
+      expect(publicRpcs).toBe(41);
+      expect(maxActiveRunReads).toBe(1);
+      expect(indexLists).toBe(1);
+      expect(indexGets).toBe(20);
+      expect(runStorageGets).toBe(60);
+
+      publicRpcs = 0;
+      maxActiveRunReads = 0;
+      paths.clear();
+      indexLists = 0;
+      indexGets = 0;
+      runStorageGets = 0;
+      const listed = await storage.runs.list({
+        workflowName: 'wire-list-fanout',
+        pagination: { limit: 20 },
+      });
+
+      expect(listed.data).toHaveLength(20);
+      expect(publicRpcs).toBe(21);
+      expect(paths.get('/v1/rpc/index/index/list')).toBe(1);
+      expect(paths.get('/v1/rpc/index/index/get')).toBeUndefined();
+      expect(Array.from(paths.entries()).filter(([path]) => path.endsWith('/getRun'))).toHaveLength(
+        20,
+      );
+      expect(maxActiveRunReads).toBe(8);
+      expect(indexLists).toBe(1);
+      expect(indexGets).toBe(0);
+      expect(runStorageGets).toBe(60);
+
+      await Promise.all(
+        runIds.map((runId) =>
+          storage.events.create(runId, {
+            eventType: 'run_completed',
+            eventData: { output: [] },
+          }),
+        ),
+      );
+      publicRpcs = 0;
+      maxActiveRunReads = 0;
+      paths.clear();
+      indexLists = 0;
+      indexGets = 0;
+      runStorageGets = 0;
+
+      const pending = await storage.runs.list({
+        workflowName: 'wire-list-fanout',
+        status: 'pending',
+        pagination: { limit: 20 },
+      });
+      expect(pending.data).toEqual([]);
+      expect(publicRpcs).toBe(1);
+      expect(paths.get('/v1/rpc/index/index/list')).toBe(1);
+      expect(maxActiveRunReads).toBe(0);
+      expect(indexLists).toBe(1);
+      expect(indexGets).toBe(0);
+      expect(runStorageGets).toBe(0);
+    } finally {
+      for (const restore of restorers) restore();
+    }
+  });
+
   it('reconstructs typed errors across the wire', async () => {
     const env = transport();
     const storage = createStorage({

--- a/test/storage-regressions.test.ts
+++ b/test/storage-regressions.test.ts
@@ -226,6 +226,29 @@ describe('Storage regressions', () => {
     expect(result.cursor).toBeNull();
   });
 
+  it('does not let earlier non-terminal index metadata hide a later run status', async () => {
+    const completed = await createRun('stale-status-index');
+    await storage.events.create(completed.runId, {
+      eventType: 'run_completed',
+      eventData: { output: [] },
+    });
+
+    const entries = await mockEnv.WORKFLOW_INDEX.list({ prefix: 'run:stale-status-index:' });
+    const entry = entries.keys[0];
+    const metadata = JSON.parse(entry.value);
+    await mockEnv.WORKFLOW_INDEX.put(
+      entry.name,
+      JSON.stringify({ ...metadata, status: 'pending' }),
+    );
+
+    const result = await storage.runs.list({
+      workflowName: 'stale-status-index',
+      status: 'completed',
+    });
+
+    expect(result.data.map((run) => run.runId)).toEqual([completed.runId]);
+  });
+
   it('orders steps by creation time instead of step id', async () => {
     const run = await createRun('step-sort-order');
     await storage.events.create(run.runId, {


### PR DESCRIPTION
## Summary

- return stored index values from `IndexDO.list()` so `runs.list()` avoids one follow-up index RPC per run
- conservatively prefilter monotonic run statuses while preserving authoritative RunDO verification
- fetch RunDOs in ordered batches with concurrency bounded at eight
- retain a bounded compatibility fallback for KV-like custom index adapters that do not return values
- add pagination, stale-status correctness, public RPC fanout, concurrency, and internal storage-operation coverage

## Why

The public `runs.list` path performed a serial `2N + 1` fleet protocol for `N` runs: one index list, `N` index gets, and `N` WorkflowRunDO gets. A default 20-run page therefore made 41 public RPCs and serialized every per-run read.

## Impact

For a 20-run exhausted page measured through the real HTTP router and DO classes:

| Measurement | Before | After |
| --- | ---: | ---: |
| Public fleet RPCs | 41 | 21 |
| Index storage operations | 1 list + 20 gets | 1 list |
| RunDO storage gets | 60 | 60 |
| Total internal storage API operations | 81 | 61 |
| Maximum concurrent RunDO reads | 1 | 8 bounded |

A terminal-status prefilter miss now completes with one public RPC, one internal index-list operation, and no RunDO reads. These are deterministic call-count measurements, not latency benchmarks.

## Validation

- `pnpm exec vitest run test/router.test.ts test/index-do.test.ts test/storage-regressions.test.ts` — 28 passed
- `pnpm check` — formatting, type-aware lint, typecheck, build, 204 tests, worker bundle validation, and package validation passed
- `pnpm test:integration` — 1 passed, 10 real-fleet tests skipped because fleet credentials were not configured
- `git diff --check`
