### PR TITLE
perf: remove unused correlation index

### DIFF
--- a/src/retention.ts
+++ b/src/retention.ts
@@ -2,6 +2,7 @@ import type { TerminalWorkflowRunStatus, WorkflowRun } from '@workflow/world';
 
 export const CLEANUP_RECORD_KEY = 'retention:cleanup';
 export const TOMBSTONE_KEY = 'retention:tombstone';
+/** Legacy correlation-index markers retained for upgrade cleanup compatibility. */
 export const INDEX_MARKER_PREFIX = 'retention:index:';
 export const HOOK_MARKER_PREFIX = 'retention:hook:';
 
@@ -85,19 +86,6 @@ export function workflowRunIndexKey(
 
 export function globalRunIndexKey(run: Pick<WorkflowRun, 'createdAt' | 'runId'>) {
   return `runall:${sortableTimestamp(run.createdAt)}:${run.runId}`;
-}
-
-export function correlationIndexKey(
-  correlationId: string,
-  createdAt: Date,
-  eventId: string,
-  runId: string,
-): string {
-  return `correlation:${encodeURIComponent(correlationId)}:${sortableTimestamp(createdAt)}:${eventId}:${runId}`;
-}
-
-export function indexMarkerKey(indexKey: string): string {
-  return `${INDEX_MARKER_PREFIX}${encodeURIComponent(indexKey)}`;
 }
 
 export function hookMarkerKey(reference: HookIndexReference): string {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -43,12 +43,7 @@ import { monotonicFactory } from 'ulid';
 import type { ApplyEventFailure, ApplyEventOutcome, ApplyEventRequest } from './apply-event.js';
 import type { HookTokenOwner, IndexNamespace } from './config.js';
 import { compact } from './util.js';
-import {
-  correlationIndexKey,
-  globalRunIndexKey,
-  type RunReadOutcome,
-  workflowRunIndexKey,
-} from './retention.js';
+import { globalRunIndexKey, type RunReadOutcome, workflowRunIndexKey } from './retention.js';
 
 /**
  * RPC surface of WorkflowRunDO used by the storage layer. Declared
@@ -419,19 +414,6 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
             runId: effectiveRunId,
             hookId: released.hookId,
           });
-        }
-        if (outcome.event?.correlationId) {
-          const correlationKey = correlationIndexKey(
-            outcome.event.correlationId,
-            outcome.event.createdAt,
-            outcome.event.eventId,
-            effectiveRunId,
-          );
-          await env.WORKFLOW_INDEX.putOwned(
-            effectiveRunId,
-            correlationKey,
-            JSON.stringify({ runId: effectiveRunId, eventId: outcome.event.eventId }),
-          );
         }
 
         const eventPage =

--- a/src/worker/durable-objects/WorkflowRunDO.ts
+++ b/src/worker/durable-objects/WorkflowRunDO.ts
@@ -19,7 +19,6 @@ import {
   CLEANUP_RECORD_KEY,
   type CleanupRecord,
   cleanupTombstone,
-  correlationIndexKey,
   type ExpireQueueRunResult,
   type ExpireRunIndexesRequest,
   type ExpireRunIndexesResult,
@@ -31,7 +30,6 @@ import {
   type HookIndexReference,
   hookMarkerKey,
   INDEX_MARKER_PREFIX,
-  indexMarkerKey,
   type RunReadOutcome,
   type RunTombstone,
   type ScheduleCleanupRequest,
@@ -149,15 +147,6 @@ export class WorkflowRunDO extends DurableObject {
       if (!outcome.ok) return outcome;
 
       await txn.put('event_sequence', eventSequence);
-      if (outcome.event?.correlationId) {
-        const key = correlationIndexKey(
-          outcome.event.correlationId,
-          outcome.event.createdAt,
-          outcome.event.eventId,
-          request.runId,
-        );
-        await txn.put(indexMarkerKey(key), key);
-      }
       if (outcome.hookToIndex) {
         const reference = {
           hookId: outcome.hookToIndex.hookId,
@@ -401,6 +390,9 @@ export class WorkflowRunDO extends DurableObject {
       }
 
       if (cleanup.phase === 'index') {
+        // Older deployments wrote correlation-index keys plus per-run markers.
+        // New events no longer create either, but keep consuming old markers so
+        // retention still removes already-persisted global keys.
         const [indexMarkers, hookMarkers] = await Promise.all([
           this.ctx.storage.list<string>({ prefix: INDEX_MARKER_PREFIX }),
           this.ctx.storage.list<HookIndexReference>({ prefix: HOOK_MARKER_PREFIX }),

--- a/test/retention.test.ts
+++ b/test/retention.test.ts
@@ -1,6 +1,7 @@
 import { HookNotFoundError, RunExpiredError } from '@workflow/errors';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createCelldWorld } from '../src/index.js';
+import { INDEX_MARKER_PREFIX } from '../src/retention.js';
 import { startHarness, type Harness } from '../src/testing/http-harness.js';
 import type { IndexDO } from '../src/worker/durable-objects/IndexDO.js';
 import type { QueueDO } from '../src/worker/durable-objects/QueueDO.js';
@@ -78,6 +79,18 @@ describe('terminal workflow retention', () => {
       { runId },
       { delaySeconds: 3_600, idempotencyKey: `wake:${runId}` },
     );
+    // Simulate an index and marker written by an older deployment. New
+    // correlated events create neither, but retention must still clean old
+    // persisted state after an in-place upgrade.
+    const legacyCorrelationKey = `correlation:legacy:1:evnt_legacy:${runId}`;
+    const index = harness.fleet.namespace('index').get({ toString: () => 'index' }) as IndexDO;
+    await index.putOwned(runId, legacyCorrelationKey, JSON.stringify({ runId }));
+    await harness.fleet
+      .cell('runs', runId)
+      .storage.put(
+        `${INDEX_MARKER_PREFIX}${encodeURIComponent(legacyCorrelationKey)}`,
+        legacyCorrelationKey,
+      );
     await finishRun(world, runId);
 
     const retained = await world.runs.get(runId);
@@ -106,6 +119,7 @@ describe('terminal workflow retention', () => {
     await expect(world.hooks.getByToken('retention-token')).rejects.toSatisfy((error) =>
       HookNotFoundError.is(error),
     );
+    expect(await index.get(legacyCorrelationKey)).toBeNull();
 
     const listed = await world.runs.list({ workflowName: 'retention-complete' });
     expect(listed.data).toEqual([]);

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -193,6 +193,89 @@ describe('full stack: vendored storage over the wire', () => {
     expect(listed.data.some((r) => r.runId === runId)).toBe(true);
   });
 
+  it('creates a correlated event with one public RPC and no unused index mutations', async () => {
+    let publicRpcs = 0;
+    const paths = new Map<string, number>();
+    const countedFetch: typeof fetch = async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      publicRpcs++;
+      paths.set(url.pathname, (paths.get(url.pathname) ?? 0) + 1);
+      return fetch(input, init);
+    };
+    const env = createRemoteEnv({
+      fleetUrl: harness.url,
+      secret: SECRET,
+      fetchImpl: countedFetch,
+    });
+    const storage = createStorage({
+      env: { WORKFLOW_DB: env.WORKFLOW_DB, WORKFLOW_INDEX: env.WORKFLOW_INDEX },
+      deploymentId: 'wire-test',
+    });
+    const created = await storage.events.create(null, {
+      eventType: 'run_created',
+      eventData: {
+        deploymentId: 'wire-test',
+        workflowName: 'wire-correlation-fanout',
+        input: [],
+      },
+    });
+
+    publicRpcs = 0;
+    paths.clear();
+    const runStorage = harness.fleet.cell('runs', created.run.runId).storage;
+    const indexStorage = harness.fleet.cell('index', 'index').storage;
+    const runMutations: string[] = [];
+    const indexMutations: string[] = [];
+    const originalRunMutation = runStorage.maybeFailMutation.bind(runStorage);
+    const originalIndexMutation = indexStorage.maybeFailMutation.bind(indexStorage);
+    runStorage.maybeFailMutation = (mutation) => {
+      runMutations.push(`${mutation.operation}:${mutation.key}`);
+      originalRunMutation(mutation);
+    };
+    indexStorage.maybeFailMutation = (mutation) => {
+      indexMutations.push(`${mutation.operation}:${mutation.key}`);
+      originalIndexMutation(mutation);
+    };
+
+    try {
+      await storage.events.create(created.run.runId, {
+        eventType: 'step_created',
+        correlationId: 'wire-step',
+        eventData: { stepName: 'wire-step', input: [] },
+      });
+    } finally {
+      runStorage.maybeFailMutation = originalRunMutation;
+      indexStorage.maybeFailMutation = originalIndexMutation;
+    }
+
+    expect(publicRpcs).toBe(1);
+    expect(paths).toEqual(new Map([[`/v1/rpc/runs/${created.run.runId}/applyEvent`, 1]]));
+    expect(runMutations).toHaveLength(4);
+    expect(runMutations).not.toContainEqual(expect.stringContaining('retention:index:'));
+    expect(indexMutations).toEqual([]);
+    expect(
+      Array.from(indexStorage.data.keys()).filter(
+        (key) => key.startsWith('correlation:') && key.endsWith(`:${created.run.runId}`),
+      ),
+    ).toEqual([]);
+
+    publicRpcs = 0;
+    paths.clear();
+    const correlated = await storage.events.listByCorrelationId({
+      runId: created.run.runId,
+      correlationId: 'wire-step',
+      pagination: { sortOrder: 'asc' },
+    });
+    expect(correlated.data).toHaveLength(1);
+    expect(correlated.data[0]).toMatchObject({
+      runId: created.run.runId,
+      correlationId: 'wire-step',
+      eventType: 'step_created',
+    });
+    expect(publicRpcs).toBe(1);
+    expect(paths).toEqual(new Map([[`/v1/rpc/runs/${created.run.runId}/listEvents`, 1]]));
+  });
+
   it('lists runs with N+1 public RPCs, bounded run fanout, and value-bearing index pages', async () => {
     let publicRpcs = 0;
     let activeRunReads = 0;

--- a/test/storage-regressions.test.ts
+++ b/test/storage-regressions.test.ts
@@ -133,13 +133,22 @@ describe('Storage regressions', () => {
     });
   });
 
-  it('returns events that match listByCorrelationId', async () => {
+  it('returns run-scoped correlated events in event order across pages', async () => {
     const run = await createRun('correlation-index');
     const otherRun = await createRun('correlation-index');
-    await storage.events.create(run.runId, {
+    const created = await storage.events.create(run.runId, {
       eventType: 'step_created',
       correlationId: 'correlation-123',
       eventData: { stepName: 'correlated-step', input: [] },
+    });
+    const started = await storage.events.create(run.runId, {
+      eventType: 'step_started',
+      correlationId: 'correlation-123',
+    });
+    const completed = await storage.events.create(run.runId, {
+      eventType: 'step_completed',
+      correlationId: 'correlation-123',
+      eventData: { result: ['done'] },
     });
     await storage.events.create(otherRun.runId, {
       eventType: 'step_created',
@@ -147,18 +156,35 @@ describe('Storage regressions', () => {
       eventData: { stepName: 'other-run-step', input: [] },
     });
 
-    const result = await storage.events.listByCorrelationId({
+    const first = await storage.events.listByCorrelationId({
       runId: run.runId,
       correlationId: 'correlation-123',
-      pagination: { sortOrder: 'asc' },
+      pagination: { limit: 2, sortOrder: 'asc' },
     });
+    expect(first.data.map((event) => event.eventId)).toEqual([
+      created.event?.eventId,
+      started.event?.eventId,
+    ]);
+    expect(first).toMatchObject({ hasMore: true, cursor: started.event?.eventId });
 
-    expect(result.data).toHaveLength(1);
-    expect(result.data[0]).toMatchObject({
+    const second = await storage.events.listByCorrelationId({
       runId: run.runId,
       correlationId: 'correlation-123',
-      eventType: 'step_created',
+      pagination: { cursor: first.cursor ?? undefined, limit: 2, sortOrder: 'asc' },
     });
+    expect(second.data.map((event) => event.eventId)).toEqual([completed.event?.eventId]);
+    expect(second).toMatchObject({ hasMore: false, cursor: null });
+
+    const descending = await storage.events.listByCorrelationId({
+      runId: run.runId,
+      correlationId: 'correlation-123',
+      pagination: { limit: 3, sortOrder: 'desc' },
+    });
+    expect(descending.data.map((event) => event.eventId)).toEqual([
+      completed.event?.eventId,
+      started.event?.eventId,
+      created.event?.eventId,
+    ]);
   });
 
   it('uses dense Workflow 5 event slots and reports writes skipped by a stale replay', async () => {


### PR DESCRIPTION
## Summary

- stop publishing a global correlation-to-event index for correlated events
- stop writing the corresponding per-run retention marker and remove dead key helpers
- keep `listByCorrelationId` run-scoped on the authoritative event log, including ordering and pagination behavior
- retain legacy marker cleanup so existing correlation-index entries are removed after an in-place upgrade

## Why

Every correlated event paid for an `IndexDO.putOwned` RPC and global durable write, plus a local retention-marker write, but no read path consulted that index. `listByCorrelationId` already scans the requested run's dense event log, which is the correct Workflow 5 ownership boundary.

## Measured impact

Measured through the real HTTP router and real Durable Object classes on the in-process fleet:

| Correlated `step_created` | Before | After |
|---|---:|---:|
| Logical World calls | 1 | 1 |
| Public DO RPCs | 2 | 1 |
| RunDO durable mutations | 5 | 4 |
| IndexDO durable mutations | 1 | 0 |

The read path remains one public `listEvents` RPC and returns the same run-scoped correlated events.

## Validation

- focused router, correlation, retention, index, and Workflow 5 contract tests: 41 passed
- `pnpm check`: formatting, type-aware lint, typecheck, build, 205 tests, worker bundle, and package validation passed
- `git diff --check`
