### PR TITLE
perf: bound QueueDO inflight deadline work

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -219,6 +219,12 @@ function createTestPump(config: CelldQueueConfig) {
     });
 
     if (response.ok) {
+      try {
+        await response.body?.cancel();
+      } catch {
+        // The status already determines the queue outcome. Do not turn an ack
+        // into a retry solely because releasing an unused body failed.
+      }
       release(envelope);
       return;
     }
@@ -405,7 +411,7 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
               { status: 503, headers: { 'Retry-After': String(result.timeoutSeconds) } },
             );
           }
-          return Response.json({ ok: true });
+          return new Response(null, { status: 204 });
         } catch (error) {
           // Permanent vs transient distinction: permanent errors surface as
           // their own status so the sender drops instead of retrying.

--- a/src/testing/fake-cell.ts
+++ b/src/testing/fake-cell.ts
@@ -20,6 +20,12 @@ export interface FakeStorageMutation {
   value?: unknown;
 }
 
+export interface FakeStorageListCall {
+  options: FakeListOptions;
+  resultSize: number;
+  transactional: boolean;
+}
+
 function applyListOptions(keys: string[], options: FakeListOptions): string[] {
   let result = keys.toSorted();
   if (options.prefix !== undefined) {
@@ -55,6 +61,8 @@ function applyListOptions(keys: string[], options: FakeListOptions): string[] {
 export class FakeStorage {
   data = new Map<string, unknown>();
   alarmAt: number | null = null;
+  /** Deterministic query-shape instrumentation for storage scaling tests. */
+  listCalls: FakeStorageListCall[] = [];
   private mutationFailure?: {
     predicate: (mutation: FakeStorageMutation) => boolean;
     error: Error;
@@ -84,6 +92,7 @@ export class FakeStorage {
 
   async list<T>(options: FakeListOptions = {}): Promise<Map<string, T>> {
     const keys = applyListOptions(Array.from(this.data.keys()), options);
+    this.recordList(options, keys.length, false);
     return new Map(keys.map((k) => [k, this.data.get(k) as T]));
   }
 
@@ -125,6 +134,11 @@ export class FakeStorage {
     this.mutationFailure = undefined;
     throw error;
   }
+
+  /** @internal Shared with FakeTransaction for deterministic query tracing. */
+  recordList(options: FakeListOptions, resultSize: number, transactional: boolean): void {
+    this.listCalls.push({ options: { ...options }, resultSize, transactional });
+  }
 }
 
 class FakeTransaction {
@@ -159,6 +173,7 @@ class FakeTransaction {
     for (const key of this.deleted) merged.delete(key);
     for (const [key, value] of this.staged) merged.set(key, value);
     const keys = applyListOptions(Array.from(merged.keys()), options);
+    this.storage.recordList(options, keys.length, true);
     return new Map(keys.map((k) => [k, merged.get(k) as T]));
   }
 

--- a/src/worker/durable-objects/QueueDO.ts
+++ b/src/worker/durable-objects/QueueDO.ts
@@ -16,7 +16,6 @@ import type { ExpireQueueRunResult } from '../../retention.js';
  *   due:<paddedMs>:<messageId>   schedule index -> messageId
  *   inflight-deadline:<paddedMs>:<messageId>
  *                                ordered crash-recovery index -> messageId
- *   inflight:<messageId>         legacy crash-recovery deadline (migrated in batches)
  *   key:<idempotencyKey>         active dedup claim -> messageId
  *   dlq:<paddedMs>:<messageId>   DeadLetterRow
  *   run:<runId>:<messageId>      QueueRunReference for retention cleanup
@@ -93,16 +92,12 @@ const DEFAULT_DELIVERY_TIMEOUT_MS = 300_000;
 const INFLIGHT_GRACE_MS = 30_000;
 /** Move overdue alarms to a new timestamp so celld observes a fresh edge. */
 const MIN_ALARM_DELAY_MS = 1;
-/** Bound deploy-time conversion of the legacy message-id-keyed inflight index. */
-const LEGACY_INFLIGHT_MIGRATION_BATCH = 128;
 /** Bound expiry recovery so one alarm cannot monopolize the cell. */
 const EXPIRED_INFLIGHT_BATCH = 128;
 
-const LEGACY_INFLIGHT_PREFIX = 'inflight:';
 const INFLIGHT_DEADLINE_PREFIX = 'inflight-deadline:';
 
 type AlarmStorage = Pick<DurableObjectStorage, 'list' | 'getAlarm' | 'setAlarm' | 'deleteAlarm'>;
-type InflightMigrationStorage = Pick<DurableObjectStorage, 'list' | 'get' | 'put' | 'delete'>;
 
 function pad(ms: number): string {
   return String(Math.max(0, Math.floor(ms))).padStart(13, '0');
@@ -283,14 +278,6 @@ export class QueueDO extends DurableObject {
     const now = this.#now();
     const maxInflight = this.#intVar('QUEUE_MAX_INFLIGHT', DEFAULT_MAX_INFLIGHT);
     const claimed = await storage.transaction<InflightClaim[]>(async (txn) => {
-      // A rollout can inherit message-id-keyed inflight records. Convert a
-      // bounded page before doing normal work; if more remain, yield through a
-      // fresh alarm edge instead of scanning or migrating the whole set.
-      if (await this.#migrateLegacyInflight(txn)) {
-        await txn.setAlarm(now + MIN_ALARM_DELAY_MS);
-        return [];
-      }
-
       // 1. Recover: an inflight entry past its deadline is a lost delivery
       // (node crash, deploy restart) — back to due for redelivery.
       const expiredPage = await txn.list<string>({
@@ -521,52 +508,12 @@ export class QueueDO extends DurableObject {
     });
   }
 
-  /**
-   * Convert one bounded page of the legacy `inflight:<messageId>` layout.
-   * Returns true when another page remains, so callers can yield to a fresh
-   * alarm rather than monopolizing the cell during a deployment transition.
-   */
-  async #migrateLegacyInflight(storage: InflightMigrationStorage): Promise<boolean> {
-    const page = await storage.list<number>({
-      prefix: LEGACY_INFLIGHT_PREFIX,
-      limit: LEGACY_INFLIGHT_MIGRATION_BATCH + 1,
-    });
-    const entries = Array.from(page.entries()).slice(0, LEGACY_INFLIGHT_MIGRATION_BATCH);
-    for (const [legacyKey, deadline] of entries) {
-      const messageId = legacyKey.slice(LEGACY_INFLIGHT_PREFIX.length);
-      await storage.delete(legacyKey);
-      const row = await storage.get<MessageRow>(`msg:${messageId}`);
-      if (!row) continue;
-
-      const migratedKey = inflightKey(deadline, messageId);
-      await storage.put(migratedKey, messageId);
-      if (row.runId) {
-        await storage.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
-          messageId: row.messageId,
-          inflightKey: migratedKey,
-          idempotencyKey: row.idempotencyKey,
-        });
-      }
-    }
-    return page.size > LEGACY_INFLIGHT_MIGRATION_BATCH;
-  }
-
   /** Arm the alarm no later than `atMs` (durable backoff never throws). */
   async #armAlarmAtMost(storage: AlarmStorage, atMs: number, now: number): Promise<void> {
     const current = await storage.getAlarm();
     if (current !== null && current <= now) {
       await storage.setAlarm(now + MIN_ALARM_DELAY_MS);
       return;
-    }
-
-    // A normally armed legacy claim already has an alarm. If celld abandoned
-    // it, any fresh enqueue/redrive must wake the bounded migration promptly.
-    if (current === null) {
-      const legacy = await storage.list({ prefix: LEGACY_INFLIGHT_PREFIX, limit: 1 });
-      if (legacy.size > 0) {
-        await storage.setAlarm(now + MIN_ALARM_DELAY_MS);
-        return;
-      }
     }
 
     const target = atMs <= now ? now + MIN_ALARM_DELAY_MS : atMs;
@@ -577,14 +524,7 @@ export class QueueDO extends DurableObject {
 
   /** Recompute the alarm from the earliest due entry / inflight deadline. */
   async #rearm(): Promise<void> {
-    const now = this.#now();
-    await this.ctx.storage.transaction(async (txn) => {
-      if (await this.#migrateLegacyInflight(txn)) {
-        await txn.setAlarm(now + MIN_ALARM_DELAY_MS);
-        return;
-      }
-      await this.#scheduleNextAlarm(txn, now);
-    });
+    await this.#scheduleNextAlarm(this.ctx.storage, this.#now());
   }
 
   /** Keep the alarm index consistent with message state in the same transaction. */
@@ -613,16 +553,15 @@ export class QueueDO extends DurableObject {
 
   async stats(): Promise<QueueStats> {
     const storage = this.ctx.storage;
-    const [due, inflight, legacyInflight, dlq, alarmAt] = await Promise.all([
+    const [due, inflight, dlq, alarmAt] = await Promise.all([
       storage.list({ prefix: 'due:' }),
       storage.list({ prefix: INFLIGHT_DEADLINE_PREFIX }),
-      storage.list({ prefix: LEGACY_INFLIGHT_PREFIX }),
       storage.list({ prefix: 'dlq:' }),
       storage.getAlarm(),
     ]);
     return {
       pending: due.size,
-      inflight: inflight.size + legacyInflight.size,
+      inflight: inflight.size,
       deadLetters: dlq.size,
       alarmAt,
     };
@@ -724,9 +663,7 @@ export class QueueDO extends DurableObject {
       let count = existing?.deleted ?? 0;
       for (const [key, reference] of references) {
         await txn.delete(`msg:${reference.messageId}`);
-        await txn.delete(
-          reference.inflightKey ?? `${LEGACY_INFLIGHT_PREFIX}${reference.messageId}`,
-        );
+        if (reference.inflightKey) await txn.delete(reference.inflightKey);
         if (reference.dueKey) await txn.delete(reference.dueKey);
         if (reference.dlqKey) await txn.delete(reference.dlqKey);
         if (reference.idempotencyKey) {

--- a/src/worker/durable-objects/QueueDO.ts
+++ b/src/worker/durable-objects/QueueDO.ts
@@ -14,7 +14,9 @@ import type { ExpireQueueRunResult } from '../../retention.js';
  *   cfg                          pinned QueueCellConfig (first-enqueue wins)
  *   msg:<messageId>              MessageRow
  *   due:<paddedMs>:<messageId>   schedule index -> messageId
- *   inflight:<messageId>         crash-recovery deadline (epoch ms)
+ *   inflight-deadline:<paddedMs>:<messageId>
+ *                                ordered crash-recovery index -> messageId
+ *   inflight:<messageId>         legacy crash-recovery deadline (migrated in batches)
  *   key:<idempotencyKey>         active dedup claim -> messageId
  *   dlq:<paddedMs>:<messageId>   DeadLetterRow
  *   run:<runId>:<messageId>      QueueRunReference for retention cleanup
@@ -66,8 +68,15 @@ export interface QueueStats {
 interface QueueRunReference {
   messageId: string;
   dueKey?: string;
+  inflightKey?: string;
   dlqKey?: string;
   idempotencyKey?: string;
+}
+
+interface InflightClaim {
+  row: MessageRow;
+  /** The exact index key is also the lease token for this delivery attempt. */
+  inflightKey: string;
 }
 
 interface ExpiredRunFence {
@@ -84,8 +93,16 @@ const DEFAULT_DELIVERY_TIMEOUT_MS = 300_000;
 const INFLIGHT_GRACE_MS = 30_000;
 /** Move overdue alarms to a new timestamp so celld observes a fresh edge. */
 const MIN_ALARM_DELAY_MS = 1;
+/** Bound deploy-time conversion of the legacy message-id-keyed inflight index. */
+const LEGACY_INFLIGHT_MIGRATION_BATCH = 128;
+/** Bound expiry recovery so one alarm cannot monopolize the cell. */
+const EXPIRED_INFLIGHT_BATCH = 128;
+
+const LEGACY_INFLIGHT_PREFIX = 'inflight:';
+const INFLIGHT_DEADLINE_PREFIX = 'inflight-deadline:';
 
 type AlarmStorage = Pick<DurableObjectStorage, 'list' | 'getAlarm' | 'setAlarm' | 'deleteAlarm'>;
+type InflightMigrationStorage = Pick<DurableObjectStorage, 'list' | 'get' | 'put' | 'delete'>;
 
 function pad(ms: number): string {
   return String(Math.max(0, Math.floor(ms))).padStart(13, '0');
@@ -93,6 +110,17 @@ function pad(ms: number): string {
 
 function dueKey(atMs: number, messageId: string): string {
   return `due:${pad(atMs)}:${messageId}`;
+}
+
+function inflightKey(deadlineMs: number, messageId: string): string {
+  return `${INFLIGHT_DEADLINE_PREFIX}${pad(deadlineMs)}:${messageId}`;
+}
+
+function deadlineFromInflightKey(key: string): number {
+  return Number.parseInt(
+    key.slice(INFLIGHT_DEADLINE_PREFIX.length, INFLIGHT_DEADLINE_PREFIX.length + 13),
+    10,
+  );
 }
 
 function runReferenceKey(runId: string, messageId: string): string {
@@ -105,6 +133,15 @@ function expiredRunKey(runId: string): string {
 
 function backoffSeconds(attempt: number): number {
   return Math.min(60, 2 ** attempt);
+}
+
+async function cancelUnusedResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // The delivery outcome is already known from the status. A cancellation
+    // failure must not turn an acknowledged callback into a retry.
+  }
 }
 
 interface QueueCellEnv {
@@ -216,7 +253,7 @@ export class QueueDO extends DurableObject {
     // celld#144: alarm handlers can overlap while awaiting. The storage-only
     // claim phase runs under the input gate; a failure is carried out and
     // rethrown outside so a failed critical section cannot reset the cell.
-    let claimed: MessageRow[] = [];
+    let claimed: InflightClaim[] = [];
     let failure: unknown = null;
     const attempt = async () => {
       try {
@@ -232,8 +269,8 @@ export class QueueDO extends DurableObject {
     }
     if (failure !== null) throw failure;
 
-    for (const row of claimed) {
-      this.ctx.waitUntil(this.#deliver(row));
+    for (const claim of claimed) {
+      this.ctx.waitUntil(this.#deliver(claim));
     }
   }
 
@@ -241,38 +278,57 @@ export class QueueDO extends DurableObject {
    * Storage-only: recover lost inflight claims, claim due messages up to the
    * inflight cap, and re-arm the alarm. Never throws for data conditions.
    */
-  async #claimPhase(): Promise<MessageRow[]> {
+  async #claimPhase(): Promise<InflightClaim[]> {
     const storage = this.ctx.storage;
     const now = this.#now();
     const maxInflight = this.#intVar('QUEUE_MAX_INFLIGHT', DEFAULT_MAX_INFLIGHT);
-    const claimed = await storage.transaction<MessageRow[]>(async (txn) => {
-      // 1. Recover: an inflight entry past its deadline is a lost delivery
-      // (node crash, deploy restart) — back to due for redelivery.
-      const inflight = await txn.list<number>({ prefix: 'inflight:' });
-      let inflightCount = 0;
-      for (const [key, deadline] of inflight) {
-        if (deadline <= now) {
-          const messageId = key.slice('inflight:'.length);
-          await txn.delete(key);
-          const row = await txn.get<MessageRow>(`msg:${messageId}`);
-          if (row) {
-            const scheduleKey = dueKey(now, messageId);
-            await txn.put(scheduleKey, messageId);
-            if (row.runId) {
-              await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
-                messageId: row.messageId,
-                dueKey: scheduleKey,
-                idempotencyKey: row.idempotencyKey,
-              });
-            }
-          }
-        } else {
-          inflightCount++;
-        }
+    const claimed = await storage.transaction<InflightClaim[]>(async (txn) => {
+      // A rollout can inherit message-id-keyed inflight records. Convert a
+      // bounded page before doing normal work; if more remain, yield through a
+      // fresh alarm edge instead of scanning or migrating the whole set.
+      if (await this.#migrateLegacyInflight(txn)) {
+        await txn.setAlarm(now + MIN_ALARM_DELAY_MS);
+        return [];
       }
 
+      // 1. Recover: an inflight entry past its deadline is a lost delivery
+      // (node crash, deploy restart) — back to due for redelivery.
+      const expiredPage = await txn.list<string>({
+        prefix: INFLIGHT_DEADLINE_PREFIX,
+        end: `${INFLIGHT_DEADLINE_PREFIX}${pad(now + 1)}`,
+        limit: EXPIRED_INFLIGHT_BATCH + 1,
+      });
+      const expired = Array.from(expiredPage.entries()).slice(0, EXPIRED_INFLIGHT_BATCH);
+      for (const [key, messageId] of expired) {
+        await txn.delete(key);
+        const row = await txn.get<MessageRow>(`msg:${messageId}`);
+        if (row) {
+          const scheduleKey = dueKey(now, messageId);
+          await txn.put(scheduleKey, messageId);
+          if (row.runId) {
+            await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+              messageId: row.messageId,
+              dueKey: scheduleKey,
+              idempotencyKey: row.idempotencyKey,
+            });
+          }
+        }
+      }
+      if (expiredPage.size > EXPIRED_INFLIGHT_BATCH) {
+        await txn.setAlarm(now + MIN_ALARM_DELAY_MS);
+        return [];
+      }
+
+      // Only the configured concurrency cap matters here. Reading at most the
+      // cap avoids replacing the expiry scan with an unbounded count scan.
+      const activeInflight = await txn.list<string>({
+        prefix: INFLIGHT_DEADLINE_PREFIX,
+        limit: maxInflight,
+      });
+      const inflightCount = activeInflight.size;
+
       // 2. Claim due messages up to the cap.
-      const rows: MessageRow[] = [];
+      const rows: InflightClaim[] = [];
       if (inflightCount < maxInflight) {
         const due = await txn.list<string>({
           prefix: 'due:',
@@ -284,8 +340,16 @@ export class QueueDO extends DurableObject {
           await txn.delete(key);
           const row = await txn.get<MessageRow>(`msg:${messageId}`);
           if (!row) continue; // orphaned schedule entry
-          await txn.put(`inflight:${messageId}`, now + timeoutMs + INFLIGHT_GRACE_MS);
-          rows.push(row);
+          const claimKey = inflightKey(now + timeoutMs + INFLIGHT_GRACE_MS, messageId);
+          await txn.put(claimKey, messageId);
+          if (row.runId) {
+            await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+              messageId: row.messageId,
+              inflightKey: claimKey,
+              idempotencyKey: row.idempotencyKey,
+            });
+          }
+          rows.push({ row, inflightKey: claimKey });
         }
       }
       await this.#scheduleNextAlarm(txn, now);
@@ -295,7 +359,7 @@ export class QueueDO extends DurableObject {
     return claimed;
   }
 
-  async #deliver(row: MessageRow): Promise<void> {
+  async #deliver({ row, inflightKey: claimKey }: InflightClaim): Promise<void> {
     const storage = this.ctx.storage;
     const timeoutMs = this.#intVar('QUEUE_DELIVERY_TIMEOUT_MS', DEFAULT_DELIVERY_TIMEOUT_MS);
     const callbackSecret = (this.env as QueueCellEnv)?.WORKFLOW_CALLBACK_SECRET;
@@ -324,7 +388,8 @@ export class QueueDO extends DurableObject {
 
     if (response?.ok) {
       // Ack: the message is done; release the dedup claim.
-      await this.#ack(row);
+      await cancelUnusedResponseBody(response);
+      await this.#ack(row, claimKey);
     } else if (response && response.status === 503) {
       // {timeoutSeconds} means "redeliver later, same message": the attempt
       // count does not advance and the dedup key stays claimed.
@@ -337,9 +402,11 @@ export class QueueDO extends DurableObject {
       }
       if (typeof timeoutSeconds === 'number') {
         await storage.transaction(async (txn) => {
+          // Deleting the exact deadline key doubles as a lease-token check. A
+          // late response from an expired claim must not mutate a newer claim.
+          if (!(await txn.delete(claimKey))) return;
           if (row.runId && (await txn.get(expiredRunKey(row.runId))) !== undefined) {
             await txn.delete(`msg:${row.messageId}`);
-            await txn.delete(`inflight:${row.messageId}`);
             await txn.delete(runReferenceKey(row.runId, row.messageId));
             if (row.idempotencyKey) {
               const dedupKey = `key:${row.idempotencyKey}`;
@@ -350,7 +417,6 @@ export class QueueDO extends DurableObject {
             await this.#scheduleNextAlarm(txn, now);
             return;
           }
-          await txn.delete(`inflight:${row.messageId}`);
           const scheduleKey = dueKey(now + timeoutSeconds * 1000, row.messageId);
           await txn.put(scheduleKey, row.messageId);
           if (row.runId) {
@@ -363,25 +429,27 @@ export class QueueDO extends DurableObject {
           await this.#scheduleNextAlarm(txn, now);
         });
       } else {
-        await this.#retry(row, 'HTTP 503');
+        await this.#retry(row, claimKey, 'HTTP 503');
       }
     } else if (response && PERMANENT_STATUSES.has(response.status)) {
       // Permanent: drop without burning retries; the handler already
       // classified this as unreplayable.
-      await this.#ack(row);
+      await cancelUnusedResponseBody(response);
+      await this.#ack(row, claimKey);
     } else {
       const reason = response
         ? `HTTP ${response.status}`
         : `transport error: ${String(transportError)}`;
-      await this.#retry(row, reason);
+      if (response) await cancelUnusedResponseBody(response);
+      await this.#retry(row, claimKey, reason);
     }
   }
 
-  async #ack(row: MessageRow): Promise<void> {
+  async #ack(row: MessageRow, claimKey: string): Promise<void> {
     const storage = this.ctx.storage;
     await storage.transaction(async (txn) => {
+      if (!(await txn.delete(claimKey))) return;
       await txn.delete(`msg:${row.messageId}`);
-      await txn.delete(`inflight:${row.messageId}`);
       if (row.idempotencyKey) {
         const holder = await txn.get<string>(`key:${row.idempotencyKey}`);
         if (holder === row.messageId) {
@@ -395,16 +463,16 @@ export class QueueDO extends DurableObject {
     });
   }
 
-  async #retry(row: MessageRow, reason: string): Promise<void> {
+  async #retry(row: MessageRow, claimKey: string, reason: string): Promise<void> {
     const storage = this.ctx.storage;
     const now = this.#now();
     const maxAttempts = this.#intVar('QUEUE_MAX_ATTEMPTS', DEFAULT_MAX_ATTEMPTS);
     const attempt = row.attempt + 1;
 
     await storage.transaction(async (txn) => {
+      if (!(await txn.delete(claimKey))) return;
       if (row.runId && (await txn.get(expiredRunKey(row.runId))) !== undefined) {
         await txn.delete(`msg:${row.messageId}`);
-        await txn.delete(`inflight:${row.messageId}`);
         await txn.delete(runReferenceKey(row.runId, row.messageId));
         if (row.idempotencyKey) {
           const dedupKey = `key:${row.idempotencyKey}`;
@@ -415,7 +483,6 @@ export class QueueDO extends DurableObject {
         await this.#scheduleNextAlarm(txn, now);
         return;
       }
-      await txn.delete(`inflight:${row.messageId}`);
 
       if (attempt >= maxAttempts) {
         const dead: DeadLetterRow = { ...row, attempt, lastError: reason, failedAt: now };
@@ -454,12 +521,52 @@ export class QueueDO extends DurableObject {
     });
   }
 
+  /**
+   * Convert one bounded page of the legacy `inflight:<messageId>` layout.
+   * Returns true when another page remains, so callers can yield to a fresh
+   * alarm rather than monopolizing the cell during a deployment transition.
+   */
+  async #migrateLegacyInflight(storage: InflightMigrationStorage): Promise<boolean> {
+    const page = await storage.list<number>({
+      prefix: LEGACY_INFLIGHT_PREFIX,
+      limit: LEGACY_INFLIGHT_MIGRATION_BATCH + 1,
+    });
+    const entries = Array.from(page.entries()).slice(0, LEGACY_INFLIGHT_MIGRATION_BATCH);
+    for (const [legacyKey, deadline] of entries) {
+      const messageId = legacyKey.slice(LEGACY_INFLIGHT_PREFIX.length);
+      await storage.delete(legacyKey);
+      const row = await storage.get<MessageRow>(`msg:${messageId}`);
+      if (!row) continue;
+
+      const migratedKey = inflightKey(deadline, messageId);
+      await storage.put(migratedKey, messageId);
+      if (row.runId) {
+        await storage.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+          messageId: row.messageId,
+          inflightKey: migratedKey,
+          idempotencyKey: row.idempotencyKey,
+        });
+      }
+    }
+    return page.size > LEGACY_INFLIGHT_MIGRATION_BATCH;
+  }
+
   /** Arm the alarm no later than `atMs` (durable backoff never throws). */
   async #armAlarmAtMost(storage: AlarmStorage, atMs: number, now: number): Promise<void> {
     const current = await storage.getAlarm();
     if (current !== null && current <= now) {
       await storage.setAlarm(now + MIN_ALARM_DELAY_MS);
       return;
+    }
+
+    // A normally armed legacy claim already has an alarm. If celld abandoned
+    // it, any fresh enqueue/redrive must wake the bounded migration promptly.
+    if (current === null) {
+      const legacy = await storage.list({ prefix: LEGACY_INFLIGHT_PREFIX, limit: 1 });
+      if (legacy.size > 0) {
+        await storage.setAlarm(now + MIN_ALARM_DELAY_MS);
+        return;
+      }
     }
 
     const target = atMs <= now ? now + MIN_ALARM_DELAY_MS : atMs;
@@ -470,7 +577,14 @@ export class QueueDO extends DurableObject {
 
   /** Recompute the alarm from the earliest due entry / inflight deadline. */
   async #rearm(): Promise<void> {
-    await this.#scheduleNextAlarm(this.ctx.storage, this.#now());
+    const now = this.#now();
+    await this.ctx.storage.transaction(async (txn) => {
+      if (await this.#migrateLegacyInflight(txn)) {
+        await txn.setAlarm(now + MIN_ALARM_DELAY_MS);
+        return;
+      }
+      await this.#scheduleNextAlarm(txn, now);
+    });
   }
 
   /** Keep the alarm index consistent with message state in the same transaction. */
@@ -482,8 +596,9 @@ export class QueueDO extends DurableObject {
       next = Number.parseInt(key.slice('due:'.length, 'due:'.length + 13), 10);
     }
 
-    const inflight = await storage.list<number>({ prefix: 'inflight:' });
-    for (const deadline of inflight.values()) {
+    const inflight = await storage.list<string>({ prefix: INFLIGHT_DEADLINE_PREFIX, limit: 1 });
+    for (const key of inflight.keys()) {
+      const deadline = deadlineFromInflightKey(key);
       if (next === null || deadline < next) next = deadline;
     }
 
@@ -498,15 +613,16 @@ export class QueueDO extends DurableObject {
 
   async stats(): Promise<QueueStats> {
     const storage = this.ctx.storage;
-    const [due, inflight, dlq, alarmAt] = await Promise.all([
+    const [due, inflight, legacyInflight, dlq, alarmAt] = await Promise.all([
       storage.list({ prefix: 'due:' }),
-      storage.list({ prefix: 'inflight:' }),
+      storage.list({ prefix: INFLIGHT_DEADLINE_PREFIX }),
+      storage.list({ prefix: LEGACY_INFLIGHT_PREFIX }),
       storage.list({ prefix: 'dlq:' }),
       storage.getAlarm(),
     ]);
     return {
       pending: due.size,
-      inflight: inflight.size,
+      inflight: inflight.size + legacyInflight.size,
       deadLetters: dlq.size,
       alarmAt,
     };
@@ -608,7 +724,9 @@ export class QueueDO extends DurableObject {
       let count = existing?.deleted ?? 0;
       for (const [key, reference] of references) {
         await txn.delete(`msg:${reference.messageId}`);
-        await txn.delete(`inflight:${reference.messageId}`);
+        await txn.delete(
+          reference.inflightKey ?? `${LEGACY_INFLIGHT_PREFIX}${reference.messageId}`,
+        );
         if (reference.dueKey) await txn.delete(reference.dueKey);
         if (reference.dlqKey) await txn.delete(reference.dlqKey);
         if (reference.idempotencyKey) {

--- a/test/queue-do.test.ts
+++ b/test/queue-do.test.ts
@@ -377,63 +377,12 @@ describe('QueueDO', () => {
     for (const key of Array.from(data.keys())) {
       if (key.startsWith('due:')) data.delete(key);
     }
-    data.set('inflight:msg_k', fleet.now - 1);
+    data.set(`${INFLIGHT_DEADLINE_PREFIX}${padded(fleet.now - 1)}:msg_k`, 'msg_k');
     fleet.cell('queue', 'q:0').storage.alarmAt = fleet.now;
 
     await tick(); // sweep moves it back to due
     await tick(); // next alarm delivers it
     expect(fetchStub).toHaveBeenCalledOnce();
-  });
-
-  it('migrates legacy inflight state without changing its deadline', async () => {
-    await queue.enqueue(enqueueReq({ messageId: 'msg_legacy', delaySeconds: 60 }));
-    const data = storage();
-    for (const key of Array.from(data.keys())) {
-      if (key.startsWith('due:')) data.delete(key);
-    }
-    const deadline = fleet.now + 30_000;
-    data.set('inflight:msg_legacy', deadline);
-    fleet.cell('queue', 'q:0').storage.alarmAt = null;
-
-    expect(await queue.rearmAlarm()).toEqual({ alarmAt: deadline });
-    expect(data.has('inflight:msg_legacy')).toBe(false);
-    expect(data.get(`${INFLIGHT_DEADLINE_PREFIX}${padded(deadline)}:msg_legacy`)).toBe(
-      'msg_legacy',
-    );
-
-    await tick(30_001);
-    expect(fetchStub).toHaveBeenCalledOnce();
-    expect(await queue.stats()).toMatchObject({ pending: 0, inflight: 0 });
-  });
-
-  it('migrates large legacy inflight state across bounded alarm batches', async () => {
-    const data = storage();
-    const deadline = fleet.now + 60_000;
-    for (let index = 0; index < 130; index++) {
-      const messageId = `msg_legacy_${String(index).padStart(3, '0')}`;
-      data.set(`msg:${messageId}`, storedMessage(messageId, fleet.now));
-      data.set(`inflight:${messageId}`, deadline);
-    }
-    fleet.cell('queue', 'q:0').storage.alarmAt = fleet.now;
-
-    await tick();
-    expect(
-      Array.from(data.keys()).filter(
-        (key) => key.startsWith('inflight:') && !key.startsWith(INFLIGHT_DEADLINE_PREFIX),
-      ),
-    ).toHaveLength(2);
-    expect(
-      Array.from(data.keys()).filter((key) => key.startsWith(INFLIGHT_DEADLINE_PREFIX)),
-    ).toHaveLength(128);
-    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(fleet.now + 1);
-
-    await tick();
-    expect(Array.from(data.keys()).filter((key) => key.startsWith('inflight:'))).toHaveLength(0);
-    expect(
-      Array.from(data.keys()).filter((key) => key.startsWith(INFLIGHT_DEADLINE_PREFIX)),
-    ).toHaveLength(130);
-    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(deadline);
-    expect(fetchStub).not.toHaveBeenCalled();
   });
 
   it('uses the exact inflight key as a lease token against late callback completion', async () => {
@@ -674,7 +623,13 @@ describe('QueueDO', () => {
       if (key.startsWith('due:') && key.endsWith(':msg_inflight')) data.delete(key);
       if (key.startsWith('due:') && key.endsWith(':msg_dead')) data.delete(key);
     }
-    data.set('inflight:msg_inflight', fleet.now + 30_000);
+    const inflightKey = `${INFLIGHT_DEADLINE_PREFIX}${padded(fleet.now + 30_000)}:msg_inflight`;
+    data.set(inflightKey, 'msg_inflight');
+    data.set(`run:${runId}:msg_inflight`, {
+      messageId: 'msg_inflight',
+      inflightKey,
+      idempotencyKey: 'inflight-key',
+    });
     const dead = data.get('msg:msg_dead') as MessageRow;
     data.delete('msg:msg_dead');
     const deadKey = `dlq:${String(fleet.now).padStart(13, '0')}:msg_dead`;

--- a/test/queue-do.test.ts
+++ b/test/queue-do.test.ts
@@ -23,6 +23,23 @@ const enqueueReq = (over: Partial<EnqueueRequest> = {}): EnqueueRequest => ({
 });
 
 const MIN_TEST_ALARM_DELAY_MS = 1;
+const INFLIGHT_DEADLINE_PREFIX = 'inflight-deadline:';
+
+function padded(ms: number): string {
+  return String(Math.max(0, Math.floor(ms))).padStart(13, '0');
+}
+
+function storedMessage(messageId: string, now: number): MessageRow {
+  return {
+    messageId,
+    queueName: '__wkf_workflow_test',
+    pathname: 'flow',
+    body: '{"data":"payload"}',
+    targetBaseUrl: 'http://app.test:3000',
+    attempt: 0,
+    enqueuedAt: now,
+  };
+}
 
 describe('QueueDO', () => {
   let fleet: FakeFleet;
@@ -85,6 +102,86 @@ describe('QueueDO', () => {
     expect(fetchStub).toHaveBeenCalledTimes(2);
   });
 
+  it('orders inflight claims by deadline and keeps same-deadline message keys distinct', async () => {
+    const releases: Array<(response: Response) => void> = [];
+    fetchStub.mockImplementation(() => new Promise<Response>((resolve) => releases.push(resolve)));
+    await queue.enqueue(enqueueReq({ messageId: 'msg_same_a' }));
+    await queue.enqueue(enqueueReq({ messageId: 'msg_same_b' }));
+
+    const delivery = tick();
+    await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledTimes(2));
+
+    const claimKeys = Array.from(storage().keys()).filter((key) =>
+      key.startsWith(INFLIGHT_DEADLINE_PREFIX),
+    );
+    expect(claimKeys).toHaveLength(2);
+    expect(claimKeys.map((key) => key.slice(INFLIGHT_DEADLINE_PREFIX.length, -11))).toEqual([
+      padded(fleet.now + 330_000),
+      padded(fleet.now + 330_000),
+    ]);
+    expect(claimKeys).toEqual([
+      `${INFLIGHT_DEADLINE_PREFIX}${padded(fleet.now + 330_000)}:msg_same_a`,
+      `${INFLIGHT_DEADLINE_PREFIX}${padded(fleet.now + 330_000)}:msg_same_b`,
+    ]);
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(fleet.now + 330_000);
+
+    for (const release of releases) release(new Response(null, { status: 204 }));
+    await delivery;
+  });
+
+  it('reschedules the alarm to the next due message after ack', async () => {
+    let finishDelivery!: (response: Response) => void;
+    fetchStub.mockImplementation(
+      () => new Promise<Response>((resolve) => (finishDelivery = resolve)),
+    );
+    await queue.enqueue(enqueueReq({ messageId: 'msg_ack_first' }));
+
+    const delivery = tick();
+    await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledOnce());
+    const nextDueAt = fleet.now + 600_000;
+    await queue.enqueue(enqueueReq({ messageId: 'msg_ack_next', delaySeconds: 600 }));
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(fleet.now + 330_000);
+
+    finishDelivery(new Response(null, { status: 204 }));
+    await delivery;
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(nextDueAt);
+  });
+
+  it('reschedules the alarm to retry backoff after a transient callback', async () => {
+    fetchStub.mockResolvedValue(new Response('retry', { status: 500 }));
+    await queue.enqueue(enqueueReq({ messageId: 'msg_retry_alarm' }));
+
+    await tick();
+
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(fleet.now + 2_000);
+    expect(
+      Array.from(storage().keys()).some(
+        (key) => key === `due:${padded(fleet.now + 2_000)}:msg_retry_alarm`,
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['successful', 200],
+    ['permanent-error', 410],
+    ['transient-error', 500],
+  ])('cancels an unused %s callback response body', async (_label, status) => {
+    const cancel = vi.fn<(reason?: unknown) => void>();
+    fetchStub.mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          cancel,
+        }),
+        { status },
+      ),
+    );
+    await queue.enqueue(enqueueReq({ messageId: `msg_cancel_${status}` }));
+
+    await tick();
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it('recovers when enqueue persistence is interrupted before the due index is written', async () => {
     const request = enqueueReq({
       messageId: 'msg_atomic_enqueue',
@@ -109,7 +206,10 @@ describe('QueueDO', () => {
     await queue.enqueue(enqueueReq({ messageId: 'msg_atomic_ack', idempotencyKey: 'atomic-ack' }));
     const cellStorage = fleet.cell('queue', 'q:0').storage;
     cellStorage.failNextMutation(
-      (mutation) => mutation.operation === 'delete' && mutation.key === 'inflight:msg_atomic_ack',
+      (mutation) =>
+        mutation.operation === 'delete' &&
+        mutation.key.startsWith('inflight-deadline:') &&
+        mutation.key.endsWith(':msg_atomic_ack'),
       new Error('injected crash during ack'),
     );
 
@@ -118,7 +218,9 @@ describe('QueueDO', () => {
     const data = storage();
     const messageIsRecoverable = data.has('msg:msg_atomic_ack');
     const acknowledgementFullyCommitted =
-      !data.has('inflight:msg_atomic_ack') && !data.has('key:atomic-ack');
+      !Array.from(data.keys()).some(
+        (key) => key.startsWith('inflight-deadline:') && key.endsWith(':msg_atomic_ack'),
+      ) && !data.has('key:atomic-ack');
     expect(messageIsRecoverable || acknowledgementFullyCommitted).toBe(true);
   });
 
@@ -281,6 +383,154 @@ describe('QueueDO', () => {
     await tick(); // sweep moves it back to due
     await tick(); // next alarm delivers it
     expect(fetchStub).toHaveBeenCalledOnce();
+  });
+
+  it('migrates legacy inflight state without changing its deadline', async () => {
+    await queue.enqueue(enqueueReq({ messageId: 'msg_legacy', delaySeconds: 60 }));
+    const data = storage();
+    for (const key of Array.from(data.keys())) {
+      if (key.startsWith('due:')) data.delete(key);
+    }
+    const deadline = fleet.now + 30_000;
+    data.set('inflight:msg_legacy', deadline);
+    fleet.cell('queue', 'q:0').storage.alarmAt = null;
+
+    expect(await queue.rearmAlarm()).toEqual({ alarmAt: deadline });
+    expect(data.has('inflight:msg_legacy')).toBe(false);
+    expect(data.get(`${INFLIGHT_DEADLINE_PREFIX}${padded(deadline)}:msg_legacy`)).toBe(
+      'msg_legacy',
+    );
+
+    await tick(30_001);
+    expect(fetchStub).toHaveBeenCalledOnce();
+    expect(await queue.stats()).toMatchObject({ pending: 0, inflight: 0 });
+  });
+
+  it('migrates large legacy inflight state across bounded alarm batches', async () => {
+    const data = storage();
+    const deadline = fleet.now + 60_000;
+    for (let index = 0; index < 130; index++) {
+      const messageId = `msg_legacy_${String(index).padStart(3, '0')}`;
+      data.set(`msg:${messageId}`, storedMessage(messageId, fleet.now));
+      data.set(`inflight:${messageId}`, deadline);
+    }
+    fleet.cell('queue', 'q:0').storage.alarmAt = fleet.now;
+
+    await tick();
+    expect(
+      Array.from(data.keys()).filter(
+        (key) => key.startsWith('inflight:') && !key.startsWith(INFLIGHT_DEADLINE_PREFIX),
+      ),
+    ).toHaveLength(2);
+    expect(
+      Array.from(data.keys()).filter((key) => key.startsWith(INFLIGHT_DEADLINE_PREFIX)),
+    ).toHaveLength(128);
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(fleet.now + 1);
+
+    await tick();
+    expect(Array.from(data.keys()).filter((key) => key.startsWith('inflight:'))).toHaveLength(0);
+    expect(
+      Array.from(data.keys()).filter((key) => key.startsWith(INFLIGHT_DEADLINE_PREFIX)),
+    ).toHaveLength(130);
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(deadline);
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it('uses the exact inflight key as a lease token against late callback completion', async () => {
+    const finishes: Array<(response: Response) => void> = [];
+    fetchStub.mockImplementation(() => new Promise<Response>((resolve) => finishes.push(resolve)));
+    fleet = new FakeFleet(
+      { queue: QueueDO },
+      {
+        clock: () => fleet.now,
+        fetch: fetchStub,
+        QUEUE_DELIVERY_TIMEOUT_MS: '10',
+      },
+    );
+    queue = fleet.namespace('queue').get({ toString: () => 'q:0' }) as QueueDO;
+    storage = () => fleet.cell('queue', 'q:0').storage.data;
+    await queue.enqueue(enqueueReq({ messageId: 'msg_lease' }));
+
+    await queue.alarm();
+    await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledOnce());
+    const firstClaim = Array.from(storage().keys()).find((key) =>
+      key.startsWith(INFLIGHT_DEADLINE_PREFIX),
+    )!;
+
+    fleet.advance(30_011);
+    await queue.alarm();
+    await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledTimes(2));
+    const pendingDeliveries = fleet.cell('queue', 'q:0').pendingWaits;
+    const secondClaim = Array.from(storage().keys()).find((key) =>
+      key.startsWith(INFLIGHT_DEADLINE_PREFIX),
+    )!;
+    expect(secondClaim).not.toBe(firstClaim);
+
+    finishes[0](new Response(null, { status: 204 }));
+    await pendingDeliveries[0];
+    expect(storage().has('msg:msg_lease')).toBe(true);
+    expect(storage().has(secondClaim)).toBe(true);
+
+    finishes[1](new Response(null, { status: 204 }));
+    await pendingDeliveries[1];
+    expect(storage().has('msg:msg_lease')).toBe(false);
+    expect(storage().has(secondClaim)).toBe(false);
+  });
+
+  it('processes expired inflight records in bounded alarm batches', async () => {
+    const data = storage();
+    const expiredDeadline = fleet.now - 1;
+    for (let index = 0; index < 130; index++) {
+      const messageId = `msg_expired_${String(index).padStart(3, '0')}`;
+      data.set(`msg:${messageId}`, storedMessage(messageId, fleet.now));
+      data.set(`${INFLIGHT_DEADLINE_PREFIX}${padded(expiredDeadline)}:${messageId}`, messageId);
+    }
+    fleet.cell('queue', 'q:0').storage.alarmAt = fleet.now;
+
+    await tick();
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(Array.from(data.keys()).filter((key) => key.startsWith('due:'))).toHaveLength(128);
+    expect(
+      Array.from(data.keys()).filter((key) => key.startsWith(INFLIGHT_DEADLINE_PREFIX)),
+    ).toHaveLength(2);
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBe(fleet.now + 1);
+
+    await tick();
+    expect(fetchStub).toHaveBeenCalledTimes(5);
+    expect(
+      Array.from(data.keys()).filter(
+        (key) => key.startsWith(INFLIGHT_DEADLINE_PREFIX) && key.includes(padded(expiredDeadline)),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('bounds inflight alarm work by expired records, concurrency, and the earliest key', async () => {
+    const cellStorage = fleet.cell('queue', 'q:0').storage;
+    const data = cellStorage.data;
+    const expiredDeadline = fleet.now - 1;
+    for (const messageId of ['msg_expired_a', 'msg_expired_b']) {
+      data.set(`msg:${messageId}`, storedMessage(messageId, fleet.now));
+      data.set(`${INFLIGHT_DEADLINE_PREFIX}${padded(expiredDeadline)}:${messageId}`, messageId);
+    }
+    for (let index = 0; index < 1_000; index++) {
+      const messageId = `msg_active_${String(index).padStart(4, '0')}`;
+      data.set(
+        `${INFLIGHT_DEADLINE_PREFIX}${padded(fleet.now + 60_000 + index)}:${messageId}`,
+        messageId,
+      );
+    }
+    cellStorage.alarmAt = fleet.now;
+    cellStorage.listCalls.length = 0;
+
+    await tick();
+
+    const inflightCalls = cellStorage.listCalls.filter(
+      (call) => call.options.prefix === INFLIGHT_DEADLINE_PREFIX,
+    );
+    expect(inflightCalls.map((call) => call.options.limit)).toEqual([129, 5, 1]);
+    expect(inflightCalls.map((call) => call.resultSize)).toEqual([2, 5, 1]);
+    expect(inflightCalls.every((call) => call.transactional)).toBe(true);
+    expect(fetchStub).not.toHaveBeenCalled();
   });
 
   it('rejects shard-count drift with CONFIG_MISMATCH', async () => {
@@ -480,6 +730,16 @@ describe('QueueDO', () => {
 
     const { alarmAt } = await queue.rearmAlarm();
     expect(alarmAt).toBe(fleet.now + 60_000);
+  });
+
+  it('rearmAlarm selects the earliest lexicographic inflight deadline', async () => {
+    const data = storage();
+    const early = fleet.now + 10_000;
+    const late = fleet.now + 90_000;
+    data.set(`${INFLIGHT_DEADLINE_PREFIX}${padded(late)}:msg_late`, 'msg_late');
+    data.set(`${INFLIGHT_DEADLINE_PREFIX}${padded(early)}:msg_early`, 'msg_early');
+
+    expect(await queue.rearmAlarm()).toEqual({ alarmAt: early });
   });
 
   it('moves an overdue alarm to a fresh timestamp so celld observes a new edge', async () => {

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -43,6 +43,7 @@ describe('Queue (celld QueueDO integration)', () => {
   afterEach(() => {
     process.env.VITEST = originalVitest;
     process.env.NODE_ENV = originalNodeEnv;
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
@@ -201,6 +202,24 @@ describe('Queue (celld QueueDO integration)', () => {
       );
       expect(third.messageId).not.toBe(first.messageId);
     });
+
+    it('should cancel an unused successful callback response body', async () => {
+      const cancel = vi.fn<(reason?: unknown) => void>();
+      const fetchStub = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            cancel,
+          }),
+          { status: 200 },
+        ),
+      );
+      vi.stubGlobal('fetch', fetchStub);
+
+      await queue.start();
+      await queue.queue('__wkf_workflow_q', { data: 'test' });
+
+      await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+    });
   });
 
   describe('createQueueHandler() (single x-vqs dialect)', () => {
@@ -217,7 +236,9 @@ describe('Queue (celld QueueDO integration)', () => {
 
       const response = await queueHandler(vqsRequest({ data: 'test-data' }));
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(204);
+      expect(response.body).toBeNull();
+      await expect(response.text()).resolves.toBe('');
       expect(handler).toHaveBeenCalledOnce();
       expect(handler).toHaveBeenCalledWith(
         { data: 'test-data' },
@@ -236,7 +257,7 @@ describe('Queue (celld QueueDO integration)', () => {
       const input = new Uint8Array([9, 8, 7]);
       const response = await queueHandler(vqsRequest({ runInput: { input } }));
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(204);
       const [message] = handler.mock.calls[0];
       expect(message.runInput.input).toBeInstanceOf(Uint8Array);
       expect(Array.from(message.runInput.input)).toEqual([9, 8, 7]);


### PR DESCRIPTION
## Summary

- re-key QueueDO inflight records by padded deadline so expiry recovery and next-alarm selection use bounded ordered range reads
- make the deadline-keyed inflight layout the only supported schema
- use the exact inflight index key as the delivery lease token, preventing late callbacks from mutating a newer claim without adding a per-ack lookup
- cancel callback response bodies when their contents are unused and return an empty 204 from the bundled successful callback handler
- add deterministic fake-storage query tracing and focused coverage for ordering, collisions, expiry batches, alarm rescheduling, lease races, retention, cancellation, and 204 responses

## Why

Queue claim and alarm scheduling previously listed the complete inflight set because deadlines were stored as values under message-ID-keyed records. That made claim-time expiry and every ack/retry alarm recomputation scale with total inflight messages.

Deadline-ordered keys let QueueDO read only expired records, cap concurrency counting at `QUEUE_MAX_INFLIGHT`, and select the earliest lease with `limit: 1`.

No deployed consumers exist, so this is intentionally a hard cutover with no legacy schema compatibility or state migration path.

## Protocol and storage impact

Public QueueDO RPC signatures and results are unchanged. Successful bundled callback responses change from `200 {"ok":true}` to an empty `204`; retry and permanent-error responses are unchanged.

Internally, alarm work is bounded by the 128-record expiry batch, the configured inflight cap, and one earliest-record lookup. Ack/retry deletes the exact lease key and does not add a message-ID lookup. Exact administrative `stats()` counts operate only on the deadline-keyed schema.

## Validation

- focused queue suite: 56 tests passed
- `pnpm check`: 15 test files, 215 tests passed
- formatting, strict lint, typecheck, build, worker bundle, and package checks passed
- integration command: 1 passed; 10 live-fleet cases skipped without fleet credentials
- `git diff --check` passed
