### PR TITLE
perf: batch and long-poll stream I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ More deployment detail is in [`celld-worker/README.md`](./celld-worker/README.md
 ```text
 Workflow application
   |
-  | authenticated HTTP RPC
+  | authenticated HTTP RPC + binary stream batches
   v
 celld worker router
   |-- WorkflowRunDO  one cell per workflow run
@@ -129,25 +129,27 @@ Workflow application /.well-known/workflow/v1/flow
 ```
 
 The application-side package implements the Workflow `World` interface and
-translates its storage, stream, and queue operations into RPC calls. The celld
-worker accepts only a fixed set of methods and routes each request to the named
-cell that owns the data.
+translates its storage and queue operations into JSON RPC calls. Stream chunk
+writes and bounded long-poll reads use a binary batch route; stream control and
+retention operations remain fixed, authenticated RPC methods. The worker routes
+each request to the named cell that owns the data.
 
 ## Configuration
 
 Application options can be passed to `createCelldWorld()` unless an environment
 variable is shown below.
 
-| Option           | Environment variable     | Default                  |
-| ---------------- | ------------------------ | ------------------------ |
-| `fleetUrl`       | `CELLD_FLEET_URL`        | required                 |
-| `secret`         | `CELLD_WORLD_SECRET`     | required with `fleetUrl` |
-| `baseUrl`        | `WORKFLOW_BASE_URL`      | `http://localhost:$PORT` |
-| `deploymentId`   | `CELLD_DEPLOYMENT_ID`    | `celld-default`          |
-| `queueShards`    | —                        | `1`                      |
-| `runRetentionMs` | `CELLD_RUN_RETENTION_MS` | `0` (disabled)           |
-| `readPollMs`     | —                        | `250`                    |
-| `rpcTimeoutMs`   | —                        | `30000`                  |
+| Option                  | Environment variable     | Default                  |
+| ----------------------- | ------------------------ | ------------------------ |
+| `fleetUrl`              | `CELLD_FLEET_URL`        | required                 |
+| `secret`                | `CELLD_WORLD_SECRET`     | required with `fleetUrl` |
+| `baseUrl`               | `WORKFLOW_BASE_URL`      | `http://localhost:$PORT` |
+| `deploymentId`          | `CELLD_DEPLOYMENT_ID`    | `celld-default`          |
+| `queueShards`           | —                        | `1`                      |
+| `runRetentionMs`        | `CELLD_RUN_RETENTION_MS` | `0` (disabled)           |
+| `streamLongPollMs`      | —                        | `20000`                  |
+| `streamFlushIntervalMs` | —                        | `0`                      |
+| `rpcTimeoutMs`          | —                        | `30000`                  |
 
 The deployed worker also accepts these celld variables:
 

--- a/celld-worker/README.md
+++ b/celld-worker/README.md
@@ -1,8 +1,9 @@
 # world-celld worker
 
 The celld-deployable half of `@ewhauser/world-celld`: four cell classes
-(WorkflowRunDO, StreamDO, IndexDO, QueueDO) behind an authenticated HTTP RPC
-router.
+(WorkflowRunDO, StreamDO, IndexDO, QueueDO) behind an authenticated HTTP router.
+Storage, control, and queue methods use fixed JSON RPC routes; stream chunks use
+bounded binary batch writes and binary long-poll reads.
 
 ## Deploy
 

--- a/celld-worker/wrangler.jsonc
+++ b/celld-worker/wrangler.jsonc
@@ -20,8 +20,8 @@
     },
   ],
   "vars": {
-    // REQUIRED: bearer secret for the world's RPC surface. All /v1/rpc
-    // routes fail closed with 503 while this is empty. Inject the real value
+    // REQUIRED: bearer secret for the world's RPC and binary stream surface.
+    // Authenticated routes fail closed with 503 while this is empty. Inject the real value
     // at the node level with CELLD_VAR_WORLD_SECRET instead of committing it.
     "WORLD_SECRET": "",
     // Optional: forwarded as x-workflow-callback-secret on queue deliveries.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import type { WorkflowRunDONamespace } from './storage.js';
 import type { StreamDONamespace } from './streamer.js';
 import type { QueueCellNamespace } from './queue.js';
+import { MAX_STREAM_LONG_POLL_MS } from './stream-protocol.js';
 
 /** Storage-layer index interface (satisfied by IndexDO over HTTP, or a mock). */
 export interface IndexNamespace {
@@ -80,8 +81,10 @@ export interface CelldWorldConfig {
    * Default: process.env.CELLD_RUN_RETENTION_MS || 0
    */
   runRetentionMs?: number;
-  /** Poll interval (ms) while waiting for new chunks on a live stream. Default: 250 */
-  readPollMs?: number;
+  /** Duration of one bounded idle stream read. Default: 20000 */
+  streamLongPollMs?: number;
+  /** Runtime stream batching delay. Default: 0 */
+  streamFlushIntervalMs?: number;
   /** Per-attempt fleet RPC deadline in milliseconds. Default: 30000 */
   rpcTimeoutMs?: number;
 }
@@ -94,7 +97,8 @@ export interface ResolvedCelldConfig {
   baseUrl?: string;
   queueShards: number;
   runRetentionMs: number;
-  readPollMs: number;
+  streamLongPollMs: number;
+  streamFlushIntervalMs: number;
   rpcTimeoutMs: number;
 }
 
@@ -106,6 +110,30 @@ export function resolveConfig(config?: CelldWorldConfig): ResolvedCelldConfig {
     throw new Error('world-celld: runRetentionMs must be a non-negative safe integer');
   }
 
+  const rpcTimeoutMs = config?.rpcTimeoutMs ?? 30_000;
+  if (!Number.isSafeInteger(rpcTimeoutMs) || rpcTimeoutMs < 1) {
+    throw new Error('world-celld: rpcTimeoutMs must be a positive safe integer');
+  }
+  const streamLongPollMs =
+    config?.streamLongPollMs ??
+    Math.min(MAX_STREAM_LONG_POLL_MS, Math.max(1, rpcTimeoutMs - 1_000));
+  if (
+    !Number.isSafeInteger(streamLongPollMs) ||
+    streamLongPollMs < 1 ||
+    streamLongPollMs > MAX_STREAM_LONG_POLL_MS
+  ) {
+    throw new Error(
+      `world-celld: streamLongPollMs must be between 1 and ${MAX_STREAM_LONG_POLL_MS}`,
+    );
+  }
+  if (streamLongPollMs >= rpcTimeoutMs) {
+    throw new Error('world-celld: streamLongPollMs must be less than rpcTimeoutMs');
+  }
+  const streamFlushIntervalMs = config?.streamFlushIntervalMs ?? 0;
+  if (!Number.isSafeInteger(streamFlushIntervalMs) || streamFlushIntervalMs < 0) {
+    throw new Error('world-celld: streamFlushIntervalMs must be a non-negative safe integer');
+  }
+
   return {
     fleetUrl: config?.fleetUrl ?? process.env.CELLD_FLEET_URL,
     secret: config?.secret ?? process.env.CELLD_WORLD_SECRET,
@@ -114,7 +142,8 @@ export function resolveConfig(config?: CelldWorldConfig): ResolvedCelldConfig {
     baseUrl: config?.baseUrl,
     queueShards: config?.queueShards ?? 1,
     runRetentionMs,
-    readPollMs: config?.readPollMs ?? 250,
-    rpcTimeoutMs: config?.rpcTimeoutMs ?? 30_000,
+    streamLongPollMs,
+    streamFlushIntervalMs,
+    rpcTimeoutMs,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { type CelldWorldConfig, type CelldWorldEnv, resolveConfig } from './conf
 import { createRemoteEnv } from './remote/namespaces.js';
 import { createQueue } from './queue.js';
 import { createStorage } from './storage.js';
-import { createStreamer } from './streamer.js';
+import { createStreamer, type CelldStreamer } from './streamer.js';
 import type { CleanupRecord } from './retention.js';
 
 export type { CelldWorldConfig, CelldWorldEnv, IndexNamespace } from './config.js';
@@ -21,6 +21,22 @@ export type {
 } from './queue.js';
 export type { WorkflowRunDONamespace, WorkflowRunDOStub } from './storage.js';
 export type { StreamDONamespace, StreamDOStub } from './streamer.js';
+export {
+  MAX_STREAM_BATCH_BYTES,
+  MAX_STREAM_CHUNK_BYTES,
+  MAX_STREAM_ERROR_BYTES,
+  MAX_STREAM_LONG_POLL_MS,
+  MAX_STREAM_READ_BYTES,
+  MAX_STREAM_READ_CHUNKS,
+  MAX_STREAM_WRITE_CHUNKS,
+} from './stream-protocol.js';
+export type {
+  StreamErrorData,
+  StreamReadRequest,
+  StreamReadResult,
+  StreamTerminalState,
+  StreamWriteResult,
+} from './stream-protocol.js';
 export type { CleanupPhase, CleanupRecord, RunTombstone } from './retention.js';
 
 export interface CelldRetentionAdmin {
@@ -30,7 +46,7 @@ export interface CelldRetentionAdmin {
   rearm(runId: string): Promise<CleanupRecord | null>;
 }
 
-export type CelldWorld = World & { retention: CelldRetentionAdmin };
+export type CelldWorld = World & CelldStreamer & { retention: CelldRetentionAdmin };
 
 export function createCelldWorld(config?: CelldWorldConfig): CelldWorld {
   const resolved = resolveConfig(config);
@@ -90,7 +106,8 @@ export function createCelldWorld(config?: CelldWorldConfig): CelldWorld {
     env: {
       WORKFLOW_STREAMS: env.WORKFLOW_STREAMS,
     },
-    readPollMs: resolved.readPollMs,
+    streamLongPollMs: resolved.streamLongPollMs,
+    streamFlushIntervalMs: resolved.streamFlushIntervalMs,
   });
 
   const runStub = (runId: string) => env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName(runId));

--- a/src/remote/namespaces.ts
+++ b/src/remote/namespaces.ts
@@ -9,6 +9,7 @@ import type { QueueCellStub } from '../queue.js';
 import type { WorkflowRunDOStub } from '../storage.js';
 import type { StreamDOStub } from '../streamer.js';
 import { callDO, type RpcTransport } from './rpc-client.js';
+import { readStreamChunks, writeStreamChunks } from './stream-client.js';
 
 interface MethodSpec {
   methods: readonly string[];
@@ -34,10 +35,8 @@ const RUNS: MethodSpec = {
 
 const STREAMS: MethodSpec = {
   methods: [
-    'writeChunk',
     'closeStream',
-    'getChunks',
-    'getInfo',
+    'failStream',
     'registerStream',
     'listStreams',
     'expireRegistry',
@@ -45,14 +44,29 @@ const STREAMS: MethodSpec = {
     'expireStream',
   ],
   mutating: new Set([
-    'writeChunk',
     'closeStream',
+    'failStream',
     'registerStream',
     'expireRegistry',
     'finalizeRegistry',
     'expireStream',
   ]),
 };
+
+function makeStreamNamespace(transport: RpcTransport) {
+  return {
+    idFromName(name: string) {
+      return { toString: () => name };
+    },
+    get(id: { toString(): string }): StreamDOStub {
+      const name = id.toString();
+      const control = makeStub<StreamDOStub>(transport, 'streams', name, STREAMS);
+      control.writeChunks = (runId, chunks) => writeStreamChunks(transport, name, runId, chunks);
+      control.readChunks = (request, signal) => readStreamChunks(transport, name, request, signal);
+      return control;
+    },
+  };
+}
 
 const QUEUE: MethodSpec = {
   methods: [
@@ -122,7 +136,7 @@ function makeIndexNamespace(transport: RpcTransport): IndexNamespace {
 export function createRemoteEnv(transport: RpcTransport): CelldWorldEnv {
   return {
     WORKFLOW_DB: makeNamespace<WorkflowRunDOStub>(transport, 'runs', RUNS),
-    WORKFLOW_STREAMS: makeNamespace<StreamDOStub>(transport, 'streams', STREAMS),
+    WORKFLOW_STREAMS: makeStreamNamespace(transport),
     WORKFLOW_INDEX: makeIndexNamespace(transport),
     WORKFLOW_QUEUE: makeNamespace<QueueCellStub>(transport, 'queue', QUEUE),
   };

--- a/src/remote/stream-client.ts
+++ b/src/remote/stream-client.ts
@@ -1,0 +1,180 @@
+import {
+  MAX_STREAM_BATCH_BYTES,
+  MAX_STREAM_READ_BYTES,
+  STREAM_BATCH_CONTENT_TYPE,
+  decodeStreamReadResult,
+  decodeStreamWriteResult,
+  encodeStreamWriteBatch,
+  type StreamReadRequest,
+  type StreamReadResult,
+  type StreamWriteResult,
+} from '../stream-protocol.js';
+import { FleetTransportError, reconstructError, type WireError } from './errors.js';
+import type { RpcTransport } from './rpc-client.js';
+
+const RETRYABLE_STATUSES = new Set([502, 503, 504]);
+const READ_ATTEMPTS = 3;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_WRITE_RESPONSE_BYTES = 64;
+const MAX_READ_RESPONSE_BYTES = MAX_STREAM_READ_BYTES + 64 * 1024;
+const MAX_ERROR_RESPONSE_BYTES = 64 * 1024;
+
+function delayMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function requestSignal(timeoutMs: number, signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(Math.max(1, timeoutMs));
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function aborted(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
+}
+
+async function readBoundedResponse(response: Response, maxBytes: number): Promise<Uint8Array> {
+  const contentLength = Number(response.headers.get('content-length') ?? '0');
+  if (contentLength > maxBytes) {
+    await response.body?.cancel('stream response exceeds configured limit').catch(() => undefined);
+    throw new FleetTransportError(`world-celld: stream response exceeds ${maxBytes} bytes`);
+  }
+  if (!response.body) return new Uint8Array();
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel('stream response exceeds configured limit').catch(() => undefined);
+        throw new FleetTransportError(`world-celld: stream response exceeds ${maxBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+async function errorFromResponse(response: Response): Promise<Error> {
+  const text = new TextDecoder().decode(
+    await readBoundedResponse(response, MAX_ERROR_RESPONSE_BYTES),
+  );
+  let wire: WireError | undefined;
+  try {
+    wire = (JSON.parse(text) as { error?: WireError }).error;
+  } catch {
+    wire = { message: text || `HTTP ${response.status}` };
+  }
+  return reconstructError(wire, response.status);
+}
+
+function streamUrl(transport: RpcTransport, name: string): string {
+  return `${transport.fleetUrl.replace(/\/$/, '')}/v1/streams/${encodeURIComponent(name)}/chunks`;
+}
+
+export async function writeStreamChunks(
+  transport: RpcTransport,
+  name: string,
+  runId: string,
+  chunks: Uint8Array[],
+): Promise<StreamWriteResult> {
+  const body = encodeStreamWriteBatch(chunks);
+  if (body.byteLength > MAX_STREAM_BATCH_BYTES + 1024) {
+    throw new Error('world-celld: encoded stream batch exceeds configured limit');
+  }
+  const url = new URL(streamUrl(transport, name));
+  url.searchParams.set('runId', runId);
+  const doFetch = transport.fetchImpl ?? fetch;
+
+  let response: Response;
+  try {
+    response = await doFetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': STREAM_BATCH_CONTENT_TYPE,
+        authorization: `Bearer ${transport.secret}`,
+      },
+      body,
+      signal: requestSignal(transport.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new FleetTransportError(`world-celld: fleet unreachable at ${url.href}`, error);
+  }
+
+  if (!response.ok) throw await errorFromResponse(response);
+  try {
+    return decodeStreamWriteResult(await readBoundedResponse(response, MAX_WRITE_RESPONSE_BYTES));
+  } catch (error) {
+    if (error instanceof FleetTransportError) throw error;
+    throw new FleetTransportError(`world-celld: malformed stream response from ${url.href}`, error);
+  }
+}
+
+export async function readStreamChunks(
+  transport: RpcTransport,
+  name: string,
+  request: StreamReadRequest,
+  signal?: AbortSignal,
+): Promise<StreamReadResult> {
+  const url = new URL(streamUrl(transport, name));
+  url.searchParams.set('runId', request.runId);
+  url.searchParams.set('startIndex', String(request.startIndex));
+  url.searchParams.set('maxChunks', String(request.maxChunks));
+  url.searchParams.set('maxBytes', String(request.maxBytes));
+  url.searchParams.set('waitMs', String(request.waitMs));
+  const doFetch = transport.fetchImpl ?? fetch;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= READ_ATTEMPTS; attempt++) {
+    if (signal?.aborted) throw aborted(signal);
+    if (attempt > 1) await delayMs(100 * attempt + Math.random() * 200);
+    let response: Response;
+    try {
+      response = await doFetch(url, {
+        method: 'GET',
+        headers: { authorization: `Bearer ${transport.secret}` },
+        signal: requestSignal(transport.timeoutMs ?? DEFAULT_TIMEOUT_MS, signal),
+      });
+    } catch (error) {
+      if (signal?.aborted) throw aborted(signal);
+      lastError = new FleetTransportError(`world-celld: fleet unreachable at ${url.href}`, error);
+      continue;
+    }
+
+    if (response.ok) {
+      try {
+        return decodeStreamReadResult(await readBoundedResponse(response, MAX_READ_RESPONSE_BYTES));
+      } catch (error) {
+        lastError = new FleetTransportError(
+          `world-celld: malformed stream response from ${url.href}`,
+          error,
+        );
+        if (attempt < READ_ATTEMPTS) continue;
+        throw lastError;
+      }
+    }
+
+    const error = await errorFromResponse(response);
+    if (RETRYABLE_STATUSES.has(response.status) && attempt < READ_ATTEMPTS) {
+      lastError = error;
+      continue;
+    }
+    throw error;
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new FleetTransportError('world-celld: stream read failed', lastError);
+}

--- a/src/stream-protocol.ts
+++ b/src/stream-protocol.ts
@@ -1,0 +1,345 @@
+/**
+ * Hard-cutover stream protocol shared by the client, Worker router, and
+ * StreamDO. Chunk payloads use a compact binary envelope on the public HTTP
+ * boundary and Uint8Array values on the DO/storage boundary.
+ */
+
+export const STREAM_BATCH_CONTENT_TYPE = 'application/vnd.world-celld.stream-batch.v1';
+
+/** One storage.put(entries) call remains below the 128-key platform limit. */
+export const MAX_STREAM_WRITE_CHUNKS = 32;
+/** A chunk remains below the 2 MiB SQLite-backed DO key/value limit. */
+export const MAX_STREAM_CHUNK_BYTES = 1024 * 1024;
+/** Keeps serialized RPC bodies well below the 32 MiB Workers RPC limit. */
+export const MAX_STREAM_BATCH_BYTES = 8 * 1024 * 1024;
+export const MAX_STREAM_READ_CHUNKS = 32;
+export const MAX_STREAM_READ_BYTES = 8 * 1024 * 1024;
+export const MAX_STREAM_ERROR_BYTES = 16 * 1024;
+/** Must remain below the default 30 second fleet request deadline. */
+export const MAX_STREAM_LONG_POLL_MS = 20_000;
+
+export type StreamTerminalState = 'open' | 'closed' | 'errored' | 'expired';
+
+export interface StreamErrorData {
+  name: string;
+  message: string;
+}
+
+export interface StreamWriteResult {
+  startIndex: number;
+  count: number;
+  tailIndex: number;
+}
+
+export interface StreamReadRequest {
+  runId: string;
+  startIndex: number;
+  maxChunks: number;
+  maxBytes: number;
+  waitMs: number;
+}
+
+export interface StreamReadResult {
+  startIndex: number;
+  tailIndex: number;
+  chunks: Uint8Array[];
+  state: StreamTerminalState;
+  timedOut: boolean;
+  error?: StreamErrorData;
+}
+
+const WRITE_MAGIC = 0x57435357; // WCSW
+const WRITE_ACK_MAGIC = 0x57435341; // WCSA
+const READ_MAGIC = 0x57435352; // WCSR
+const PROTOCOL_VERSION = 1;
+const WRITE_HEADER_BYTES = 8;
+const WRITE_ACK_BYTES = 16;
+const READ_HEADER_BYTES = 28;
+
+const STATE_TO_WIRE: Record<StreamTerminalState, number> = {
+  open: 0,
+  closed: 1,
+  errored: 2,
+  expired: 3,
+};
+
+const WIRE_TO_STATE: readonly StreamTerminalState[] = ['open', 'closed', 'errored', 'expired'];
+
+function protocolError(message: string): Error {
+  const error = new Error(`world-celld: invalid stream protocol: ${message}`);
+  error.name = 'StreamProtocolError';
+  return error;
+}
+
+function requireSafeIndex(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < -1 || value > 0x7fffffff) {
+    throw protocolError(`${field} is out of range`);
+  }
+}
+
+export function validateStreamWriteChunks(chunks: readonly Uint8Array[]): number {
+  if (chunks.length === 0) throw protocolError('batch must contain at least one chunk');
+  if (chunks.length > MAX_STREAM_WRITE_CHUNKS) {
+    throw protocolError(`batch exceeds ${MAX_STREAM_WRITE_CHUNKS} chunks`);
+  }
+
+  let totalBytes = 0;
+  for (const chunk of chunks) {
+    if (!(chunk instanceof Uint8Array)) throw protocolError('chunk is not binary data');
+    if (chunk.byteLength > MAX_STREAM_CHUNK_BYTES) {
+      throw protocolError(`chunk exceeds ${MAX_STREAM_CHUNK_BYTES} bytes`);
+    }
+    totalBytes += chunk.byteLength;
+    if (totalBytes > MAX_STREAM_BATCH_BYTES) {
+      throw protocolError(`batch exceeds ${MAX_STREAM_BATCH_BYTES} bytes`);
+    }
+  }
+  return totalBytes;
+}
+
+export function validateStreamReadRequest(request: StreamReadRequest): void {
+  if (!request.runId) throw protocolError('runId is required');
+  if (!Number.isSafeInteger(request.startIndex) || request.startIndex < 0) {
+    throw protocolError('startIndex must be a non-negative safe integer');
+  }
+  if (
+    !Number.isSafeInteger(request.maxChunks) ||
+    request.maxChunks < 0 ||
+    request.maxChunks > MAX_STREAM_READ_CHUNKS
+  ) {
+    throw protocolError(`maxChunks must be between 0 and ${MAX_STREAM_READ_CHUNKS}`);
+  }
+  if (
+    !Number.isSafeInteger(request.maxBytes) ||
+    request.maxBytes < 1 ||
+    request.maxBytes > MAX_STREAM_READ_BYTES
+  ) {
+    throw protocolError(`maxBytes must be between 1 and ${MAX_STREAM_READ_BYTES}`);
+  }
+  if (
+    !Number.isSafeInteger(request.waitMs) ||
+    request.waitMs < 0 ||
+    request.waitMs > MAX_STREAM_LONG_POLL_MS
+  ) {
+    throw protocolError(`waitMs must be between 0 and ${MAX_STREAM_LONG_POLL_MS}`);
+  }
+}
+
+export function encodeStreamWriteBatch(chunks: readonly Uint8Array[]): Uint8Array {
+  const totalBytes = validateStreamWriteChunks(chunks);
+  const encoded = new Uint8Array(WRITE_HEADER_BYTES + chunks.length * 4 + totalBytes);
+  const view = new DataView(encoded.buffer);
+  view.setUint32(0, WRITE_MAGIC);
+  view.setUint16(4, PROTOCOL_VERSION);
+  view.setUint16(6, chunks.length);
+
+  let offset = WRITE_HEADER_BYTES;
+  for (const chunk of chunks) {
+    view.setUint32(offset, chunk.byteLength);
+    offset += 4;
+    encoded.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return encoded;
+}
+
+export function decodeStreamWriteBatch(encoded: Uint8Array): Uint8Array[] {
+  if (encoded.byteLength < WRITE_HEADER_BYTES) throw protocolError('truncated write header');
+  const view = new DataView(encoded.buffer, encoded.byteOffset, encoded.byteLength);
+  if (view.getUint32(0) !== WRITE_MAGIC) throw protocolError('bad write magic');
+  if (view.getUint16(4) !== PROTOCOL_VERSION) throw protocolError('unsupported write version');
+  const count = view.getUint16(6);
+  const chunks: Uint8Array[] = [];
+  let offset = WRITE_HEADER_BYTES;
+  for (let index = 0; index < count; index++) {
+    if (offset + 4 > encoded.byteLength) throw protocolError('truncated chunk length');
+    const length = view.getUint32(offset);
+    offset += 4;
+    if (offset + length > encoded.byteLength) throw protocolError('truncated chunk data');
+    chunks.push(encoded.subarray(offset, offset + length));
+    offset += length;
+  }
+  if (offset !== encoded.byteLength) throw protocolError('trailing write data');
+  validateStreamWriteChunks(chunks);
+  return chunks;
+}
+
+export function encodeStreamWriteResult(result: StreamWriteResult): Uint8Array {
+  requireSafeIndex(result.startIndex, 'startIndex');
+  requireSafeIndex(result.tailIndex, 'tailIndex');
+  if (
+    !Number.isSafeInteger(result.count) ||
+    result.count < 1 ||
+    result.count > MAX_STREAM_WRITE_CHUNKS
+  ) {
+    throw protocolError('write count is out of range');
+  }
+  const encoded = new Uint8Array(WRITE_ACK_BYTES);
+  const view = new DataView(encoded.buffer);
+  view.setUint32(0, WRITE_ACK_MAGIC);
+  view.setUint16(4, PROTOCOL_VERSION);
+  view.setUint16(6, result.count);
+  view.setInt32(8, result.startIndex);
+  view.setInt32(12, result.tailIndex);
+  return encoded;
+}
+
+export function decodeStreamWriteResult(encoded: Uint8Array): StreamWriteResult {
+  if (encoded.byteLength !== WRITE_ACK_BYTES) throw protocolError('invalid write response size');
+  const view = new DataView(encoded.buffer, encoded.byteOffset, encoded.byteLength);
+  if (view.getUint32(0) !== WRITE_ACK_MAGIC) throw protocolError('bad write response magic');
+  if (view.getUint16(4) !== PROTOCOL_VERSION) {
+    throw protocolError('unsupported write response version');
+  }
+  const count = view.getUint16(6);
+  if (count < 1 || count > MAX_STREAM_WRITE_CHUNKS) {
+    throw protocolError('write response count is out of range');
+  }
+  const result = {
+    count,
+    startIndex: view.getInt32(8),
+    tailIndex: view.getInt32(12),
+  };
+  requireSafeIndex(result.startIndex, 'startIndex');
+  requireSafeIndex(result.tailIndex, 'tailIndex');
+  if (result.tailIndex !== result.startIndex + result.count - 1) {
+    throw protocolError('write response offsets are inconsistent');
+  }
+  return result;
+}
+
+export function encodeStreamReadResult(result: StreamReadResult): Uint8Array {
+  requireSafeIndex(result.startIndex, 'startIndex');
+  requireSafeIndex(result.tailIndex, 'tailIndex');
+  let chunkBytes = 0;
+  for (const chunk of result.chunks) chunkBytes += 4 + chunk.byteLength;
+  if (result.chunks.length > MAX_STREAM_READ_CHUNKS || chunkBytes > MAX_STREAM_READ_BYTES + 128) {
+    throw protocolError('read result exceeds configured bounds');
+  }
+
+  const encoder = new TextEncoder();
+  const errorName = result.error ? encoder.encode(result.error.name) : new Uint8Array();
+  const errorMessage = result.error ? encoder.encode(result.error.message) : new Uint8Array();
+  if (errorName.byteLength + errorMessage.byteLength > MAX_STREAM_ERROR_BYTES) {
+    throw protocolError(`stream error exceeds ${MAX_STREAM_ERROR_BYTES} bytes`);
+  }
+  const encoded = new Uint8Array(
+    READ_HEADER_BYTES + chunkBytes + errorName.byteLength + errorMessage.byteLength,
+  );
+  const view = new DataView(encoded.buffer);
+  view.setUint32(0, READ_MAGIC);
+  view.setUint8(4, PROTOCOL_VERSION);
+  const state = STATE_TO_WIRE[result.state];
+  if (state === undefined) throw protocolError('unknown stream state');
+  view.setUint8(5, state);
+  view.setUint8(6, result.timedOut ? 1 : 0);
+  view.setUint8(7, 0);
+  view.setInt32(8, result.startIndex);
+  view.setInt32(12, result.tailIndex);
+  view.setUint32(16, result.chunks.length);
+  view.setUint32(20, errorName.byteLength);
+  view.setUint32(24, errorMessage.byteLength);
+
+  let offset = READ_HEADER_BYTES;
+  for (const chunk of result.chunks) {
+    view.setUint32(offset, chunk.byteLength);
+    offset += 4;
+    encoded.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  encoded.set(errorName, offset);
+  offset += errorName.byteLength;
+  encoded.set(errorMessage, offset);
+  return encoded;
+}
+
+export function decodeStreamReadResult(encoded: Uint8Array): StreamReadResult {
+  if (encoded.byteLength < READ_HEADER_BYTES) throw protocolError('truncated read header');
+  const view = new DataView(encoded.buffer, encoded.byteOffset, encoded.byteLength);
+  if (view.getUint32(0) !== READ_MAGIC) throw protocolError('bad read magic');
+  if (view.getUint8(4) !== PROTOCOL_VERSION) throw protocolError('unsupported read version');
+  const state = WIRE_TO_STATE[view.getUint8(5)];
+  if (!state) throw protocolError('unknown stream state');
+  const startIndex = view.getInt32(8);
+  const tailIndex = view.getInt32(12);
+  requireSafeIndex(startIndex, 'startIndex');
+  requireSafeIndex(tailIndex, 'tailIndex');
+  const count = view.getUint32(16);
+  const errorNameLength = view.getUint32(20);
+  const errorMessageLength = view.getUint32(24);
+  if (count > MAX_STREAM_READ_CHUNKS) throw protocolError('read chunk count exceeds limit');
+  if (errorNameLength + errorMessageLength > MAX_STREAM_ERROR_BYTES) {
+    throw protocolError('read error exceeds limit');
+  }
+
+  const chunks: Uint8Array[] = [];
+  let offset = READ_HEADER_BYTES;
+  let totalBytes = 0;
+  for (let index = 0; index < count; index++) {
+    if (offset + 4 > encoded.byteLength) throw protocolError('truncated read chunk length');
+    const length = view.getUint32(offset);
+    offset += 4;
+    if (offset + length > encoded.byteLength) throw protocolError('truncated read chunk data');
+    totalBytes += length;
+    if (totalBytes > MAX_STREAM_READ_BYTES) throw protocolError('read bytes exceed limit');
+    chunks.push(encoded.subarray(offset, offset + length));
+    offset += length;
+  }
+
+  if (offset + errorNameLength + errorMessageLength !== encoded.byteLength) {
+    throw protocolError('invalid read error payload');
+  }
+  const decoder = new TextDecoder();
+  const error =
+    errorNameLength > 0 || errorMessageLength > 0
+      ? {
+          name: decoder.decode(encoded.subarray(offset, offset + errorNameLength)),
+          message: decoder.decode(encoded.subarray(offset + errorNameLength)),
+        }
+      : undefined;
+
+  return {
+    startIndex,
+    tailIndex,
+    chunks,
+    state,
+    timedOut: (view.getUint8(6) & 1) !== 0,
+    error,
+  };
+}
+
+export function normalizeStreamError(error: unknown): StreamErrorData {
+  let normalized: StreamErrorData;
+  if (error instanceof Error) {
+    normalized = { name: error.name || 'Error', message: error.message };
+  } else if (typeof error === 'string') {
+    normalized = { name: 'Error', message: error };
+  } else if (
+    error &&
+    typeof error === 'object' &&
+    typeof (error as { name?: unknown }).name === 'string' &&
+    typeof (error as { message?: unknown }).message === 'string'
+  ) {
+    normalized = {
+      name: (error as StreamErrorData).name,
+      message: (error as StreamErrorData).message,
+    };
+  } else {
+    normalized = { name: 'Error', message: String(error) };
+  }
+
+  // Bound persisted terminal metadata as well as its binary response frame.
+  normalized.name = normalized.name.slice(0, 1024);
+  normalized.message = normalized.message.slice(0, 4096);
+  while (
+    new TextEncoder().encode(normalized.name).byteLength +
+      new TextEncoder().encode(normalized.message).byteLength >
+    MAX_STREAM_ERROR_BYTES
+  ) {
+    normalized.message = normalized.message.slice(0, Math.max(0, normalized.message.length - 256));
+    if (normalized.message.length === 0) {
+      normalized.name = normalized.name.slice(0, Math.max(0, normalized.name.length - 256));
+    }
+  }
+  return normalized;
+}

--- a/src/stream-protocol.ts
+++ b/src/stream-protocol.ts
@@ -6,7 +6,7 @@
 
 export const STREAM_BATCH_CONTENT_TYPE = 'application/vnd.world-celld.stream-batch.v1';
 
-/** One storage.put(entries) call remains below the 128-key platform limit. */
+/** Metadata plus payload and size-index entries remain below the 128-key platform limit. */
 export const MAX_STREAM_WRITE_CHUNKS = 32;
 /** A chunk remains below the 2 MiB SQLite-backed DO key/value limit. */
 export const MAX_STREAM_CHUNK_BYTES = 1024 * 1024;
@@ -111,10 +111,12 @@ export function validateStreamReadRequest(request: StreamReadRequest): void {
   }
   if (
     !Number.isSafeInteger(request.maxBytes) ||
-    request.maxBytes < 1 ||
+    request.maxBytes < MAX_STREAM_CHUNK_BYTES ||
     request.maxBytes > MAX_STREAM_READ_BYTES
   ) {
-    throw protocolError(`maxBytes must be between 1 and ${MAX_STREAM_READ_BYTES}`);
+    throw protocolError(
+      `maxBytes must be between ${MAX_STREAM_CHUNK_BYTES} and ${MAX_STREAM_READ_BYTES}`,
+    );
   }
   if (
     !Number.isSafeInteger(request.waitMs) ||
@@ -156,7 +158,10 @@ export function decodeStreamWriteBatch(encoded: Uint8Array): Uint8Array[] {
     const length = view.getUint32(offset);
     offset += 4;
     if (offset + length > encoded.byteLength) throw protocolError('truncated chunk data');
-    chunks.push(encoded.subarray(offset, offset + length));
+    // Persisted DO values are structured-cloned. A view would retain the
+    // complete batch backing buffer and could exceed the per-value storage
+    // limit even when this individual chunk is valid.
+    chunks.push(new Uint8Array(encoded.subarray(offset, offset + length)));
     offset += length;
   }
   if (offset !== encoded.byteLength) throw protocolError('trailing write data');

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -6,28 +6,55 @@ import type {
   Streamer,
 } from '@workflow/world';
 import type { ExpireRunStreamsResult, ExpireStreamResult } from './retention.js';
+import {
+  MAX_STREAM_BATCH_BYTES,
+  MAX_STREAM_CHUNK_BYTES,
+  MAX_STREAM_LONG_POLL_MS,
+  MAX_STREAM_READ_BYTES,
+  MAX_STREAM_READ_CHUNKS,
+  MAX_STREAM_WRITE_CHUNKS,
+  normalizeStreamError,
+  type StreamErrorData,
+  type StreamReadRequest,
+  type StreamReadResult,
+  type StreamWriteResult,
+} from './stream-protocol.js';
 
 export interface CelldStreamerConfig {
   env: {
     WORKFLOW_STREAMS: StreamDONamespace;
   };
-  /**
-   * Poll interval (ms) while waiting for new chunks on a live stream.
-   * Modified vs upstream: configurable because each poll is a fleet HTTP
-   * round-trip here, not an in-process DO call. Default: 100.
-   */
-  readPollMs?: number;
+  /** Duration of one bounded idle read. Default: 20000. */
+  streamLongPollMs?: number;
+  /** Runtime coalescing delay for streams.writeMulti(). Default: 0. */
+  streamFlushIntervalMs?: number;
 }
 
-/** Workflow 5 streamer plus the package's pre-5 convenience aliases. */
-export interface CelldStreamer extends Streamer {
+export interface CelldStreamer extends Omit<Streamer, 'streams'> {
+  streams: Streamer['streams'] & {
+    fail(runId: string, name: string, error: StreamErrorData | string): Promise<void>;
+  };
   writeToStream(
     name: string,
     runId: string | Promise<string>,
     chunk: string | Uint8Array,
   ): Promise<void>;
+  writeChunksToStream(
+    name: string,
+    runId: string | Promise<string>,
+    chunks: readonly (string | Uint8Array)[],
+  ): Promise<void>;
   closeStream(name: string, runId: string | Promise<string>): Promise<void>;
-  readFromStream(name: string, startIndex?: number): Promise<ReadableStream<Uint8Array>>;
+  errorStream(
+    name: string,
+    runId: string | Promise<string>,
+    error: StreamErrorData | string,
+  ): Promise<void>;
+  readFromStream(
+    name: string,
+    runId: string,
+    startIndex?: number,
+  ): Promise<ReadableStream<Uint8Array>>;
   listStreamsByRunId(runId: string): Promise<string[]>;
   getStreamChunks(
     name: string,
@@ -37,19 +64,12 @@ export interface CelldStreamer extends Streamer {
   getStreamInfo(name: string, runId: string): Promise<StreamInfoResponse>;
 }
 
-/**
- * RPC surface of StreamDO (see durable-objects/StreamDO.ts). The streamer
- * talks to the DO exclusively via these methods — there is no fetch()
- * protocol.
- */
+/** Direct StreamDO RPC surface. Remote stubs specialize read/write as binary HTTP. */
 export interface StreamDOStub {
-  writeChunk(runId: string, data: Uint8Array): Promise<number>;
+  writeChunks(runId: string, chunks: Uint8Array[]): Promise<StreamWriteResult>;
+  readChunks(request: StreamReadRequest, signal?: AbortSignal): Promise<StreamReadResult>;
   closeStream(runId: string): Promise<void>;
-  getChunks(params: {
-    startIndex: number;
-    limit: number;
-  }): Promise<{ chunks: Uint8Array[]; done: boolean; tailIndex: number }>;
-  getInfo(): Promise<{ tailIndex: number; done: boolean }>;
+  failStream(runId: string, error: StreamErrorData | string): Promise<void>;
   registerStream(runId: string, name: string): Promise<void>;
   listStreams(): Promise<string[]>;
   expireRegistry(runId: string, expiredAt: number): Promise<ExpireRunStreamsResult>;
@@ -66,21 +86,38 @@ export interface StreamDOId {
   toString(): string;
 }
 
-/** Default poll interval while waiting for new chunks on a live stream. */
-const READ_POLL_MS = 100;
-/** Chunks fetched per DO round-trip while reading. */
-const READ_BATCH_SIZE = 32;
-/** Default / maximum page sizes for getStreamChunks. */
-const DEFAULT_CHUNK_PAGE_SIZE = 32;
-const MAX_CHUNK_PAGE_SIZE = 32;
+const DEFAULT_LONG_POLL_MS = MAX_STREAM_LONG_POLL_MS;
+const DEFAULT_CHUNK_PAGE_SIZE = MAX_STREAM_READ_CHUNKS;
+const MAX_CHUNK_PAGE_SIZE = MAX_STREAM_READ_CHUNKS;
+const REGISTERED_STREAM_CACHE_SIZE = 4096;
 
 function toBytes(chunk: string | Uint8Array): Uint8Array {
   return typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk;
 }
 
+function throwTerminal(result: StreamReadResult): void {
+  if (result.state === 'expired') throw new Error('Stream has expired');
+  if (result.state === 'errored') {
+    const error = new Error(result.error?.message ?? 'Stream failed');
+    error.name = result.error?.name ?? 'Error';
+    throw error;
+  }
+}
+
 export function createStreamer(config: CelldStreamerConfig): CelldStreamer {
   const { env } = config;
-  const readPollMs = config.readPollMs ?? READ_POLL_MS;
+  const streamLongPollMs = config.streamLongPollMs ?? DEFAULT_LONG_POLL_MS;
+  if (
+    !Number.isSafeInteger(streamLongPollMs) ||
+    streamLongPollMs < 1 ||
+    streamLongPollMs > MAX_STREAM_LONG_POLL_MS
+  ) {
+    throw new Error(`streamLongPollMs must be between 1 and ${MAX_STREAM_LONG_POLL_MS}`);
+  }
+  const streamFlushIntervalMs = config.streamFlushIntervalMs ?? 0;
+  if (!Number.isSafeInteger(streamFlushIntervalMs) || streamFlushIntervalMs < 0) {
+    throw new Error('streamFlushIntervalMs must be a non-negative safe integer');
+  }
 
   const getStreamDO = (streamName: string): StreamDOStub => {
     const id = env.WORKFLOW_STREAMS.idFromName(`stream:${streamName}`);
@@ -92,25 +129,58 @@ export function createStreamer(config: CelldStreamerConfig): CelldStreamer {
     return env.WORKFLOW_STREAMS.get(id);
   };
 
-  /** Per-isolate cache so each (runId, stream) pair registers only once. */
+  /** Bounded per-isolate cache; eviction only repeats idempotent registration. */
   const registeredStreams = new Set<string>();
 
   async function registerStreamForRun(name: string, runId: string): Promise<void> {
     const cacheKey = `${runId}\0${name}`;
     if (registeredStreams.has(cacheKey)) return;
     await getRunRegistryDO(runId).registerStream(runId, name);
+    if (registeredStreams.size >= REGISTERED_STREAM_CACHE_SIZE) {
+      const oldest = registeredStreams.values().next().value;
+      if (oldest !== undefined) registeredStreams.delete(oldest);
+    }
     registeredStreams.add(cacheKey);
   }
 
-  const writeToStream = async (
+  const writeChunksToStream = async (
+    name: string,
+    runId: string | Promise<string>,
+    input: readonly (string | Uint8Array)[],
+  ): Promise<void> => {
+    if (input.length === 0) return;
+    const resolvedRunId = await runId;
+    const chunks = input.map(toBytes);
+    for (const chunk of chunks) {
+      if (chunk.byteLength > MAX_STREAM_CHUNK_BYTES) {
+        throw new Error(`Stream chunk exceeds ${MAX_STREAM_CHUNK_BYTES} bytes`);
+      }
+    }
+    await registerStreamForRun(name, resolvedRunId);
+
+    let batch: Uint8Array[] = [];
+    let batchBytes = 0;
+    for (const chunk of chunks) {
+      if (
+        batch.length > 0 &&
+        (batch.length === MAX_STREAM_WRITE_CHUNKS ||
+          batchBytes + chunk.byteLength > MAX_STREAM_BATCH_BYTES)
+      ) {
+        await getStreamDO(name).writeChunks(resolvedRunId, batch);
+        batch = [];
+        batchBytes = 0;
+      }
+      batch.push(chunk);
+      batchBytes += chunk.byteLength;
+    }
+    if (batch.length > 0) await getStreamDO(name).writeChunks(resolvedRunId, batch);
+  };
+
+  const writeToStream = (
     name: string,
     runId: string | Promise<string>,
     chunk: string | Uint8Array,
-  ): Promise<void> => {
-    const resolvedRunId = await runId;
-    await registerStreamForRun(name, resolvedRunId);
-    await getStreamDO(name).writeChunk(resolvedRunId, toBytes(chunk));
-  };
+  ): Promise<void> => writeChunksToStream(name, runId, [chunk]);
 
   const closeStream = async (name: string, runId: string | Promise<string>): Promise<void> => {
     const resolvedRunId = await runId;
@@ -118,51 +188,80 @@ export function createStreamer(config: CelldStreamerConfig): CelldStreamer {
     await getStreamDO(name).closeStream(resolvedRunId);
   };
 
+  const errorStream = async (
+    name: string,
+    runId: string | Promise<string>,
+    error: StreamErrorData | string,
+  ): Promise<void> => {
+    const resolvedRunId = await runId;
+    await registerStreamForRun(name, resolvedRunId);
+    await getStreamDO(name).failStream(resolvedRunId, normalizeStreamError(error));
+  };
+
   const readFromStream = async (
     name: string,
+    runId: string,
     startIndex = 0,
   ): Promise<ReadableStream<Uint8Array>> => {
     const stub = getStreamDO(name);
 
-    // Negative startIndex counts back from the current end, clamped to 0.
     let nextIndex: number;
     if (startIndex < 0) {
-      const info = await stub.getInfo();
+      const info = await stub.readChunks({
+        runId,
+        startIndex: 0,
+        maxChunks: 0,
+        maxBytes: MAX_STREAM_READ_BYTES,
+        waitMs: 0,
+      });
+      throwTerminal(info);
       nextIndex = Math.max(0, info.tailIndex + 1 + startIndex);
     } else {
       nextIndex = startIndex;
     }
 
     let cancelled = false;
+    const abortController = new AbortController();
 
     return new ReadableStream<Uint8Array>({
       async pull(controller) {
-        // Loop until we can enqueue data, close, or the reader cancels.
-        // Errors from the DO propagate and error the stream — readers must
-        // never see a silently-truncated stream.
-        while (true) {
+        for (;;) {
           if (cancelled) return;
-          const { chunks, done } = await stub.getChunks({
-            startIndex: nextIndex,
-            limit: READ_BATCH_SIZE,
-          });
-          if (chunks.length > 0) {
-            for (const chunk of chunks) {
-              controller.enqueue(chunk);
-            }
-            nextIndex += chunks.length;
+          let result: StreamReadResult;
+          try {
+            result = await stub.readChunks(
+              {
+                runId,
+                startIndex: nextIndex,
+                maxChunks: MAX_STREAM_READ_CHUNKS,
+                maxBytes: MAX_STREAM_READ_BYTES,
+                waitMs: streamLongPollMs,
+              },
+              abortController.signal,
+            );
+          } catch (error) {
+            if (cancelled || abortController.signal.aborted) return;
+            throw error;
+          }
+
+          if (result.chunks.length > 0) {
+            for (const chunk of result.chunks) controller.enqueue(chunk);
+            nextIndex += result.chunks.length;
             return;
           }
-          if (done) {
+          throwTerminal(result);
+          if (result.state === 'closed') {
             controller.close();
             return;
           }
-          await new Promise((resolve) => setTimeout(resolve, readPollMs));
+          // A normal long-poll timeout returns no data; keep the pending
+          // ReadableStream read attached through the next bounded request.
         }
       },
 
       cancel() {
         cancelled = true;
+        abortController.abort(new DOMException('Stream reader cancelled', 'AbortError'));
       },
     });
   };
@@ -172,47 +271,70 @@ export function createStreamer(config: CelldStreamerConfig): CelldStreamer {
 
   const getStreamChunks = async (
     name: string,
-    _runId: string,
+    runId: string,
     options?: GetChunksOptions,
   ): Promise<StreamChunksResponse> => {
-    const limit = Math.min(options?.limit ?? DEFAULT_CHUNK_PAGE_SIZE, MAX_CHUNK_PAGE_SIZE);
+    const requestedLimit = options?.limit ?? DEFAULT_CHUNK_PAGE_SIZE;
+    if (!Number.isSafeInteger(requestedLimit) || requestedLimit < 1) {
+      throw new Error('Stream chunk limit must be a positive safe integer');
+    }
+    const limit = Math.min(requestedLimit, MAX_CHUNK_PAGE_SIZE);
     const startIndex = options?.cursor ? Number.parseInt(options.cursor, 10) : 0;
     if (Number.isNaN(startIndex) || startIndex < 0) {
       throw new Error(`Invalid stream cursor: ${options?.cursor}`);
     }
 
-    const stub = getStreamDO(name);
-    const result = await stub.getChunks({ startIndex, limit: limit + 1 });
-    const hasMore = result.chunks.length > limit;
-    const data: StreamChunk[] = result.chunks
-      .slice(0, limit)
-      .map((chunk, offset) => ({ index: startIndex + offset, data: chunk }));
+    const result = await getStreamDO(name).readChunks({
+      runId,
+      startIndex,
+      maxChunks: limit,
+      maxBytes: MAX_STREAM_READ_BYTES,
+      waitMs: 0,
+    });
+    throwTerminal(result);
+    const data: StreamChunk[] = result.chunks.map((chunk, offset) => ({
+      index: startIndex + offset,
+      data: chunk,
+    }));
+    const nextIndex = startIndex + data.length;
+    const hasMore = nextIndex <= result.tailIndex;
 
     return {
       data,
-      cursor: hasMore ? String(startIndex + limit) : null,
+      cursor: hasMore ? String(nextIndex) : null,
       hasMore,
-      done: result.done,
+      done: result.state === 'closed',
     };
   };
 
-  const getStreamInfo = (name: string, _runId: string): Promise<StreamInfoResponse> =>
-    getStreamDO(name).getInfo();
+  const getStreamInfo = async (name: string, runId: string): Promise<StreamInfoResponse> => {
+    const result = await getStreamDO(name).readChunks({
+      runId,
+      startIndex: 0,
+      maxChunks: 0,
+      maxBytes: MAX_STREAM_READ_BYTES,
+      waitMs: 0,
+    });
+    throwTerminal(result);
+    return { tailIndex: result.tailIndex, done: result.state === 'closed' };
+  };
 
   return {
+    streamFlushIntervalMs,
     streams: {
       write: (runId, name, chunk) => writeToStream(name, runId, chunk),
+      writeMulti: (runId, name, chunks) => writeChunksToStream(name, runId, chunks),
       close: (runId, name) => closeStream(name, runId),
-      get: (runId, name, startIndex) => {
-        void runId;
-        return readFromStream(name, startIndex);
-      },
+      fail: (runId, name, error) => errorStream(name, runId, error),
+      get: (runId, name, startIndex) => readFromStream(name, runId, startIndex),
       list: listStreamsByRunId,
       getChunks: (runId, name, options) => getStreamChunks(name, runId, options),
       getInfo: (runId, name) => getStreamInfo(name, runId),
     },
     writeToStream,
+    writeChunksToStream,
     closeStream,
+    errorStream,
     readFromStream,
     listStreamsByRunId,
     getStreamChunks,

--- a/src/test-mocks.ts
+++ b/src/test-mocks.ts
@@ -11,6 +11,14 @@ import { slotToEventId, type Event, type Hook, type Step, type WorkflowRun } fro
 import type { HookTokenOwner } from './config.js';
 import type { EnqueueOutcome, EnqueueRequest, QueueCellStub } from './queue.js';
 import {
+  normalizeStreamError,
+  type StreamErrorData,
+  type StreamReadRequest,
+  type StreamReadResult,
+  type StreamTerminalState,
+  type StreamWriteResult,
+} from './stream-protocol.js';
+import {
   applyEvent,
   finalizeEventPage,
   type ApplyEventOutcome,
@@ -385,44 +393,107 @@ class MockKVNamespace {
  */
 class MockStreamDOStub {
   private chunks: Uint8Array[] = [];
-  private closed = false;
+  private state: StreamTerminalState = 'open';
+  private error: StreamErrorData | undefined;
   private registry = new Set<string>();
   private ownerRunId: string | undefined;
   private expired = false;
+  private waiters = new Set<() => void>();
 
-  async writeChunk(runId: string, data: Uint8Array): Promise<number> {
+  private wake(): void {
+    for (const resolve of Array.from(this.waiters)) resolve();
+  }
+
+  async writeChunks(runId: string, data: Uint8Array[]): Promise<StreamWriteResult> {
     if (this.expired) throw new Error('Stream has expired');
     if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Stream owner mismatch');
     this.ownerRunId = runId;
-    if (this.closed) {
+    if (this.state !== 'open') {
       throw new Error('Cannot write to a closed stream');
     }
-    this.chunks.push(data);
-    return this.chunks.length - 1;
+    if (data.length === 0) throw new Error('Stream batch must not be empty');
+    const startIndex = this.chunks.length;
+    this.chunks.push(...data.map((chunk) => structuredClone(chunk)));
+    this.wake();
+    return { startIndex, count: data.length, tailIndex: this.chunks.length - 1 };
   }
 
   async closeStream(runId: string): Promise<void> {
     if (this.expired) throw new Error('Stream has expired');
     if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Stream owner mismatch');
     this.ownerRunId = runId;
-    this.closed = true;
+    if (this.state === 'open') this.state = 'closed';
+    this.wake();
   }
 
-  async getChunks(params: { startIndex: number; limit: number }): Promise<{
-    chunks: Uint8Array[];
-    done: boolean;
-    tailIndex: number;
-  }> {
-    const start = Math.max(0, params.startIndex);
-    return {
-      chunks: this.chunks.slice(start, start + params.limit),
-      done: this.closed,
-      tailIndex: this.chunks.length - 1,
+  async failStream(runId: string, error: StreamErrorData | string): Promise<void> {
+    if (this.expired) throw new Error('Stream has expired');
+    if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Stream owner mismatch');
+    this.ownerRunId = runId;
+    if (this.state === 'open') {
+      this.state = 'errored';
+      this.error = normalizeStreamError(error);
+    }
+    this.wake();
+  }
+
+  async readChunks(request: StreamReadRequest, signal?: AbortSignal): Promise<StreamReadResult> {
+    const snapshot = (timedOut: boolean): StreamReadResult => {
+      let bytes = 0;
+      const chunks: Uint8Array[] = [];
+      if (this.state !== 'expired') {
+        for (const chunk of this.chunks.slice(
+          request.startIndex,
+          request.startIndex + request.maxChunks,
+        )) {
+          if (bytes + chunk.byteLength > request.maxBytes) break;
+          chunks.push(structuredClone(chunk));
+          bytes += chunk.byteLength;
+        }
+      }
+      return {
+        startIndex: request.startIndex,
+        tailIndex: this.chunks.length - 1,
+        chunks,
+        state: this.state,
+        timedOut,
+        error: this.error,
+      };
     };
-  }
+    const immediate = snapshot(false);
+    if (
+      immediate.chunks.length > 0 ||
+      immediate.state !== 'open' ||
+      request.waitMs === 0 ||
+      request.maxChunks === 0
+    ) {
+      return immediate;
+    }
+    if (signal?.aborted) throw signal.reason;
 
-  async getInfo(): Promise<{ tailIndex: number; done: boolean }> {
-    return { tailIndex: this.chunks.length - 1, done: this.closed };
+    const timedOut = await new Promise<boolean>((resolve, reject) => {
+      let settled = false;
+      const finish = (timeout: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.waiters.delete(onChange);
+        signal?.removeEventListener('abort', onAbort);
+        resolve(timeout);
+      };
+      const onChange = () => finish(false);
+      const onAbort = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.waiters.delete(onChange);
+        reject(signal?.reason);
+      };
+      const timer = setTimeout(() => finish(true), request.waitMs);
+      this.waiters.add(onChange);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+    return snapshot(timedOut);
   }
 
   async registerStream(runId: string, name: string): Promise<void> {
@@ -454,8 +525,9 @@ class MockStreamDOStub {
     const chunks = this.chunks.length;
     this.ownerRunId = runId;
     this.chunks = [];
-    this.closed = true;
+    this.state = 'expired';
     this.expired = true;
+    this.wake();
     return { deleted: true, chunks };
   }
 }

--- a/src/test-mocks.ts
+++ b/src/test-mocks.ts
@@ -12,6 +12,8 @@ import type { HookTokenOwner } from './config.js';
 import type { EnqueueOutcome, EnqueueRequest, QueueCellStub } from './queue.js';
 import {
   normalizeStreamError,
+  validateStreamReadRequest,
+  validateStreamWriteChunks,
   type StreamErrorData,
   type StreamReadRequest,
   type StreamReadResult,
@@ -405,15 +407,15 @@ class MockStreamDOStub {
   }
 
   async writeChunks(runId: string, data: Uint8Array[]): Promise<StreamWriteResult> {
+    validateStreamWriteChunks(data);
     if (this.expired) throw new Error('Stream has expired');
     if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Stream owner mismatch');
     this.ownerRunId = runId;
     if (this.state !== 'open') {
       throw new Error('Cannot write to a closed stream');
     }
-    if (data.length === 0) throw new Error('Stream batch must not be empty');
     const startIndex = this.chunks.length;
-    this.chunks.push(...data.map((chunk) => structuredClone(chunk)));
+    this.chunks.push(...data.map((chunk) => new Uint8Array(chunk)));
     this.wake();
     return { startIndex, count: data.length, tailIndex: this.chunks.length - 1 };
   }
@@ -438,6 +440,7 @@ class MockStreamDOStub {
   }
 
   async readChunks(request: StreamReadRequest, signal?: AbortSignal): Promise<StreamReadResult> {
+    validateStreamReadRequest(request);
     const snapshot = (timedOut: boolean): StreamReadResult => {
       let bytes = 0;
       const chunks: Uint8Array[] = [];

--- a/src/testing/fake-cell.ts
+++ b/src/testing/fake-cell.ts
@@ -20,6 +20,17 @@ export interface FakeStorageMutation {
   value?: unknown;
 }
 
+export interface FakeStorageOperationCounts {
+  get: number;
+  getMany: number;
+  list: number;
+  put: number;
+  putMany: number;
+  delete: number;
+  deleteMany: number;
+  transaction: number;
+}
+
 function applyListOptions(keys: string[], options: FakeListOptions): string[] {
   let result = keys.toSorted();
   if (options.prefix !== undefined) {
@@ -55,6 +66,17 @@ function applyListOptions(keys: string[], options: FakeListOptions): string[] {
 export class FakeStorage {
   data = new Map<string, unknown>();
   alarmAt: number | null = null;
+  readonly operationCounts: FakeStorageOperationCounts = {
+    get: 0,
+    getMany: 0,
+    list: 0,
+    put: 0,
+    putMany: 0,
+    delete: 0,
+    deleteMany: 0,
+    transaction: 0,
+  };
+  private transactionTail: Promise<void> = Promise.resolve();
   private mutationFailure?: {
     predicate: (mutation: FakeStorageMutation) => boolean;
     error: Error;
@@ -62,20 +84,50 @@ export class FakeStorage {
 
   constructor(private clock: () => number = () => Date.now()) {}
 
-  async get<T>(key: string): Promise<T | undefined> {
-    return this.data.get(key) as T | undefined;
+  async get<T>(key: string): Promise<T | undefined>;
+  async get<T>(keys: string[]): Promise<Map<string, T>>;
+  async get<T>(keyOrKeys: string | string[]): Promise<T | undefined | Map<string, T>> {
+    if (Array.isArray(keyOrKeys)) {
+      this.operationCounts.getMany += 1;
+      return new Map(
+        keyOrKeys.filter((key) => this.data.has(key)).map((key) => [key, this.data.get(key) as T]),
+      );
+    }
+    this.operationCounts.get += 1;
+    return this.data.get(keyOrKeys) as T | undefined;
   }
 
-  async put<T>(key: string, value: T): Promise<void> {
-    this.maybeFailMutation({ operation: 'put', key, value });
-    // Match structured-clone persistence: mutations to the caller's object
-    // after put() must not leak into storage.
-    this.data.set(key, structuredClone(value));
+  async put<T>(key: string, value: T): Promise<void>;
+  async put<T>(entries: Record<string, T>): Promise<void>;
+  async put<T>(keyOrEntries: string | Record<string, T>, value?: T): Promise<void> {
+    if (typeof keyOrEntries === 'string') {
+      this.operationCounts.put += 1;
+      this.maybeFailMutation({ operation: 'put', key: keyOrEntries, value });
+      this.data.set(keyOrEntries, structuredClone(value));
+      return;
+    }
+    this.operationCounts.putMany += 1;
+    for (const [key, entryValue] of Object.entries(keyOrEntries)) {
+      this.maybeFailMutation({ operation: 'put', key, value: entryValue });
+    }
+    for (const [key, entryValue] of Object.entries(keyOrEntries)) {
+      this.data.set(key, structuredClone(entryValue));
+    }
   }
 
-  async delete(key: string): Promise<boolean> {
-    this.maybeFailMutation({ operation: 'delete', key });
-    return this.data.delete(key);
+  async delete(key: string): Promise<boolean>;
+  async delete(keys: string[]): Promise<number>;
+  async delete(keyOrKeys: string | string[]): Promise<boolean | number> {
+    if (typeof keyOrKeys === 'string') {
+      this.operationCounts.delete += 1;
+      this.maybeFailMutation({ operation: 'delete', key: keyOrKeys });
+      return this.data.delete(keyOrKeys);
+    }
+    this.operationCounts.deleteMany += 1;
+    for (const key of keyOrKeys) this.maybeFailMutation({ operation: 'delete', key });
+    let deleted = 0;
+    for (const key of keyOrKeys) if (this.data.delete(key)) deleted += 1;
+    return deleted;
   }
 
   async deleteAll(): Promise<void> {
@@ -83,15 +135,27 @@ export class FakeStorage {
   }
 
   async list<T>(options: FakeListOptions = {}): Promise<Map<string, T>> {
+    this.operationCounts.list += 1;
     const keys = applyListOptions(Array.from(this.data.keys()), options);
     return new Map(keys.map((k) => [k, this.data.get(k) as T]));
   }
 
   async transaction<T>(cb: (txn: FakeTransaction) => Promise<T>): Promise<T> {
-    const txn = new FakeTransaction(this);
-    const result = await cb(txn);
-    txn.commit();
-    return result;
+    this.operationCounts.transaction += 1;
+    let release!: () => void;
+    const previous = this.transactionTail;
+    this.transactionTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      const txn = new FakeTransaction(this);
+      const result = await cb(txn);
+      txn.commit();
+      return result;
+    } finally {
+      release();
+    }
   }
 
   async getAlarm(): Promise<number | null> {
@@ -108,6 +172,17 @@ export class FakeStorage {
 
   now(): number {
     return this.clock();
+  }
+
+  resetOperationCounts(): void {
+    for (const key of Object.keys(this.operationCounts) as (keyof FakeStorageOperationCounts)[]) {
+      this.operationCounts[key] = 0;
+    }
+  }
+
+  /** @internal Used by FakeTransaction to count the same platform operations. */
+  recordOperation(operation: keyof FakeStorageOperationCounts): void {
+    this.operationCounts[operation] += 1;
   }
 
   /** Inject one matching write failure, including writes inside transactions. */
@@ -134,19 +209,60 @@ class FakeTransaction {
 
   constructor(private storage: FakeStorage) {}
 
-  async get<T>(key: string): Promise<T | undefined> {
+  async get<T>(key: string): Promise<T | undefined>;
+  async get<T>(keys: string[]): Promise<Map<string, T>>;
+  async get<T>(keyOrKeys: string | string[]): Promise<T | undefined | Map<string, T>> {
+    if (Array.isArray(keyOrKeys)) {
+      this.storage.recordOperation('getMany');
+      const result = new Map<string, T>();
+      for (const key of keyOrKeys) {
+        if (this.deleted.has(key)) continue;
+        if (this.staged.has(key)) result.set(key, this.staged.get(key) as T);
+        else if (this.storage.data.has(key)) result.set(key, this.storage.data.get(key) as T);
+      }
+      return result;
+    }
+    this.storage.recordOperation('get');
+    const key = keyOrKeys;
     if (this.deleted.has(key)) return undefined;
     if (this.staged.has(key)) return this.staged.get(key) as T;
     return this.storage.data.get(key) as T | undefined;
   }
 
-  async put<T>(key: string, value: T): Promise<void> {
-    this.storage.maybeFailMutation({ operation: 'put', key, value });
-    this.deleted.delete(key);
-    this.staged.set(key, structuredClone(value));
+  async put<T>(key: string, value: T): Promise<void>;
+  async put<T>(entries: Record<string, T>): Promise<void>;
+  async put<T>(keyOrEntries: string | Record<string, T>, value?: T): Promise<void> {
+    if (typeof keyOrEntries === 'string') {
+      this.storage.recordOperation('put');
+      this.storage.maybeFailMutation({ operation: 'put', key: keyOrEntries, value });
+      this.deleted.delete(keyOrEntries);
+      this.staged.set(keyOrEntries, structuredClone(value));
+      return;
+    }
+    this.storage.recordOperation('putMany');
+    for (const [key, entryValue] of Object.entries(keyOrEntries)) {
+      this.storage.maybeFailMutation({ operation: 'put', key, value: entryValue });
+    }
+    for (const [key, entryValue] of Object.entries(keyOrEntries)) {
+      this.deleted.delete(key);
+      this.staged.set(key, structuredClone(entryValue));
+    }
   }
 
-  async delete(key: string): Promise<boolean> {
+  async delete(key: string): Promise<boolean>;
+  async delete(keys: string[]): Promise<number>;
+  async delete(keyOrKeys: string | string[]): Promise<boolean | number> {
+    if (typeof keyOrKeys === 'string') {
+      this.storage.recordOperation('delete');
+      return this.deleteOne(keyOrKeys);
+    }
+    this.storage.recordOperation('deleteMany');
+    let deleted = 0;
+    for (const key of keyOrKeys) if (this.deleteOne(key)) deleted += 1;
+    return deleted;
+  }
+
+  private deleteOne(key: string): boolean {
     this.storage.maybeFailMutation({ operation: 'delete', key });
     const existed = (!this.deleted.has(key) && this.staged.has(key)) || this.storage.data.has(key);
     this.staged.delete(key);
@@ -155,6 +271,7 @@ class FakeTransaction {
   }
 
   async list<T>(options: FakeListOptions = {}): Promise<Map<string, T>> {
+    this.storage.recordOperation('list');
     const merged = new Map(this.storage.data);
     for (const key of this.deleted) merged.delete(key);
     for (const [key, value] of this.staged) merged.set(key, value);
@@ -226,26 +343,35 @@ export class FakeFleet {
     };
   }
 
+  private instantiate(
+    bindingKey: string,
+    name: string,
+    storage: FakeStorage,
+    pendingWaits: Promise<unknown>[],
+  ): InstanceType<CellClass> {
+    const CellCtor = this.classes[bindingKey];
+    if (!CellCtor) throw new Error(`no cell class registered for binding: ${bindingKey}`);
+    const ctx = {
+      storage,
+      id: { toString: () => name, name },
+      waitUntil(promise: Promise<unknown>) {
+        pendingWaits.push(promise);
+      },
+      async blockConcurrencyWhile<T>(cb: () => Promise<T>): Promise<T> {
+        return cb();
+      },
+    };
+    return new CellCtor(ctx, this.cellEnv);
+  }
+
   cell(bindingKey: string, name: string): CellSlot {
     const key = `${bindingKey}\0${name}`;
     let slot = this.cells.get(key);
     if (!slot) {
-      const CellCtor = this.classes[bindingKey];
-      if (!CellCtor) throw new Error(`no cell class registered for binding: ${bindingKey}`);
       const storage = new FakeStorage(() => this.now);
       const pendingWaits: Promise<unknown>[] = [];
-      const ctx = {
-        storage,
-        id: { toString: () => name, name },
-        waitUntil(promise: Promise<unknown>) {
-          pendingWaits.push(promise);
-        },
-        async blockConcurrencyWhile<T>(cb: () => Promise<T>): Promise<T> {
-          return cb();
-        },
-      };
       slot = {
-        instance: new CellCtor(ctx, this.cellEnv),
+        instance: this.instantiate(bindingKey, name, storage, pendingWaits),
         storage,
         pendingWaits,
         alarmRetryCount: 0,
@@ -254,6 +380,13 @@ export class FakeFleet {
       this.cells.set(key, slot);
     }
     return slot;
+  }
+
+  /** Recreate one in-memory DO instance while preserving its durable storage. */
+  restartCell(bindingKey: string, name: string): InstanceType<CellClass> {
+    const slot = this.cell(bindingKey, name);
+    slot.instance = this.instantiate(bindingKey, name, slot.storage, slot.pendingWaits);
+    return slot.instance;
   }
 
   advance(ms: number): void {

--- a/src/testing/fake-cell.ts
+++ b/src/testing/fake-cell.ts
@@ -66,6 +66,7 @@ function applyListOptions(keys: string[], options: FakeListOptions): string[] {
 export class FakeStorage {
   data = new Map<string, unknown>();
   alarmAt: number | null = null;
+  readonly getManyCalls: string[][] = [];
   readonly operationCounts: FakeStorageOperationCounts = {
     get: 0,
     getMany: 0,
@@ -89,6 +90,7 @@ export class FakeStorage {
   async get<T>(keyOrKeys: string | string[]): Promise<T | undefined | Map<string, T>> {
     if (Array.isArray(keyOrKeys)) {
       this.operationCounts.getMany += 1;
+      this.getManyCalls.push([...keyOrKeys]);
       return new Map(
         keyOrKeys.filter((key) => this.data.has(key)).map((key) => [key, this.data.get(key) as T]),
       );
@@ -178,6 +180,7 @@ export class FakeStorage {
     for (const key of Object.keys(this.operationCounts) as (keyof FakeStorageOperationCounts)[]) {
       this.operationCounts[key] = 0;
     }
+    this.getManyCalls.length = 0;
   }
 
   /** @internal Used by FakeTransaction to count the same platform operations. */

--- a/src/testing/http-harness.ts
+++ b/src/testing/http-harness.ts
@@ -62,6 +62,17 @@ export async function startHarness(options: HarnessOptions = {}): Promise<Harnes
   const router = createRouter(env);
 
   const server = http.createServer(async (req, res) => {
+    const requestAbort = new AbortController();
+    const abortRequest = () => {
+      if (!requestAbort.signal.aborted) {
+        requestAbort.abort(new DOMException('HTTP client disconnected', 'AbortError'));
+      }
+    };
+    const abortOnPrematureClose = () => {
+      if (!res.writableEnded) abortRequest();
+    };
+    req.once('aborted', abortRequest);
+    res.once('close', abortOnPrematureClose);
     try {
       const chunks: Buffer[] = [];
       for await (const chunk of req) {
@@ -72,13 +83,19 @@ export async function startHarness(options: HarnessOptions = {}): Promise<Harnes
         method: req.method,
         headers: req.headers as Record<string, string>,
         body: req.method === 'GET' || req.method === 'HEAD' || body.length === 0 ? null : body,
+        signal: requestAbort.signal,
       });
       const response = await router(request);
+      if (requestAbort.signal.aborted || res.destroyed) return;
       res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
       res.end(Buffer.from(await response.arrayBuffer()));
     } catch (error) {
+      if (requestAbort.signal.aborted || res.destroyed) return;
       res.writeHead(500, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: { name: 'HarnessError', message: String(error) } }));
+    } finally {
+      req.off('aborted', abortRequest);
+      res.off('close', abortOnPrematureClose);
     }
   });
 

--- a/src/worker/durable-objects/StreamDO.ts
+++ b/src/worker/durable-objects/StreamDO.ts
@@ -1,5 +1,6 @@
 import type { ExpireRunStreamsResult, ExpireStreamResult } from '../../retention.js';
 import {
+  MAX_STREAM_CHUNK_BYTES,
   normalizeStreamError,
   validateStreamReadRequest,
   validateStreamWriteChunks,
@@ -31,6 +32,7 @@ interface StreamWaiter {
 
 const META_KEY = 'meta';
 const CHUNK_KEY_PREFIX = 'chunk:';
+const CHUNK_SIZE_KEY_PREFIX = 'chunk-size:';
 /** Registry keys used when this DO instance acts as a per-run stream index. */
 const STREAM_REGISTRY_PREFIX = 'stream:';
 const REGISTRY_OWNER_KEY = 'registry:owner';
@@ -59,6 +61,28 @@ function validateMeta(meta: StreamMeta): StreamMeta {
 /** Zero-padding keeps storage.list() results in stream offset order. */
 function chunkKey(index: number): string {
   return `${CHUNK_KEY_PREFIX}${index.toString().padStart(12, '0')}`;
+}
+
+function chunkSizeKey(index: number): string {
+  return `${CHUNK_SIZE_KEY_PREFIX}${index.toString().padStart(12, '0')}`;
+}
+
+function validateChunkSize(size: unknown, index: number): number {
+  if (
+    typeof size !== 'number' ||
+    !Number.isSafeInteger(size) ||
+    size < 0 ||
+    size > MAX_STREAM_CHUNK_BYTES
+  ) {
+    throw new Error(`Invalid persisted stream chunk size at index ${index}`);
+  }
+  return size;
+}
+
+function compactChunk(chunk: Uint8Array): Uint8Array {
+  return chunk.byteOffset === 0 && chunk.byteLength === chunk.buffer.byteLength
+    ? chunk
+    : new Uint8Array(chunk);
 }
 
 function abortReason(signal: AbortSignal): unknown {
@@ -180,16 +204,28 @@ export class StreamDO extends DurableObject {
         : Math.max(0, Math.min(request.maxChunks, meta.count - request.startIndex));
     const chunks: Uint8Array[] = [];
     if (available > 0) {
-      const entries = await this.ctx.storage.list<Uint8Array>({
-        prefix: CHUNK_KEY_PREFIX,
-        start: chunkKey(request.startIndex),
-        limit: available,
-      });
+      const indexes = Array.from({ length: available }, (_, offset) => request.startIndex + offset);
+      const sizeKeys = indexes.map(chunkSizeKey);
+      const storedSizes = await this.ctx.storage.get<number>(sizeKeys);
+      const selectedIndexes: number[] = [];
+      const selectedSizes: number[] = [];
       let bytes = 0;
-      for (const chunk of entries.values()) {
-        if (bytes + chunk.byteLength > request.maxBytes) break;
+      for (const index of indexes) {
+        const size = validateChunkSize(storedSizes.get(chunkSizeKey(index)), index);
+        if (bytes + size > request.maxBytes) break;
+        selectedIndexes.push(index);
+        selectedSizes.push(size);
+        bytes += size;
+      }
+
+      const payloadKeys = selectedIndexes.map(chunkKey);
+      const storedChunks = await this.ctx.storage.get<Uint8Array>(payloadKeys);
+      for (let offset = 0; offset < payloadKeys.length; offset++) {
+        const chunk = storedChunks.get(payloadKeys[offset]);
+        if (!(chunk instanceof Uint8Array) || chunk.byteLength !== selectedSizes[offset]) {
+          throw new Error(`Invalid persisted stream chunk at index ${selectedIndexes[offset]}`);
+        }
         chunks.push(chunk);
-        bytes += chunk.byteLength;
       }
     }
 
@@ -206,6 +242,7 @@ export class StreamDO extends DurableObject {
   /** Append one bounded binary batch with contiguous indexes. */
   async writeChunks(runId: string, chunks: Uint8Array[]): Promise<StreamWriteResult> {
     validateStreamWriteChunks(chunks);
+    const storedChunks = chunks.map(compactChunk);
     return await this.runMutation(async () => {
       const committed = await this.ctx.storage.transaction(async (txn) => {
         const stored = await txn.get<StreamMeta>(META_KEY);
@@ -220,9 +257,11 @@ export class StreamDO extends DurableObject {
           state: 'open',
           ownerRunId: runId,
         };
-        const entries: Record<string, StreamMeta | Uint8Array> = { [META_KEY]: nextMeta };
-        for (let offset = 0; offset < chunks.length; offset++) {
-          entries[chunkKey(startIndex + offset)] = chunks[offset];
+        const entries: Record<string, StreamMeta | Uint8Array | number> = { [META_KEY]: nextMeta };
+        for (let offset = 0; offset < storedChunks.length; offset++) {
+          const index = startIndex + offset;
+          entries[chunkKey(index)] = storedChunks[offset];
+          entries[chunkSizeKey(index)] = storedChunks[offset].byteLength;
         }
         await txn.put(entries);
         return {
@@ -393,10 +432,13 @@ export class StreamDO extends DurableObject {
       this.wakeReaders();
 
       if (!fenced.alreadyDeleted) {
-        for (let offset = 0; offset < fenced.chunkCount; offset += RETENTION_DELETE_BATCH) {
+        const deleteIndexesPerBatch = Math.floor(RETENTION_DELETE_BATCH / 2);
+        for (let offset = 0; offset < fenced.chunkCount; offset += deleteIndexesPerBatch) {
           const keys: string[] = [];
-          const end = Math.min(fenced.chunkCount, offset + RETENTION_DELETE_BATCH);
-          for (let index = offset; index < end; index++) keys.push(chunkKey(index));
+          const end = Math.min(fenced.chunkCount, offset + deleteIndexesPerBatch);
+          for (let index = offset; index < end; index++) {
+            keys.push(chunkKey(index), chunkSizeKey(index));
+          }
           await this.ctx.storage.delete(keys);
         }
         const tombstone: StreamMeta = {

--- a/src/worker/durable-objects/StreamDO.ts
+++ b/src/worker/durable-objects/StreamDO.ts
@@ -1,13 +1,32 @@
-import { DurableObject } from '../do-base.js';
 import type { ExpireRunStreamsResult, ExpireStreamResult } from '../../retention.js';
+import {
+  normalizeStreamError,
+  validateStreamReadRequest,
+  validateStreamWriteChunks,
+  type StreamErrorData,
+  type StreamReadRequest,
+  type StreamReadResult,
+  type StreamTerminalState,
+  type StreamWriteResult,
+} from '../../stream-protocol.js';
+import { DurableObject } from '../do-base.js';
 
 interface StreamMeta {
-  /** Number of chunks written so far (also the next chunk index). */
+  /** Number of durable chunks (also the next chunk index). */
   count: number;
-  /** Whether the stream has been closed (EOF). */
-  closed: boolean;
+  state: StreamTerminalState;
   ownerRunId?: string;
+  error?: StreamErrorData;
   expiredAt?: number;
+  expiredChunkCount?: number;
+  payloadDeleted?: boolean;
+}
+
+interface StreamWaiter {
+  resolve(reason: 'change' | 'timeout'): void;
+  timer: ReturnType<typeof setTimeout>;
+  signal?: AbortSignal;
+  onAbort?: () => void;
 }
 
 const META_KEY = 'meta';
@@ -16,115 +35,278 @@ const CHUNK_KEY_PREFIX = 'chunk:';
 const STREAM_REGISTRY_PREFIX = 'stream:';
 const REGISTRY_OWNER_KEY = 'registry:owner';
 const REGISTRY_EXPIRED_KEY = 'registry:expired';
+const RETENTION_DELETE_BATCH = 128;
 
-/**
- * Zero-pad chunk indexes so `storage.list({ prefix })` returns chunks in
- * write order. 12 digits comfortably exceeds any realistic chunk count.
- */
+function emptyMeta(): StreamMeta {
+  return { count: 0, state: 'open' };
+}
+
+function validateMeta(meta: StreamMeta): StreamMeta {
+  if (
+    !Number.isSafeInteger(meta.count) ||
+    meta.count < 0 ||
+    meta.count > 0x7fffffff ||
+    !['open', 'closed', 'errored', 'expired'].includes(meta.state)
+  ) {
+    throw new Error('Invalid persisted stream metadata');
+  }
+  if (meta.state === 'errored' && !meta.error) {
+    throw new Error('Invalid persisted stream error metadata');
+  }
+  return meta;
+}
+
+/** Zero-padding keeps storage.list() results in stream offset order. */
 function chunkKey(index: number): string {
   return `${CHUNK_KEY_PREFIX}${index.toString().padStart(12, '0')}`;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
 }
 
 /**
  * Durable Object backing workflow streams.
  *
- * Two roles, selected by the DO name:
- * - `stream:<name>`: chunk storage for a single stream. A monotonic
- *   per-stream counter (maintained transactionally inside the DO) assigns
- *   each chunk its index; one chunk per storage key.
- * - `run-streams:<runId>`: registry of stream names owned by a run,
- *   powering `listStreamsByRunId`.
+ * Stream cells persist binary chunks under monotonic offset keys. Public
+ * reads are bounded long polls, and writes append a bounded ordered batch in
+ * one storage transaction. Per-run registry cells retain their existing role.
  */
 export class StreamDO extends DurableObject {
+  private meta: StreamMeta | undefined;
+  private metaLoad: Promise<StreamMeta> | undefined;
+  private mutationTail: Promise<void> = Promise.resolve();
+  private changeVersion = 0;
+  private readonly waiters = new Set<StreamWaiter>();
+
   private async getMeta(): Promise<StreamMeta> {
-    const meta = await this.ctx.storage.get<StreamMeta>(META_KEY);
-    return meta ?? { count: 0, closed: false };
+    if (this.meta) return this.meta;
+    this.metaLoad ??= this.ctx.storage.get<StreamMeta>(META_KEY).then((meta) => {
+      const loaded = meta ? validateMeta(meta) : emptyMeta();
+      this.meta = loaded;
+      return loaded;
+    });
+    try {
+      return await this.metaLoad;
+    } catch (error) {
+      this.metaLoad = undefined;
+      throw error;
+    }
   }
 
   private assertOwner(meta: StreamMeta, runId: string): void {
-    if (meta.expiredAt !== undefined) {
-      throw new Error(`Workflow run "${runId}" has expired`);
-    }
+    if (!runId) throw new Error('Stream runId is required');
     if (meta.ownerRunId !== undefined && meta.ownerRunId !== runId) {
       throw new Error(`Stream is owned by workflow run "${meta.ownerRunId}"`);
     }
   }
 
-  /**
-   * Append a chunk. The index is allocated inside the transaction, so
-   * concurrent writers can never collide or skip.
-   */
-  async writeChunk(runId: string, data: Uint8Array): Promise<number> {
-    return await this.ctx.storage.transaction(async (txn) => {
-      const meta = (await txn.get<StreamMeta>(META_KEY)) ?? { count: 0, closed: false };
-      this.assertOwner(meta, runId);
-      if (meta.closed) {
-        throw new Error('Cannot write to a closed stream');
-      }
-      const index = meta.count;
-      await txn.put(chunkKey(index), data);
-      await txn.put<StreamMeta>(META_KEY, {
-        count: index + 1,
-        closed: false,
-        ownerRunId: runId,
-      });
-      return index;
+  private assertWritable(meta: StreamMeta, runId: string): void {
+    this.assertOwner(meta, runId);
+    if (meta.state === 'expired') throw new Error(`Workflow run "${runId}" has expired`);
+    if (meta.state === 'closed') throw new Error('Cannot write to a closed stream');
+    if (meta.state === 'errored') throw new Error('Cannot write to an errored stream');
+  }
+
+  private runMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.mutationTail.then(operation, operation);
+    this.mutationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private wakeReaders(): void {
+    this.changeVersion += 1;
+    for (const waiter of Array.from(this.waiters)) waiter.resolve('change');
+  }
+
+  private waitForChange(
+    observedVersion: number,
+    waitMs: number,
+    signal?: AbortSignal,
+  ): Promise<'change' | 'timeout'> {
+    if (signal?.aborted) return Promise.reject(abortReason(signal));
+
+    return new Promise<'change' | 'timeout'>((resolve, reject) => {
+      let settled = false;
+      const waiter: StreamWaiter = {
+        timer: setTimeout(() => finish('timeout'), waitMs),
+        signal,
+        resolve: (reason) => finish(reason),
+      };
+
+      const cleanup = () => {
+        clearTimeout(waiter.timer);
+        this.waiters.delete(waiter);
+        if (waiter.signal && waiter.onAbort) {
+          waiter.signal.removeEventListener('abort', waiter.onAbort);
+        }
+      };
+      const finish = (reason: 'change' | 'timeout') => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(reason);
+      };
+      waiter.onAbort = () => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(abortReason(signal!));
+      };
+
+      this.waiters.add(waiter);
+      signal?.addEventListener('abort', waiter.onAbort, { once: true });
+
+      // A writer may have committed after the caller inspected metadata but
+      // before this waiter was installed. The generation check closes that
+      // lost-wakeup window without another storage read.
+      if (this.changeVersion !== observedVersion) finish('change');
     });
   }
 
-  /**
-   * Close the stream (idempotent). Readers observe `done: true` once all
-   * previously written chunks have been consumed.
-   */
-  async closeStream(runId: string): Promise<void> {
-    await this.ctx.storage.transaction(async (txn) => {
-      const meta = (await txn.get<StreamMeta>(META_KEY)) ?? { count: 0, closed: false };
-      this.assertOwner(meta, runId);
-      await txn.put<StreamMeta>(META_KEY, { ...meta, ownerRunId: runId, closed: true });
-    });
-  }
-
-  /**
-   * Read up to `limit` chunks starting at `startIndex` (0-based, inclusive).
-   */
-  async getChunks(params: { startIndex: number; limit: number }): Promise<{
-    chunks: Uint8Array[];
-    /** Whether the stream is closed. */
-    done: boolean;
-    /** Index of the last written chunk, -1 when empty. */
-    tailIndex: number;
-  }> {
+  private async readSnapshot(
+    request: StreamReadRequest,
+    timedOut: boolean,
+  ): Promise<StreamReadResult> {
     const meta = await this.getMeta();
-    if (meta.expiredAt !== undefined) {
-      throw new Error('Stream has expired');
+    this.assertOwner(meta, request.runId);
+
+    const available =
+      meta.state === 'expired'
+        ? 0
+        : Math.max(0, Math.min(request.maxChunks, meta.count - request.startIndex));
+    const chunks: Uint8Array[] = [];
+    if (available > 0) {
+      const entries = await this.ctx.storage.list<Uint8Array>({
+        prefix: CHUNK_KEY_PREFIX,
+        start: chunkKey(request.startIndex),
+        limit: available,
+      });
+      let bytes = 0;
+      for (const chunk of entries.values()) {
+        if (bytes + chunk.byteLength > request.maxBytes) break;
+        chunks.push(chunk);
+        bytes += chunk.byteLength;
+      }
     }
-    const start = Math.max(0, params.startIndex);
-    const entries = await this.ctx.storage.list<Uint8Array>({
-      prefix: CHUNK_KEY_PREFIX,
-      start: chunkKey(start),
-      limit: params.limit,
-    });
+
     return {
-      chunks: Array.from(entries.values()),
-      done: meta.closed,
+      startIndex: request.startIndex,
       tailIndex: meta.count - 1,
+      chunks,
+      state: meta.state,
+      timedOut,
+      error: meta.error,
     };
   }
 
-  /**
-   * Lightweight stream metadata: last chunk index and completion flag.
-   */
-  async getInfo(): Promise<{ tailIndex: number; done: boolean }> {
-    const meta = await this.getMeta();
-    if (meta.expiredAt !== undefined) {
-      throw new Error('Stream has expired');
-    }
-    return { tailIndex: meta.count - 1, done: meta.closed };
+  /** Append one bounded binary batch with contiguous indexes. */
+  async writeChunks(runId: string, chunks: Uint8Array[]): Promise<StreamWriteResult> {
+    validateStreamWriteChunks(chunks);
+    return await this.runMutation(async () => {
+      const committed = await this.ctx.storage.transaction(async (txn) => {
+        const stored = await txn.get<StreamMeta>(META_KEY);
+        const meta = stored ? validateMeta(stored) : emptyMeta();
+        this.assertWritable(meta, runId);
+        const startIndex = meta.count;
+        if (startIndex + chunks.length > 0x7fffffff) {
+          throw new Error('Stream offset limit exceeded');
+        }
+        const nextMeta: StreamMeta = {
+          count: startIndex + chunks.length,
+          state: 'open',
+          ownerRunId: runId,
+        };
+        const entries: Record<string, StreamMeta | Uint8Array> = { [META_KEY]: nextMeta };
+        for (let offset = 0; offset < chunks.length; offset++) {
+          entries[chunkKey(startIndex + offset)] = chunks[offset];
+        }
+        await txn.put(entries);
+        return {
+          meta: nextMeta,
+          result: {
+            startIndex,
+            count: chunks.length,
+            tailIndex: nextMeta.count - 1,
+          } satisfies StreamWriteResult,
+        };
+      });
+      this.meta = committed.meta;
+      this.metaLoad = Promise.resolve(committed.meta);
+      this.wakeReaders();
+      return committed.result;
+    });
   }
 
   /**
-   * Register a stream name against this per-run registry instance.
+   * Return available binary chunks and terminal metadata in one bounded
+   * operation, waiting at most waitMs when the requested offset is idle.
    */
+  async readChunks(request: StreamReadRequest, signal?: AbortSignal): Promise<StreamReadResult> {
+    validateStreamReadRequest(request);
+    const observedVersion = this.changeVersion;
+    const immediate = await this.readSnapshot(request, false);
+    if (
+      immediate.chunks.length > 0 ||
+      immediate.state !== 'open' ||
+      request.waitMs === 0 ||
+      request.maxChunks === 0
+    ) {
+      return immediate;
+    }
+
+    const reason = await this.waitForChange(observedVersion, request.waitMs, signal);
+    return await this.readSnapshot(request, reason === 'timeout');
+  }
+
+  /** Close idempotently; the first terminal state wins. */
+  async closeStream(runId: string): Promise<void> {
+    await this.runMutation(async () => {
+      const nextMeta = await this.ctx.storage.transaction(async (txn) => {
+        const stored = await txn.get<StreamMeta>(META_KEY);
+        const meta = stored ? validateMeta(stored) : emptyMeta();
+        this.assertOwner(meta, runId);
+        if (meta.state === 'expired') throw new Error(`Workflow run "${runId}" has expired`);
+        if (meta.state !== 'open') return meta;
+        const closed: StreamMeta = { ...meta, ownerRunId: runId, state: 'closed' };
+        await txn.put(META_KEY, closed);
+        return closed;
+      });
+      this.meta = nextMeta;
+      this.metaLoad = Promise.resolve(nextMeta);
+      this.wakeReaders();
+    });
+  }
+
+  /** Persist a terminal stream failure and wake every pending reader. */
+  async failStream(runId: string, error: StreamErrorData | string): Promise<void> {
+    const normalized = normalizeStreamError(error);
+    await this.runMutation(async () => {
+      const nextMeta = await this.ctx.storage.transaction(async (txn) => {
+        const stored = await txn.get<StreamMeta>(META_KEY);
+        const meta = stored ? validateMeta(stored) : emptyMeta();
+        this.assertOwner(meta, runId);
+        if (meta.state === 'expired') throw new Error(`Workflow run "${runId}" has expired`);
+        if (meta.state !== 'open') return meta;
+        const failed: StreamMeta = {
+          ...meta,
+          ownerRunId: runId,
+          state: 'errored',
+          error: normalized,
+        };
+        await txn.put(META_KEY, failed);
+        return failed;
+      });
+      this.meta = nextMeta;
+      this.metaLoad = Promise.resolve(nextMeta);
+      this.wakeReaders();
+    });
+  }
+
+  /** Register a stream name against this per-run registry instance. */
   async registerStream(runId: string, name: string): Promise<void> {
     await this.ctx.storage.transaction(async (txn) => {
       if ((await txn.get(REGISTRY_EXPIRED_KEY)) !== undefined) {
@@ -139,9 +321,6 @@ export class StreamDO extends DurableObject {
     });
   }
 
-  /**
-   * List stream names registered against this per-run registry instance.
-   */
   async listStreams(): Promise<string[]> {
     if ((await this.ctx.storage.get(REGISTRY_EXPIRED_KEY)) !== undefined) {
       throw new Error('Workflow run streams have expired');
@@ -175,28 +354,62 @@ export class StreamDO extends DurableObject {
         throw new Error(`Stream registry for workflow run "${runId}" is not expired`);
       }
       const entries = await txn.list({ prefix: STREAM_REGISTRY_PREFIX });
-      for (const key of entries.keys()) await txn.delete(key);
+      const keys = Array.from(entries.keys());
+      for (let offset = 0; offset < keys.length; offset += RETENTION_DELETE_BATCH) {
+        await txn.delete(keys.slice(offset, offset + RETENTION_DELETE_BATCH));
+      }
     });
   }
 
-  /** Delete stream payload while leaving a small ownership tombstone. */
+  /**
+   * Fence first, wake readers, then delete known chunk keys in bounded groups.
+   * The tombstone records progress so restart/retry remains idempotent.
+   */
   async expireStream(runId: string, expiredAt: number): Promise<ExpireStreamResult> {
-    return await this.ctx.storage.transaction(async (txn) => {
-      const meta = (await txn.get<StreamMeta>(META_KEY)) ?? { count: 0, closed: false };
-      if (meta.ownerRunId !== undefined && meta.ownerRunId !== runId) {
-        throw new Error(`Stream is owned by workflow run "${meta.ownerRunId}"`);
-      }
-      const chunks = await txn.list({ prefix: CHUNK_KEY_PREFIX });
-      for (const key of chunks.keys()) {
-        await txn.delete(key);
-      }
-      await txn.put<StreamMeta>(META_KEY, {
-        count: 0,
-        closed: true,
-        ownerRunId: runId,
-        expiredAt,
+    return await this.runMutation(async () => {
+      const fenced = await this.ctx.storage.transaction(async (txn) => {
+        const stored = await txn.get<StreamMeta>(META_KEY);
+        const meta = stored ? validateMeta(stored) : emptyMeta();
+        this.assertOwner(meta, runId);
+        const chunkCount = meta.expiredChunkCount ?? meta.count;
+        if (meta.state === 'expired' && meta.payloadDeleted) {
+          return { meta, chunkCount, alreadyDeleted: true };
+        }
+        const nextMeta: StreamMeta = {
+          ...meta,
+          ownerRunId: runId,
+          state: 'expired',
+          error: undefined,
+          expiredAt,
+          expiredChunkCount: chunkCount,
+          payloadDeleted: false,
+        };
+        await txn.put(META_KEY, nextMeta);
+        return { meta: nextMeta, chunkCount, alreadyDeleted: false };
       });
-      return { deleted: true, chunks: chunks.size };
+
+      this.meta = fenced.meta;
+      this.metaLoad = Promise.resolve(fenced.meta);
+      this.wakeReaders();
+
+      if (!fenced.alreadyDeleted) {
+        for (let offset = 0; offset < fenced.chunkCount; offset += RETENTION_DELETE_BATCH) {
+          const keys: string[] = [];
+          const end = Math.min(fenced.chunkCount, offset + RETENTION_DELETE_BATCH);
+          for (let index = offset; index < end; index++) keys.push(chunkKey(index));
+          await this.ctx.storage.delete(keys);
+        }
+        const tombstone: StreamMeta = {
+          ...fenced.meta,
+          count: 0,
+          payloadDeleted: true,
+        };
+        await this.ctx.storage.put(META_KEY, tombstone);
+        this.meta = tombstone;
+        this.metaLoad = Promise.resolve(tombstone);
+      }
+
+      return { deleted: true, chunks: fenced.chunkCount };
     });
   }
 }

--- a/src/worker/router.ts
+++ b/src/worker/router.ts
@@ -4,13 +4,27 @@
  * Routes:
  *   GET  /v1/health                              — liveness + spec version (unauthenticated)
  *   POST /v1/rpc/{binding}/{name}/{method}       — DO RPC (bearer auth)
+ *   GET  /v1/streams/{name}/chunks               — bounded binary long-poll read
+ *   POST /v1/streams/{name}/chunks               — bounded binary batch append
  *
- * The RPC body is an rpc-codec-encoded JSON array of arguments; the response
- * body is the rpc-codec-encoded return value. Only whitelisted methods
- * dispatch — everything else (including fetch/alarm) is unreachable.
+ * Generic RPC bodies use the tagged JSON codec. Stream chunk bodies use the
+ * compact binary stream protocol. Only whitelisted routes/methods dispatch.
  */
 import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { rpcParse, rpcStringify } from '../codec.js';
+import {
+  MAX_STREAM_BATCH_BYTES,
+  MAX_STREAM_LONG_POLL_MS,
+  MAX_STREAM_READ_BYTES,
+  MAX_STREAM_READ_CHUNKS,
+  STREAM_BATCH_CONTENT_TYPE,
+  decodeStreamWriteBatch,
+  encodeStreamReadResult,
+  encodeStreamWriteResult,
+  type StreamReadRequest,
+  type StreamReadResult,
+  type StreamWriteResult,
+} from '../stream-protocol.js';
 import { authenticate } from './auth.js';
 
 export const WORLD_NAME = 'world-celld';
@@ -50,10 +64,8 @@ const BINDINGS: Record<string, { env: keyof WorkerEnv; methods: ReadonlySet<stri
   streams: {
     env: 'WORKFLOW_STREAMS',
     methods: new Set([
-      'writeChunk',
       'closeStream',
-      'getChunks',
-      'getInfo',
+      'failStream',
       'registerStream',
       'listStreams',
       'expireRegistry',
@@ -92,6 +104,7 @@ const BINDINGS: Record<string, { env: keyof WorkerEnv; methods: ReadonlySet<stri
 
 /** Request body cap: oversize payloads get a clear 413 instead of an OOM. */
 const MAX_BODY_BYTES = 32 * 1024 * 1024;
+const MAX_STREAM_WRITE_BODY_BYTES = MAX_STREAM_BATCH_BYTES + 1024;
 
 function errorResponse(status: number, name: string, message: string): Response {
   return Response.json({ error: { name, message } }, { status });
@@ -120,6 +133,52 @@ async function readBoundedBody(request: Request): Promise<string | null> {
   }
 }
 
+async function readBoundedBytes(request: Request, maxBytes: number): Promise<Uint8Array | null> {
+  if (!request.body) return new Uint8Array();
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel('stream body exceeds configured limit').catch(() => undefined);
+        return null;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+function parseBoundedInteger(url: URL, name: string, minimum: number, maximum: number): number {
+  const raw = url.searchParams.get(name);
+  const value = raw === null ? Number.NaN : Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    const error = new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+    error.name = 'StreamProtocolError';
+    throw error;
+  }
+  return value;
+}
+
+function streamResponse(body: Uint8Array): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': STREAM_BATCH_CONTENT_TYPE },
+  });
+}
+
 export function createRouter(env: WorkerEnv) {
   return async (request: Request): Promise<Response> => {
     const url = new URL(request.url);
@@ -138,13 +197,78 @@ export function createRouter(env: WorkerEnv) {
       });
     }
 
-    if (parts[1] !== 'rpc') {
-      return errorResponse(404, 'NotFound', `unknown path: ${url.pathname}`);
-    }
-
     const auth = await authenticate(request, env.WORLD_SECRET);
     if (!auth.ok) {
       return auth.response;
+    }
+
+    if (parts[1] === 'streams' && parts.length === 4 && parts[3] === 'chunks') {
+      const namespace = env.WORKFLOW_STREAMS;
+      if (!namespace) {
+        return errorResponse(500, 'WorldMisconfigured', 'missing binding: WORKFLOW_STREAMS');
+      }
+      const name = decodeURIComponent(parts[2]);
+      const runId = url.searchParams.get('runId');
+      if (!runId) return errorResponse(400, 'BadRequest', 'runId is required');
+      const stub = namespace.get(namespace.idFromName(name)) as {
+        writeChunks(runId: string, chunks: Uint8Array[]): Promise<StreamWriteResult>;
+        readChunks(request: StreamReadRequest): Promise<StreamReadResult>;
+      };
+
+      try {
+        if (request.method === 'POST') {
+          if (!request.headers.get('content-type')?.startsWith(STREAM_BATCH_CONTENT_TYPE)) {
+            return errorResponse(415, 'UnsupportedMediaType', STREAM_BATCH_CONTENT_TYPE);
+          }
+          const contentLength = Number(request.headers.get('content-length') ?? '0');
+          if (contentLength > MAX_STREAM_WRITE_BODY_BYTES) {
+            return errorResponse(
+              413,
+              'PayloadTooLarge',
+              `body exceeds ${MAX_STREAM_WRITE_BODY_BYTES} bytes`,
+            );
+          }
+          const body = await readBoundedBytes(request, MAX_STREAM_WRITE_BODY_BYTES);
+          if (body === null) {
+            return errorResponse(
+              413,
+              'PayloadTooLarge',
+              `body exceeds ${MAX_STREAM_WRITE_BODY_BYTES} bytes`,
+            );
+          }
+          const result = await stub.writeChunks(runId, decodeStreamWriteBatch(body));
+          return streamResponse(encodeStreamWriteResult(result));
+        }
+
+        if (request.method === 'GET') {
+          const result = await stub.readChunks({
+            runId,
+            startIndex: parseBoundedInteger(url, 'startIndex', 0, 0x7fffffff),
+            maxChunks: parseBoundedInteger(url, 'maxChunks', 0, MAX_STREAM_READ_CHUNKS),
+            maxBytes: parseBoundedInteger(url, 'maxBytes', 1, MAX_STREAM_READ_BYTES),
+            waitMs: parseBoundedInteger(url, 'waitMs', 0, MAX_STREAM_LONG_POLL_MS),
+          });
+          return streamResponse(encodeStreamReadResult(result));
+        }
+
+        return errorResponse(405, 'MethodNotAllowed', 'expected GET or POST');
+      } catch (error) {
+        const err = error as { name?: string; message?: string; status?: number };
+        return Response.json(
+          {
+            error: {
+              name: err?.name ?? 'Error',
+              message: err?.message ?? String(error),
+              status: typeof err?.status === 'number' ? err.status : undefined,
+            },
+          },
+          { status: err?.name === 'StreamProtocolError' ? 400 : 500 },
+        );
+      }
+    }
+
+    if (parts[1] !== 'rpc') {
+      return errorResponse(404, 'NotFound', `unknown path: ${url.pathname}`);
     }
 
     if (request.method !== 'POST' || parts.length !== 5) {

--- a/src/worker/router.ts
+++ b/src/worker/router.ts
@@ -14,6 +14,7 @@ import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { rpcParse, rpcStringify } from '../codec.js';
 import {
   MAX_STREAM_BATCH_BYTES,
+  MAX_STREAM_CHUNK_BYTES,
   MAX_STREAM_LONG_POLL_MS,
   MAX_STREAM_READ_BYTES,
   MAX_STREAM_READ_CHUNKS,
@@ -212,7 +213,7 @@ export function createRouter(env: WorkerEnv) {
       if (!runId) return errorResponse(400, 'BadRequest', 'runId is required');
       const stub = namespace.get(namespace.idFromName(name)) as {
         writeChunks(runId: string, chunks: Uint8Array[]): Promise<StreamWriteResult>;
-        readChunks(request: StreamReadRequest): Promise<StreamReadResult>;
+        readChunks(request: StreamReadRequest, signal?: AbortSignal): Promise<StreamReadResult>;
       };
 
       try {
@@ -241,13 +242,21 @@ export function createRouter(env: WorkerEnv) {
         }
 
         if (request.method === 'GET') {
-          const result = await stub.readChunks({
-            runId,
-            startIndex: parseBoundedInteger(url, 'startIndex', 0, 0x7fffffff),
-            maxChunks: parseBoundedInteger(url, 'maxChunks', 0, MAX_STREAM_READ_CHUNKS),
-            maxBytes: parseBoundedInteger(url, 'maxBytes', 1, MAX_STREAM_READ_BYTES),
-            waitMs: parseBoundedInteger(url, 'waitMs', 0, MAX_STREAM_LONG_POLL_MS),
-          });
+          const result = await stub.readChunks(
+            {
+              runId,
+              startIndex: parseBoundedInteger(url, 'startIndex', 0, 0x7fffffff),
+              maxChunks: parseBoundedInteger(url, 'maxChunks', 0, MAX_STREAM_READ_CHUNKS),
+              maxBytes: parseBoundedInteger(
+                url,
+                'maxBytes',
+                MAX_STREAM_CHUNK_BYTES,
+                MAX_STREAM_READ_BYTES,
+              ),
+              waitMs: parseBoundedInteger(url, 'waitMs', 0, MAX_STREAM_LONG_POLL_MS),
+            },
+            request.signal,
+          );
           return streamResponse(encodeStreamReadResult(result));
         }
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -4,10 +4,12 @@
  */
 import { WorkflowRunNotFoundError } from '@workflow/errors';
 import { createConnection } from 'node:net';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { rpcStringify } from '../src/codec.js';
 import { createRemoteEnv } from '../src/remote/namespaces.js';
 import {
+  MAX_STREAM_CHUNK_BYTES,
+  MAX_STREAM_READ_BYTES,
   MAX_STREAM_WRITE_CHUNKS,
   STREAM_BATCH_CONTENT_TYPE,
   decodeStreamWriteBatch,
@@ -125,6 +127,15 @@ describe('router auth and shape', () => {
       body: new Uint8Array(),
     });
     expect(malformed.status).toBe(400);
+
+    const undersizedRead = await fetch(
+      `${harness.url}${path}&startIndex=0&maxChunks=1&maxBytes=${MAX_STREAM_CHUNK_BYTES - 1}&waitMs=0`,
+      { headers: { authorization: `Bearer ${SECRET}` } },
+    );
+    expect(undersizedRead.status).toBe(400);
+    await expect(undersizedRead.json()).resolves.toMatchObject({
+      error: { name: 'StreamProtocolError' },
+    });
   });
 
   it('400s malformed bodies', async () => {
@@ -432,8 +443,17 @@ describe('full stack: vendored storage over the wire', () => {
     expect(calls[1].body).toBeInstanceOf(Uint8Array);
     expect(decodeStreamWriteBatch(calls[1].body!)).toEqual(chunks);
 
-    calls.length = 0;
     const streamStorage = harness.fleet.cell('streams', `stream:${name}`).storage;
+    const storedPayloads = Array.from(streamStorage.data.entries())
+      .filter(([key]) => key.startsWith('chunk:'))
+      .map(([, value]) => value as Uint8Array);
+    expect(storedPayloads).toHaveLength(MAX_STREAM_WRITE_CHUNKS);
+    for (const chunk of storedPayloads) {
+      expect(chunk.byteOffset).toBe(0);
+      expect(chunk.buffer.byteLength).toBe(chunk.byteLength);
+    }
+
+    calls.length = 0;
     streamStorage.resetOperationCounts();
     await streamer.streams.writeMulti!(runId, name, chunks);
 
@@ -447,6 +467,7 @@ describe('full stack: vendored storage over the wire', () => {
     });
 
     calls.length = 0;
+    streamStorage.resetOperationCounts();
     const page = await streamer.getStreamChunks(name, runId, { limit: 32 });
     expect(calls).toHaveLength(1);
     expect(calls[0].url).toContain('/v1/streams/');
@@ -454,6 +475,11 @@ describe('full stack: vendored storage over the wire', () => {
     expect(page.data.map((chunk) => Array.from(chunk.data))).toEqual(
       chunks.map((chunk) => Array.from(chunk)),
     );
+    expect(streamStorage.operationCounts).toMatchObject({
+      get: 0,
+      getMany: 2,
+      list: 0,
+    });
   });
 
   it('holds one idle public read and wakes it on close without storage polling', async () => {
@@ -489,5 +515,33 @@ describe('full stack: vendored storage over the wire', () => {
 
     await streamer.closeStream(name, runId);
     await expect(pending).resolves.toMatchObject({ done: true });
+  });
+
+  it('removes the DO waiter when an HTTP long-poll client disconnects', async () => {
+    const name = `stream:wire-abort-${Date.now()}`;
+    const runId = `wrun_abort_${Date.now()}`;
+    const controller = new AbortController();
+    const url = new URL(`${harness.url}/v1/streams/${encodeURIComponent(name)}/chunks`);
+    url.searchParams.set('runId', runId);
+    url.searchParams.set('startIndex', '0');
+    url.searchParams.set('maxChunks', '32');
+    url.searchParams.set('maxBytes', String(MAX_STREAM_READ_BYTES));
+    url.searchParams.set('waitMs', '1000');
+
+    const pending = fetch(url, {
+      headers: { authorization: `Bearer ${SECRET}` },
+      signal: controller.signal,
+    });
+    const waiterCount = () =>
+      (
+        harness.fleet.cell('streams', name).instance as unknown as {
+          waiters: Set<unknown>;
+        }
+      ).waiters.size;
+    await vi.waitFor(() => expect(waiterCount()).toBe(1));
+
+    controller.abort(new DOMException('test disconnect', 'AbortError'));
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    await vi.waitFor(() => expect(waiterCount()).toBe(0));
   });
 });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -7,6 +7,11 @@ import { createConnection } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { rpcStringify } from '../src/codec.js';
 import { createRemoteEnv } from '../src/remote/namespaces.js';
+import {
+  MAX_STREAM_WRITE_CHUNKS,
+  STREAM_BATCH_CONTENT_TYPE,
+  decodeStreamWriteBatch,
+} from '../src/stream-protocol.js';
 import { createStorage } from '../src/storage.js';
 import { createStreamer } from '../src/streamer.js';
 import { startHarness, type Harness } from '../src/testing/http-harness.js';
@@ -105,6 +110,21 @@ describe('router auth and shape', () => {
     expect((await rpc('/v1/rpc/runs/wrun_x/fetch', [], SECRET)).status).toBe(404);
     expect((await rpc('/v1/rpc/runs/wrun_x/alarm', [], SECRET)).status).toBe(404);
     expect((await rpc('/v1/rpc/runs/wrun_x/constructor', [], SECRET)).status).toBe(404);
+    expect((await rpc('/v1/rpc/streams/stream%3Ax/writeChunk', [], SECRET)).status).toBe(404);
+  });
+
+  it('authenticates and validates the hard-cutover binary stream route', async () => {
+    const path = '/v1/streams/stream%3Ax/chunks?runId=wrun_x';
+    expect((await fetch(`${harness.url}${path}`)).status).toBe(401);
+    const malformed = await fetch(`${harness.url}${path}`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${SECRET}`,
+        'content-type': STREAM_BATCH_CONTENT_TYPE,
+      },
+      body: new Uint8Array(),
+    });
+    expect(malformed.status).toBe(400);
   });
 
   it('400s malformed bodies', async () => {
@@ -379,5 +399,95 @@ describe('full stack: vendored storage over the wire', () => {
     await expect(streamer.writeToStream('wire-stream', 'wrun_s1', 'nope')).rejects.toThrow(
       /closed stream/,
     );
+  });
+
+  it('uses two public calls for a cold maximum batch and binary payloads end-to-end', async () => {
+    const calls: Array<{ url: string; contentType: string | null; body?: Uint8Array }> = [];
+    const countingFetch: typeof fetch = async (input, init) => {
+      calls.push({
+        url: input instanceof Request ? input.url : input instanceof URL ? input.href : input,
+        contentType: new Headers(init?.headers).get('content-type'),
+        body: init?.body instanceof Uint8Array ? new Uint8Array(init.body) : undefined,
+      });
+      return await fetch(input, init);
+    };
+    const env = createRemoteEnv({
+      fleetUrl: harness.url,
+      secret: SECRET,
+      fetchImpl: countingFetch,
+    });
+    const streamer = createStreamer({ env: { WORKFLOW_STREAMS: env.WORKFLOW_STREAMS } });
+    const name = `wire-batch-${Date.now()}`;
+    const runId = `wrun_batch_${Date.now()}`;
+    const chunks = Array.from({ length: MAX_STREAM_WRITE_CHUNKS }, (_, index) =>
+      Uint8Array.of(0, index, 255),
+    );
+
+    await streamer.streams.writeMulti!(runId, name, chunks);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toContain('/v1/rpc/streams/');
+    expect(calls[1].url).toContain('/v1/streams/');
+    expect(calls[1].contentType).toBe(STREAM_BATCH_CONTENT_TYPE);
+    expect(calls[1].body).toBeInstanceOf(Uint8Array);
+    expect(decodeStreamWriteBatch(calls[1].body!)).toEqual(chunks);
+
+    calls.length = 0;
+    const streamStorage = harness.fleet.cell('streams', `stream:${name}`).storage;
+    streamStorage.resetOperationCounts();
+    await streamer.streams.writeMulti!(runId, name, chunks);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('/v1/streams/');
+    expect(streamStorage.operationCounts).toMatchObject({
+      transaction: 1,
+      get: 1,
+      putMany: 1,
+      put: 0,
+    });
+
+    calls.length = 0;
+    const page = await streamer.getStreamChunks(name, runId, { limit: 32 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('/v1/streams/');
+    expect(page.data).toHaveLength(32);
+    expect(page.data.map((chunk) => Array.from(chunk.data))).toEqual(
+      chunks.map((chunk) => Array.from(chunk)),
+    );
+  });
+
+  it('holds one idle public read and wakes it on close without storage polling', async () => {
+    const calls: string[] = [];
+    const countingFetch: typeof fetch = async (input, init) => {
+      calls.push(input instanceof Request ? input.url : input instanceof URL ? input.href : input);
+      return await fetch(input, init);
+    };
+    const env = createRemoteEnv({
+      fleetUrl: harness.url,
+      secret: SECRET,
+      fetchImpl: countingFetch,
+    });
+    const streamer = createStreamer({
+      env: { WORKFLOW_STREAMS: env.WORKFLOW_STREAMS },
+      streamLongPollMs: 200,
+    });
+    const name = `wire-idle-${Date.now()}`;
+    const runId = `wrun_idle_${Date.now()}`;
+    const stream = await streamer.streams.get(runId, name);
+    const reader = stream.getReader();
+    const pending = reader.read();
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const readCalls = () => calls.filter((url) => url.includes('/v1/streams/')).length;
+    expect(readCalls()).toBe(1);
+    const streamStorage = harness.fleet.cell('streams', `stream:${name}`).storage;
+    streamStorage.resetOperationCounts();
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(readCalls()).toBe(1);
+    expect(streamStorage.operationCounts).toMatchObject({ get: 0, list: 0 });
+
+    await streamer.closeStream(name, runId);
+    await expect(pending).resolves.toMatchObject({ done: true });
   });
 });

--- a/test/stream-do.test.ts
+++ b/test/stream-do.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   MAX_STREAM_BATCH_BYTES,
+  MAX_STREAM_CHUNK_BYTES,
   MAX_STREAM_READ_BYTES,
   MAX_STREAM_WRITE_CHUNKS,
   type StreamReadRequest,
@@ -86,6 +87,63 @@ describe('StreamDO binary batch and long-poll protocol', () => {
         Array.from({ length: 9 }, () => oneMiB),
       ),
     ).rejects.toThrow(/batch exceeds/);
+  });
+
+  it('compacts direct-RPC subarrays before structured-clone storage', async () => {
+    const { fleet, get, name } = setup();
+    const backing = new Uint8Array(MAX_STREAM_CHUNK_BYTES + 64);
+    const chunk = backing.subarray(32, 32 + MAX_STREAM_CHUNK_BYTES);
+
+    await get().writeChunks(RUN_ID, [chunk]);
+
+    const stored = fleet.cell('streams', name).storage.data.get('chunk:000000000000') as Uint8Array;
+    expect(stored.byteLength).toBe(MAX_STREAM_CHUNK_BYTES);
+    expect(stored.byteOffset).toBe(0);
+    expect(stored.buffer.byteLength).toBe(MAX_STREAM_CHUNK_BYTES);
+  });
+
+  it('batch-fetches 32 small chunks without over-reading the byte budget', async () => {
+    const { fleet, get, name } = setup();
+    const chunks = Array.from({ length: MAX_STREAM_WRITE_CHUNKS }, (_, index) =>
+      new Uint8Array(MAX_STREAM_READ_BYTES / MAX_STREAM_WRITE_CHUNKS).fill(index),
+    );
+    await get().writeChunks(RUN_ID, chunks);
+    const storage = fleet.cell('streams', name).storage;
+    storage.resetOperationCounts();
+
+    const result = await get().readChunks(readRequest());
+
+    expect(result.chunks).toHaveLength(MAX_STREAM_WRITE_CHUNKS);
+    expect(result.chunks.map((chunk) => chunk[0])).toEqual(
+      Array.from({ length: MAX_STREAM_WRITE_CHUNKS }, (_, index) => index),
+    );
+    expect(storage.operationCounts).toMatchObject({
+      get: 0,
+      getMany: 2,
+      list: 0,
+    });
+  });
+
+  it('fetches only the payload prefix selected by the byte budget', async () => {
+    const { fleet, get, name } = setup();
+    const chunkBytes = MAX_STREAM_CHUNK_BYTES / 8;
+    await get().writeChunks(
+      RUN_ID,
+      Array.from({ length: 16 }, (_, index) => new Uint8Array(chunkBytes).fill(index)),
+    );
+    const storage = fleet.cell('streams', name).storage;
+    storage.resetOperationCounts();
+
+    const result = await get().readChunks(
+      readRequest({ maxBytes: MAX_STREAM_CHUNK_BYTES, maxChunks: 16 }),
+    );
+
+    expect(result.chunks).toHaveLength(8);
+    expect(storage.getManyCalls).toHaveLength(2);
+    expect(storage.getManyCalls[0]).toHaveLength(16);
+    expect(storage.getManyCalls[0].every((key) => key.startsWith('chunk-size:'))).toBe(true);
+    expect(storage.getManyCalls[1]).toHaveLength(8);
+    expect(storage.getManyCalls[1].every((key) => key.startsWith('chunk:'))).toBe(true);
   });
 
   it('times out one bounded idle read without polling storage', async () => {

--- a/test/stream-do.test.ts
+++ b/test/stream-do.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_STREAM_BATCH_BYTES,
+  MAX_STREAM_READ_BYTES,
+  MAX_STREAM_WRITE_CHUNKS,
+  type StreamReadRequest,
+} from '../src/stream-protocol.js';
+import { FakeFleet } from '../src/testing/fake-cell.js';
+import { StreamDO } from '../src/worker/durable-objects/StreamDO.js';
+
+const RUN_ID = 'wrun_stream_do';
+
+function setup(name = 'stream:test') {
+  const fleet = new FakeFleet({ streams: StreamDO as never });
+  const get = () => fleet.namespace('streams').get({ toString: () => name }) as StreamDO;
+  return { fleet, get, name };
+}
+
+function readRequest(overrides: Partial<StreamReadRequest> = {}): StreamReadRequest {
+  return {
+    runId: RUN_ID,
+    startIndex: 0,
+    maxChunks: 32,
+    maxBytes: MAX_STREAM_READ_BYTES,
+    waitMs: 0,
+    ...overrides,
+  };
+}
+
+describe('StreamDO binary batch and long-poll protocol', () => {
+  it('round-trips an immediate ordered binary batch with contiguous offsets', async () => {
+    const { get } = setup();
+    const chunks = [
+      new Uint8Array([0, 1, 2, 255]),
+      new TextEncoder().encode('middle'),
+      new Uint8Array([9, 8, 7]),
+    ];
+
+    await expect(get().writeChunks(RUN_ID, chunks)).resolves.toEqual({
+      startIndex: 0,
+      count: 3,
+      tailIndex: 2,
+    });
+    const result = await get().readChunks(readRequest());
+
+    expect(result).toMatchObject({
+      startIndex: 0,
+      tailIndex: 2,
+      state: 'open',
+      timedOut: false,
+    });
+    expect(result.chunks.map((chunk) => Array.from(chunk))).toEqual(
+      chunks.map((chunk) => Array.from(chunk)),
+    );
+  });
+
+  it('rejects an empty protocol batch and accepts the maximum count', async () => {
+    const { get } = setup();
+    await expect(get().writeChunks(RUN_ID, [])).rejects.toThrow(/at least one chunk/);
+
+    const chunks = Array.from({ length: MAX_STREAM_WRITE_CHUNKS }, (_, index) =>
+      Uint8Array.of(index),
+    );
+    await expect(get().writeChunks(RUN_ID, chunks)).resolves.toMatchObject({
+      startIndex: 0,
+      count: MAX_STREAM_WRITE_CHUNKS,
+      tailIndex: MAX_STREAM_WRITE_CHUNKS - 1,
+    });
+    await expect(get().writeChunks(RUN_ID, [...chunks, Uint8Array.of(33)])).rejects.toThrow(
+      /exceeds 32 chunks/,
+    );
+  });
+
+  it('enforces the total batch byte limit', async () => {
+    const { get } = setup();
+    const oneMiB = new Uint8Array(1024 * 1024);
+    await expect(
+      get().writeChunks(
+        RUN_ID,
+        Array.from({ length: MAX_STREAM_BATCH_BYTES / oneMiB.byteLength }, () => oneMiB),
+      ),
+    ).resolves.toMatchObject({ count: 8 });
+    await expect(
+      get().writeChunks(
+        RUN_ID,
+        Array.from({ length: 9 }, () => oneMiB),
+      ),
+    ).rejects.toThrow(/batch exceeds/);
+  });
+
+  it('times out one bounded idle read without polling storage', async () => {
+    const { fleet, get, name } = setup();
+    // Warm immutable metadata once, then isolate the idle-path operation count.
+    await get().readChunks(readRequest());
+    const storage = fleet.cell('streams', name).storage;
+    storage.resetOperationCounts();
+
+    const startedAt = performance.now();
+    const result = await get().readChunks(readRequest({ waitMs: 30 }));
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result).toMatchObject({ chunks: [], state: 'open', timedOut: true });
+    expect(elapsedMs).toBeGreaterThanOrEqual(20);
+    expect(storage.operationCounts).toMatchObject({ get: 0, list: 0 });
+  });
+
+  it('wakes concurrent readers promptly on one batch write', async () => {
+    const { get } = setup();
+    const readers = Array.from({ length: 4 }, () =>
+      get().readChunks(readRequest({ waitMs: 1_000 })),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await get().writeChunks(RUN_ID, [new TextEncoder().encode('wake')]);
+    const results = await Promise.all(readers);
+
+    expect(results).toHaveLength(4);
+    for (const result of results) {
+      expect(new TextDecoder().decode(result.chunks[0])).toBe('wake');
+      expect(result.timedOut).toBe(false);
+    }
+  });
+
+  it('wakes on close and preserves the first terminal state', async () => {
+    const { get } = setup();
+    const pending = get().readChunks(readRequest({ waitMs: 1_000 }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await get().closeStream(RUN_ID);
+
+    await expect(pending).resolves.toMatchObject({ state: 'closed', chunks: [] });
+    await get().failStream(RUN_ID, 'late failure');
+    await expect(get().readChunks(readRequest())).resolves.toMatchObject({ state: 'closed' });
+    await expect(get().writeChunks(RUN_ID, [Uint8Array.of(1)])).rejects.toThrow(/closed/);
+  });
+
+  it('wakes on a persisted stream error and rejects later writes', async () => {
+    const { get } = setup();
+    const pending = get().readChunks(readRequest({ waitMs: 1_000 }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await get().failStream(RUN_ID, { name: 'ProducerError', message: 'producer failed' });
+
+    await expect(pending).resolves.toMatchObject({
+      state: 'errored',
+      error: { name: 'ProducerError', message: 'producer failed' },
+    });
+    await expect(get().writeChunks(RUN_ID, [Uint8Array.of(1)])).rejects.toThrow(/errored/);
+  });
+
+  it('serializes concurrent writers without collisions or reordering inside a batch', async () => {
+    const { get } = setup();
+    const first = [Uint8Array.of(1), Uint8Array.of(2), Uint8Array.of(3)];
+    const second = [Uint8Array.of(4), Uint8Array.of(5)];
+
+    const [firstResult, secondResult] = await Promise.all([
+      get().writeChunks(RUN_ID, first),
+      get().writeChunks(RUN_ID, second),
+    ]);
+    expect(firstResult).toMatchObject({ startIndex: 0, tailIndex: 2 });
+    expect(secondResult).toMatchObject({ startIndex: 3, tailIndex: 4 });
+    const result = await get().readChunks(readRequest());
+    expect(result.chunks.map((chunk) => chunk[0])).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('loads persisted offsets and terminal state after a DO restart', async () => {
+    const { fleet, get, name } = setup();
+    await get().writeChunks(RUN_ID, [Uint8Array.of(1), Uint8Array.of(2)]);
+    fleet.restartCell('streams', name);
+    await expect(get().writeChunks(RUN_ID, [Uint8Array.of(3)])).resolves.toMatchObject({
+      startIndex: 2,
+      tailIndex: 2,
+    });
+    await get().closeStream(RUN_ID);
+    fleet.restartCell('streams', name);
+
+    await expect(get().readChunks(readRequest())).resolves.toMatchObject({
+      tailIndex: 2,
+      state: 'closed',
+    });
+  });
+
+  it('removes an aborted waiter and remains usable', async () => {
+    const { get } = setup();
+    const controller = new AbortController();
+    const pending = get().readChunks(readRequest({ waitMs: 1_000 }), controller.signal);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    controller.abort(new DOMException('test abort', 'AbortError'));
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect((get() as unknown as { waiters: Set<unknown> }).waiters.size).toBe(0);
+    await get().writeChunks(RUN_ID, [Uint8Array.of(7)]);
+    await expect(get().readChunks(readRequest())).resolves.toMatchObject({ tailIndex: 0 });
+  });
+
+  it('fences expiry before bounded deletion and wakes pending readers', async () => {
+    const { fleet, get, name } = setup();
+    await get().writeChunks(RUN_ID, [Uint8Array.of(1), Uint8Array.of(2)]);
+    const pending = get().readChunks(readRequest({ startIndex: 2, waitMs: 1_000 }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await expect(get().expireStream(RUN_ID, Date.now())).resolves.toEqual({
+      deleted: true,
+      chunks: 2,
+    });
+    await expect(pending).resolves.toMatchObject({ state: 'expired', chunks: [] });
+    expect(Array.from(fleet.cell('streams', name).storage.data.keys())).toEqual(['meta']);
+    await expect(get().expireStream(RUN_ID, Date.now())).resolves.toEqual({
+      deleted: true,
+      chunks: 2,
+    });
+  });
+
+  it('coalesces a maximum write into one metadata read and one batch put', async () => {
+    const { fleet, get, name } = setup();
+    const storage = fleet.cell('streams', name).storage;
+    storage.resetOperationCounts();
+
+    await get().writeChunks(
+      RUN_ID,
+      Array.from({ length: MAX_STREAM_WRITE_CHUNKS }, (_, index) => Uint8Array.of(index)),
+    );
+
+    expect(storage.operationCounts).toMatchObject({
+      transaction: 1,
+      get: 1,
+      putMany: 1,
+      put: 0,
+    });
+  });
+});

--- a/test/stream-protocol.test.ts
+++ b/test/stream-protocol.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_STREAM_CHUNK_BYTES,
+  MAX_STREAM_READ_BYTES,
+  decodeStreamWriteBatch,
+  encodeStreamWriteBatch,
+  validateStreamReadRequest,
+} from '../src/stream-protocol.js';
+
+describe('stream binary protocol', () => {
+  it('decodes each write chunk into a compact storage-safe buffer', () => {
+    const chunks = [Uint8Array.of(1, 2, 3), Uint8Array.of(4, 5, 6, 7)];
+    const encoded = encodeStreamWriteBatch(chunks);
+    const decoded = decodeStreamWriteBatch(encoded);
+
+    expect(decoded).toEqual(chunks);
+    for (const chunk of decoded) {
+      expect(chunk.byteOffset).toBe(0);
+      expect(chunk.buffer.byteLength).toBe(chunk.byteLength);
+      expect(chunk.buffer).not.toBe(encoded.buffer);
+      expect(structuredClone(chunk).buffer.byteLength).toBe(chunk.byteLength);
+    }
+  });
+
+  it('requires every read budget to fit one maximum-size chunk', () => {
+    const request = {
+      runId: 'wrun_protocol',
+      startIndex: 0,
+      maxChunks: 1,
+      maxBytes: MAX_STREAM_CHUNK_BYTES,
+      waitMs: 0,
+    };
+
+    expect(() => validateStreamReadRequest(request)).not.toThrow();
+    expect(() =>
+      validateStreamReadRequest({ ...request, maxBytes: MAX_STREAM_CHUNK_BYTES - 1 }),
+    ).toThrow(`maxBytes must be between ${MAX_STREAM_CHUNK_BYTES} and ${MAX_STREAM_READ_BYTES}`);
+  });
+});

--- a/test/streamer.test.ts
+++ b/test/streamer.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createStreamer, type StreamDOStub } from '../src/streamer.js';
+import { MAX_STREAM_READ_BYTES } from '../src/stream-protocol.js';
 import { createMockEnv } from '../src/test-mocks.js';
 
 async function readAll(stream: ReadableStream<Uint8Array>): Promise<Uint8Array[]> {
@@ -31,6 +32,12 @@ describe('Streamer (StreamDO RPC integration)', () => {
   });
 
   describe('writeToStream()', () => {
+    it('exposes writeMulti and treats an empty runtime batch as a no-op', async () => {
+      expect(typeof streamer.streams.writeMulti).toBe('function');
+      await streamer.streams.writeMulti!('wrun_empty', 'empty-stream', []);
+      expect(await streamer.listStreamsByRunId('wrun_empty')).toEqual([]);
+    });
+
     it('should write string chunks with monotonic indexes', async () => {
       await streamer.writeToStream('test-stream', 'wrun_123', 'Hello');
       await streamer.writeToStream('test-stream', 'wrun_123', ' world');
@@ -38,7 +45,13 @@ describe('Streamer (StreamDO RPC integration)', () => {
       const stub = mockEnv.WORKFLOW_STREAMS.get(
         mockEnv.WORKFLOW_STREAMS.idFromName('stream:test-stream'),
       );
-      const { chunks, tailIndex } = await stub.getChunks({ startIndex: 0, limit: 10 });
+      const { chunks, tailIndex } = await stub.readChunks({
+        runId: 'wrun_123',
+        startIndex: 0,
+        maxChunks: 10,
+        maxBytes: MAX_STREAM_READ_BYTES,
+        waitMs: 0,
+      });
       expect(chunks).toHaveLength(2);
       expect(tailIndex).toBe(1);
       expect(new TextDecoder().decode(chunks[0])).toBe('Hello');
@@ -52,7 +65,13 @@ describe('Streamer (StreamDO RPC integration)', () => {
       const stub = mockEnv.WORKFLOW_STREAMS.get(
         mockEnv.WORKFLOW_STREAMS.idFromName('stream:binary-stream'),
       );
-      const { chunks } = await stub.getChunks({ startIndex: 0, limit: 10 });
+      const { chunks } = await stub.readChunks({
+        runId: 'wrun_456',
+        startIndex: 0,
+        maxChunks: 10,
+        maxBytes: MAX_STREAM_READ_BYTES,
+        waitMs: 0,
+      });
       expect(Array.from(chunks[0])).toEqual([0, 1, 2, 253, 254, 255]);
     });
 
@@ -120,7 +139,7 @@ describe('Streamer (StreamDO RPC integration)', () => {
       await streamer.writeToStream('test-stream', 'wrun_123', 'Chunk 3\n');
       await streamer.closeStream('test-stream', 'wrun_123');
 
-      const stream = await streamer.readFromStream('test-stream');
+      const stream = await streamer.readFromStream('test-stream', 'wrun_123');
       const chunks = await readAll(stream);
 
       expect(chunks).toHaveLength(3);
@@ -132,7 +151,7 @@ describe('Streamer (StreamDO RPC integration)', () => {
       await streamer.writeToStream('binary-stream', 'wrun_123', new Uint8Array([5, 6, 7, 8, 9]));
       await streamer.closeStream('binary-stream', 'wrun_123');
 
-      const stream = await streamer.readFromStream('binary-stream');
+      const stream = await streamer.readFromStream('binary-stream', 'wrun_123');
       const chunks = await readAll(stream);
 
       expect(chunks).toHaveLength(2);
@@ -143,13 +162,13 @@ describe('Streamer (StreamDO RPC integration)', () => {
     it('should read a live stream that closes later', async () => {
       await streamer.writeToStream('live-stream', 'wrun_123', 'early');
 
-      const stream = await streamer.readFromStream('live-stream');
+      const stream = await streamer.readFromStream('live-stream', 'wrun_123');
       const reader = stream.getReader();
 
       const first = await reader.read();
       expect(new TextDecoder().decode(first.value)).toBe('early');
 
-      // Write + close while the reader is polling for more.
+      // Write + close while one bounded read is waiting for more.
       setTimeout(() => {
         void streamer
           .writeToStream('live-stream', 'wrun_123', 'late')
@@ -169,7 +188,7 @@ describe('Streamer (StreamDO RPC integration)', () => {
       await streamer.writeToStream('test-stream', 'wrun_123', 'two');
       await streamer.closeStream('test-stream', 'wrun_123');
 
-      const stream = await streamer.readFromStream('test-stream', 1);
+      const stream = await streamer.readFromStream('test-stream', 'wrun_123', 1);
       const chunks = await readAll(stream);
 
       expect(text(chunks)).toBe('onetwo');
@@ -181,7 +200,7 @@ describe('Streamer (StreamDO RPC integration)', () => {
       await streamer.writeToStream('test-stream', 'wrun_123', 'two');
       await streamer.closeStream('test-stream', 'wrun_123');
 
-      const stream = await streamer.readFromStream('test-stream', -2);
+      const stream = await streamer.readFromStream('test-stream', 'wrun_123', -2);
       const chunks = await readAll(stream);
 
       expect(text(chunks)).toBe('onetwo');
@@ -190,7 +209,7 @@ describe('Streamer (StreamDO RPC integration)', () => {
     it('should handle stream cancellation', async () => {
       await streamer.writeToStream('test-stream', 'wrun_123', 'data');
 
-      const stream = await streamer.readFromStream('test-stream');
+      const stream = await streamer.readFromStream('test-stream', 'wrun_123');
       const reader = stream.getReader();
 
       await reader.read();
@@ -202,10 +221,10 @@ describe('Streamer (StreamDO RPC integration)', () => {
 
     it('should propagate DO errors instead of silently closing', async () => {
       const failingStub: StreamDOStub = {
-        writeChunk: vi.fn<StreamDOStub['writeChunk']>(fail),
+        writeChunks: vi.fn<StreamDOStub['writeChunks']>(fail),
         closeStream: vi.fn<StreamDOStub['closeStream']>(fail),
-        getChunks: vi.fn<StreamDOStub['getChunks']>(fail),
-        getInfo: vi.fn<StreamDOStub['getInfo']>(fail),
+        failStream: vi.fn<StreamDOStub['failStream']>(fail),
+        readChunks: vi.fn<StreamDOStub['readChunks']>(fail),
         registerStream: vi.fn<StreamDOStub['registerStream']>(fail),
         listStreams: vi.fn<StreamDOStub['listStreams']>(fail),
         expireRegistry: vi.fn<StreamDOStub['expireRegistry']>(fail),
@@ -220,10 +239,25 @@ describe('Streamer (StreamDO RPC integration)', () => {
       };
 
       const failingStreamer = createStreamer({ env: failingEnv });
-      const stream = await failingStreamer.readFromStream('error-stream');
+      const stream = await failingStreamer.readFromStream('error-stream', 'wrun_error');
       const reader = stream.getReader();
 
       await expect(reader.read()).rejects.toThrow('DO unavailable');
+    });
+
+    it('surfaces a persisted producer error to a waiting reader', async () => {
+      const stream = await streamer.readFromStream('failed-stream', 'wrun_failed');
+      const reader = stream.getReader();
+      const pending = reader.read();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await streamer.errorStream('failed-stream', 'wrun_failed', {
+        name: 'ProducerError',
+        message: 'producer failed',
+      });
+
+      const error = await pending.catch((caught) => caught);
+      expect(error).toMatchObject({ name: 'ProducerError', message: 'producer failed' });
     });
   });
 
@@ -274,19 +308,20 @@ describe('Streamer (StreamDO RPC integration)', () => {
       ).rejects.toThrow(/Invalid stream cursor/);
     });
 
-    it('keeps a default page below the Worker memory limit after base64 encoding', async () => {
+    it('bounds a page by raw binary bytes without base64 expansion', async () => {
       const oneMiB = new Uint8Array(1024 * 1024);
+      const readChunks = vi.fn<StreamDOStub['readChunks']>(async ({ startIndex, maxBytes }) => ({
+        startIndex,
+        chunks: Array.from({ length: maxBytes / oneMiB.byteLength }, () => oneMiB),
+        state: 'open',
+        timedOut: false,
+        tailIndex: 31,
+      }));
       const largeChunkStub: StreamDOStub = {
-        writeChunk: vi.fn<StreamDOStub['writeChunk']>(),
+        writeChunks: vi.fn<StreamDOStub['writeChunks']>(),
         closeStream: vi.fn<StreamDOStub['closeStream']>(),
-        getChunks: vi.fn<StreamDOStub['getChunks']>(async ({ limit }) => ({
-          // Reuse one allocation: the regression is the logical response size,
-          // not Node heap pressure inside the test process.
-          chunks: Array.from({ length: limit }, () => oneMiB),
-          done: false,
-          tailIndex: limit - 1,
-        })),
-        getInfo: vi.fn<StreamDOStub['getInfo']>(async () => ({ tailIndex: -1, done: false })),
+        failStream: vi.fn<StreamDOStub['failStream']>(),
+        readChunks,
         registerStream: vi.fn<StreamDOStub['registerStream']>(),
         listStreams: vi.fn<StreamDOStub['listStreams']>(async () => []),
         expireRegistry: vi.fn<StreamDOStub['expireRegistry']>(async () => ({ streams: [] })),
@@ -306,13 +341,11 @@ describe('Streamer (StreamDO RPC integration)', () => {
       });
 
       const page = await boundedStreamer.getStreamChunks('large-stream', 'wrun_large');
-      const base64Bytes = page.data.reduce(
-        (total, chunk) => total + 4 * Math.ceil(chunk.data.byteLength / 3),
-        0,
+      const rawBytes = page.data.reduce((total, chunk) => total + chunk.data.byteLength, 0);
+      expect(rawBytes).toBe(MAX_STREAM_READ_BYTES);
+      expect(readChunks).toHaveBeenCalledWith(
+        expect.objectContaining({ maxBytes: MAX_STREAM_READ_BYTES, waitMs: 0 }),
       );
-
-      // This is a lower bound: tagged JSON and response buffering add overhead.
-      expect(base64Bytes).toBeLessThan(128 * 1024 * 1024);
     });
   });
 


### PR DESCRIPTION
## Summary

- replace fixed 250 ms stream polling with one bounded long-poll read that returns binary chunks, offsets, and terminal/error state together
- batch up to 32 ordered chunk writes into one binary request and one StreamDO transaction
- carry chunk payloads as binary data across the client, Worker route, Durable Object RPC, and storage boundaries
- wake pending readers on writes, close, producer error, and expiry, with bounded timeout/abort cleanup and restart-safe stream metadata
- make a clean pre-release protocol cutover by removing the superseded per-chunk and metadata RPC surface

## Impact

Idle readers no longer issue four public HTTP requests per second or repeatedly read metadata and list chunks. With the default 20 second bound, an idle reader uses about three public requests per minute.

A warm 32-chunk write changes from 32 public stream RPCs and 32 StreamDO transactions to one binary stream request and one transaction. The StreamDO storage work changes from 32 metadata reads plus 64 individual puts to one metadata read plus one multi-key put. Stream registry registration remains separate and unchanged.

These are deterministic call-count measurements, not latency benchmarks.

## Limits and semantics

- 32 chunks per batch
- 1 MiB per chunk
- 8 MiB per write/read batch
- 20 second maximum long poll
- first terminal state wins for close/error
- expiry fences readers before bounded deletion
- no legacy decoder, persisted-state migration, compatibility layer, or dual-read/write path

## Validation

- `pnpm exec vitest run test/stream-do.test.ts test/streamer.test.ts test/router.test.ts test/retention.test.ts test/rpc-client.test.ts` — 56 tests passed
- `pnpm check` — formatting, strict lint, typecheck, build, 221 tests, Worker bundle, and package checks passed
- `pnpm test:integration` — 1 passed; 10 live-fleet cases skipped because no external fleet was configured
- `git diff --check`
