### PR TITLE
perf: bound cleanup and batch Durable Object storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The deployed worker also accepts these celld variables:
 | `WORLD_SECRET`              | none     | Required bearer secret for RPC routes                |
 | `WORKFLOW_CALLBACK_SECRET`  | none     | Sent with deliveries as `x-workflow-callback-secret` |
 | `QUEUE_MAX_ATTEMPTS`        | `5`      | Attempts before a message is dead-lettered           |
-| `QUEUE_MAX_INFLIGHT`        | `5`      | Concurrent deliveries per queue cell                 |
+| `QUEUE_MAX_INFLIGHT`        | `5`      | Concurrent deliveries per queue cell (maximum `128`) |
 | `QUEUE_DELIVERY_TIMEOUT_MS` | `300000` | Timeout for an application callback                  |
 
 `queueShards` is part of queue placement and is pinned when a queue cell is
@@ -173,8 +173,13 @@ pending runs are never eligible for automatic cleanup.
 
 At expiration, the run cell fences new writes and removes the run's derived
 indexes, stream chunks, pending and dead-letter queue messages, and durable run
-payloads. Cleanup is a persisted, idempotent state machine: an interrupted
-phase records its error and re-arms itself with capped backoff.
+payloads. Cleanup is a persisted, idempotent state machine. Each alarm processes
+one bounded page, persists its progress, and re-arms the next alarm; an
+interrupted phase records its error and retries with capped backoff.
+
+Terminal hook and wait disposal uses the same alarm mechanism even when run
+retention is disabled, so a terminal event never performs an unbounded storage
+transaction.
 
 The final state is a metadata-only tombstone, not an empty cell. It prevents a
 delayed queue delivery or stale RPC from recreating an expired run. Reads and
@@ -201,6 +206,8 @@ an existing terminal run that has no cleanup record.
   must be idempotent.
 - Queue cells expose `stats`, `listDeadLetters`, `redriveDeadLetter`,
   `purgeDeadLetters`, and `rearmAlarm` through the authenticated RPC endpoint.
+  `purgeDeadLetters` deletes at most 128 entries per call; repeat it while its
+  result reports `hasMore`.
 - Run cells expose retention status, scheduling, immediate cleanup, and alarm
   recovery through `world.retention`.
 - A new application URL applies to newly enqueued messages. Existing messages

--- a/src/apply-event.ts
+++ b/src/apply-event.ts
@@ -59,7 +59,7 @@ const RUN_KEY = 'run';
 export const EVENT_KEY_PREFIX = 'event:';
 export const STEP_KEY_PREFIX = 'step:';
 export const HOOK_KEY_PREFIX = 'hook:';
-const WAIT_KEY_PREFIX = 'wait:';
+export const WAIT_KEY_PREFIX = 'wait:';
 export const STEP_CREATED_KEY_PREFIX = 'stepcreated:';
 export const HOOK_CREATED_KEY_PREFIX = 'hookcreated:';
 /**
@@ -98,9 +98,50 @@ export interface EventStoreListOptions {
  */
 export interface EventStore {
   get<T>(key: string): Promise<T | undefined>;
+  /** Optional native multi-key read (128 keys per Durable Object call). */
+  getMany?<T>(keys: string[]): Promise<Map<string, T>>;
   put<T>(key: string, value: T): Promise<void>;
   delete(key: string): Promise<boolean>;
+  /** Optional native multi-key delete. */
+  deleteMany?(keys: string[]): Promise<number>;
   list<T>(options: EventStoreListOptions): Promise<Map<string, T>>;
+  /**
+   * Celld-only capability: terminal entity cleanup is persisted and paged by
+   * WorkflowRunDO alarms instead of running inside the event transaction.
+   */
+  deferTerminalCleanup?: boolean;
+}
+
+const STORAGE_BATCH_SIZE = 128;
+const MAX_ENTITY_PAGE_SIZE = 1000;
+
+async function getMany<T>(store: EventStore, keys: string[]): Promise<Map<string, T>> {
+  if (store.getMany) {
+    const result = new Map<string, T>();
+    for (let offset = 0; offset < keys.length; offset += STORAGE_BATCH_SIZE) {
+      const page = await store.getMany<T>(keys.slice(offset, offset + STORAGE_BATCH_SIZE));
+      for (const entry of page) result.set(...entry);
+    }
+    return result;
+  }
+  const values = await Promise.all(keys.map((key) => store.get<T>(key)));
+  return new Map(
+    keys.flatMap((key, index) =>
+      values[index] === undefined ? [] : ([[key, values[index] as T]] as Array<[string, T]>),
+    ),
+  );
+}
+
+async function deleteMany(store: EventStore, keys: string[]): Promise<number> {
+  if (store.deleteMany) {
+    let deleted = 0;
+    for (let offset = 0; offset < keys.length; offset += STORAGE_BATCH_SIZE) {
+      deleted += await store.deleteMany(keys.slice(offset, offset + STORAGE_BATCH_SIZE));
+    }
+    return deleted;
+  }
+  const results = await Promise.all(keys.map((key) => store.delete(key)));
+  return results.filter(Boolean).length;
 }
 
 export interface ApplyEventRequest {
@@ -247,7 +288,9 @@ export async function listByCreationTime<T>(
   entityPrefix: string,
   params: { limit: number; cursor?: string; sortOrder?: 'asc' | 'desc' },
 ): Promise<{ data: T[]; cursor: string | null; hasMore: boolean }> {
-  const { limit, cursor, sortOrder = 'asc' } = params;
+  const requestedLimit = Number.isFinite(params.limit) ? Math.floor(params.limit) : 1;
+  const limit = Math.min(MAX_ENTITY_PAGE_SIZE, Math.max(1, requestedLimit));
+  const { cursor, sortOrder = 'asc' } = params;
   const entries = await store.list<string>(
     sortOrder === 'desc'
       ? {
@@ -263,11 +306,12 @@ export async function listByCreationTime<T>(
         },
   );
   const page = Array.from(entries.entries()).slice(0, limit);
-  const data: T[] = [];
-  for (const [, id] of page) {
-    const item = await store.get<T>(`${entityPrefix}${id}`);
-    if (item !== undefined) data.push(item);
-  }
+  const entityKeys = page.map(([, id]) => `${entityPrefix}${id}`);
+  const entities = await getMany<T>(store, entityKeys);
+  const data = entityKeys.flatMap((key) => {
+    const item = entities.get(key);
+    return item === undefined ? [] : [item];
+  });
   const hasMore = entries.size > limit;
   const lastKey = page.at(-1)?.[0];
   return {
@@ -281,22 +325,24 @@ export async function listByCreationTime<T>(
 async function releaseAllHooks(
   store: EventStore,
 ): Promise<Array<{ hookId: string; token: string }>> {
+  if (store.deferTerminalCleanup) return [];
   const hooks = await store.list<Hook>({ prefix: HOOK_KEY_PREFIX });
   const released: Array<{ hookId: string; token: string }> = [];
+  const keys: string[] = [];
   for (const hook of hooks.values()) {
-    await store.delete(`${HOOK_KEY_PREFIX}${hook.hookId}`);
-    await store.delete(creationIndexKey(HOOK_CREATED_KEY_PREFIX, hook.createdAt, hook.hookId));
+    keys.push(`${HOOK_KEY_PREFIX}${hook.hookId}`);
+    keys.push(creationIndexKey(HOOK_CREATED_KEY_PREFIX, hook.createdAt, hook.hookId));
     released.push({ hookId: hook.hookId, token: hook.token });
   }
+  await deleteMany(store, keys);
   return released;
 }
 
 /** Delete all persisted waits once their owning run becomes terminal. */
 async function releaseAllWaits(store: EventStore): Promise<void> {
+  if (store.deferTerminalCleanup) return;
   const waits = await store.list<Wait>({ prefix: WAIT_KEY_PREFIX });
-  for (const key of waits.keys()) {
-    await store.delete(key);
-  }
+  await deleteMany(store, Array.from(waits.keys()));
 }
 
 export async function applyEvent(

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,9 @@ export interface IndexNamespace {
     owner: HookTokenOwner,
   ): Promise<void>;
   releaseHookToken(token: string, owner: HookTokenOwner): Promise<void>;
-  deleteHookIndexes(token: string, hookId: string, owner: HookTokenOwner): Promise<void>;
+  releaseHookIndexes(
+    request: import('./retention.js').ReleaseHookIndexesRequest,
+  ): Promise<import('./retention.js').ReleaseHookIndexesResult>;
 }
 
 export interface HookTokenOwner {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -103,6 +103,7 @@ export interface QueueCellStub {
   expireRun(
     runId: string,
     expiredAt: number,
+    options?: { limit?: number },
   ): Promise<import('./retention.js').ExpireQueueRunResult>;
 }
 

--- a/src/remote/namespaces.ts
+++ b/src/remote/namespaces.ts
@@ -128,8 +128,7 @@ function makeIndexNamespace(transport: RpcTransport): IndexNamespace {
     finalizeHookIndexes: (token, hookId, serializedHook, owner) =>
       call<void>('finalizeHookIndexes', [token, hookId, serializedHook, owner], false),
     releaseHookToken: (token, owner) => call<void>('releaseHookToken', [token, owner], false),
-    deleteHookIndexes: (token, hookId, owner) =>
-      call<void>('deleteHookIndexes', [token, hookId, owner], false),
+    releaseHookIndexes: (request) => call('releaseHookIndexes', [request], false),
   };
 }
 

--- a/src/retention.ts
+++ b/src/retention.ts
@@ -2,9 +2,8 @@ import type { TerminalWorkflowRunStatus, WorkflowRun } from '@workflow/world';
 
 export const CLEANUP_RECORD_KEY = 'retention:cleanup';
 export const TOMBSTONE_KEY = 'retention:tombstone';
-/** Legacy correlation-index markers retained for upgrade cleanup compatibility. */
-export const INDEX_MARKER_PREFIX = 'retention:index:';
 export const HOOK_MARKER_PREFIX = 'retention:hook:';
+export const TERMINAL_CLEANUP_KEY = 'terminal:cleanup';
 
 export type CleanupPhase = 'retained' | 'index' | 'streams' | 'queues' | 'payload' | 'tombstoned';
 
@@ -18,6 +17,8 @@ export interface CleanupRecord {
   dueAt: Date;
   queueShards: number;
   phase: CleanupPhase;
+  /** Optimistic-concurrency token for alarm/RPC work that awaits another cell. */
+  generation: number;
   attempts: number;
   lastError?: string;
   lastAttemptAt?: Date;
@@ -45,6 +46,27 @@ export interface HookIndexReference {
   token: string;
 }
 
+export interface TerminalCleanupRecord {
+  version: 1;
+  runId: string;
+  phase: 'hooks' | 'waits';
+  generation: number;
+  attempts: number;
+  lastError?: string;
+  lastAttemptAt?: Date;
+}
+
+export interface ReleaseHookIndexesRequest {
+  runId: string;
+  hooks: HookIndexReference[];
+  /** Install a fence that prevents delayed hook finalization after terminal state. */
+  terminal: boolean;
+}
+
+export interface ReleaseHookIndexesResult {
+  deleted: number;
+}
+
 export interface ExpireRunIndexesRequest {
   runId: string;
   keys: string[];
@@ -60,13 +82,26 @@ export interface ExpireRunStreamsResult {
   streams: string[];
 }
 
+export interface FinalizeRunStreamsResult {
+  /** Cumulative registry entries removed for this run. */
+  deleted: number;
+  done: boolean;
+}
+
 export interface ExpireStreamResult {
+  /** True only when this call installed the stream's expiration fence. */
   deleted: boolean;
+  /** Chunk rows removed by this bounded call. */
   chunks: number;
+  /** Payload bytes represented by the removed chunk rows. */
+  bytes: number;
+  done: boolean;
 }
 
 export interface ExpireQueueRunResult {
+  /** Cumulative messages removed for this run in this queue shard. */
   deleted: number;
+  done: boolean;
 }
 
 export interface ScheduleCleanupRequest {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -409,10 +409,12 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
         } else if (hookReservation && data.eventType === 'hook_created') {
           await env.WORKFLOW_INDEX.releaseHookToken(data.eventData.token, hookReservation);
         }
-        for (const released of outcome.releasedHooks) {
-          await env.WORKFLOW_INDEX.deleteHookIndexes(released.token, released.hookId, {
+        const terminal = Boolean(outcome.run && isTerminalWorkflowRunStatus(outcome.run.status));
+        if (terminal || outcome.releasedHooks.length > 0) {
+          await env.WORKFLOW_INDEX.releaseHookIndexes({
             runId: effectiveRunId,
-            hookId: released.hookId,
+            hooks: outcome.releasedHooks,
+            terminal,
           });
         }
 

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -5,7 +5,11 @@ import type {
   StreamInfoResponse,
   Streamer,
 } from '@workflow/world';
-import type { ExpireRunStreamsResult, ExpireStreamResult } from './retention.js';
+import type {
+  ExpireRunStreamsResult,
+  ExpireStreamResult,
+  FinalizeRunStreamsResult,
+} from './retention.js';
 import {
   MAX_STREAM_BATCH_BYTES,
   MAX_STREAM_CHUNK_BYTES,
@@ -72,9 +76,17 @@ export interface StreamDOStub {
   failStream(runId: string, error: StreamErrorData | string): Promise<void>;
   registerStream(runId: string, name: string): Promise<void>;
   listStreams(): Promise<string[]>;
-  expireRegistry(runId: string, expiredAt: number): Promise<ExpireRunStreamsResult>;
-  finalizeRegistry(runId: string): Promise<void>;
-  expireStream(runId: string, expiredAt: number): Promise<ExpireStreamResult>;
+  expireRegistry(
+    runId: string,
+    expiredAt: number,
+    options?: { limit?: number },
+  ): Promise<ExpireRunStreamsResult>;
+  finalizeRegistry(runId: string, streams: string[]): Promise<FinalizeRunStreamsResult>;
+  expireStream(
+    runId: string,
+    expiredAt: number,
+    options?: { limit?: number; byteLimit?: number },
+  ): Promise<ExpireStreamResult>;
 }
 
 export interface StreamDONamespace {

--- a/src/test-mocks.ts
+++ b/src/test-mocks.ts
@@ -39,6 +39,8 @@ import { parse } from './vendor/shared/index.js';
 import type {
   CleanupRecord,
   ExpireRunIndexesRequest,
+  ReleaseHookIndexesRequest,
+  ReleaseHookIndexesResult,
   RunReadOutcome,
   ScheduleCleanupRequest,
 } from './retention.js';
@@ -244,7 +246,12 @@ class MockWorkflowRunDOStub {
  */
 class MockKVNamespace {
   async get(key: string): Promise<string | null> {
-    return kvData.get(key) ?? null;
+    const value = kvData.get(key);
+    if (value && (key.startsWith('hook:') || key.startsWith('hookid:'))) {
+      const hook = parse<Hook>(value);
+      if (kvData.has(`terminal:${hook.runId}`) || kvData.has(`expired:${hook.runId}`)) return null;
+    }
+    return value ?? null;
   }
 
   async put(key: string, value: string): Promise<void> {
@@ -260,6 +267,7 @@ class MockKVNamespace {
   async expireRun(request: ExpireRunIndexesRequest): Promise<{ deleted: number }> {
     kvData.set(`expired:${request.runId}`, String(request.expiredAt));
     let deleted = 0;
+    if (kvData.delete(`terminal:${request.runId}`)) deleted++;
     for (const key of request.keys) {
       if (kvData.delete(key)) deleted++;
     }
@@ -345,6 +353,10 @@ class MockKVNamespace {
     serializedHook: string,
     owner: HookTokenOwner,
   ): Promise<void> {
+    if (kvData.has(`terminal:${owner.runId}`) || kvData.has(`expired:${owner.runId}`)) {
+      await this.releaseHookToken(token, owner);
+      return;
+    }
     const raw = kvData.get(`hook:${token}`);
     if (raw !== undefined) {
       const hook = parse<Hook>(raw);
@@ -375,17 +387,30 @@ class MockKVNamespace {
     }
   }
 
-  async deleteHookIndexes(token: string, hookId: string, owner: HookTokenOwner): Promise<void> {
-    for (const key of [`hook:${token}`, `hookid:${hookId}`]) {
-      const raw = kvData.get(key);
-      if (raw !== undefined) {
-        const hook = parse<Hook>(raw);
-        if (hook.runId === owner.runId && hook.hookId === owner.hookId) {
-          kvData.delete(key);
+  async releaseHookIndexes(request: ReleaseHookIndexesRequest): Promise<ReleaseHookIndexesResult> {
+    if (request.terminal) kvData.set(`terminal:${request.runId}`, String(Date.now()));
+    let deleted = 0;
+    for (const { token, hookId } of request.hooks) {
+      const owner = { runId: request.runId, hookId };
+      for (const key of [`hook:${token}`, `hookid:${hookId}`]) {
+        const raw = kvData.get(key);
+        if (raw !== undefined) {
+          const hook = parse<Hook>(raw);
+          if (hook.runId === owner.runId && hook.hookId === owner.hookId) {
+            deleted += Number(kvData.delete(key));
+          }
+        }
+      }
+      const claimKey = `hookclaim:${token}`;
+      const claim = kvData.get(claimKey);
+      if (claim !== undefined) {
+        const holder = JSON.parse(claim) as HookTokenOwner;
+        if (holder.runId === owner.runId && holder.hookId === owner.hookId) {
+          deleted += Number(kvData.delete(claimKey));
         }
       }
     }
-    await this.releaseHookToken(token, owner);
+    return { deleted };
   }
 }
 
@@ -400,6 +425,7 @@ class MockStreamDOStub {
   private registry = new Set<string>();
   private ownerRunId: string | undefined;
   private expired = false;
+  private registryDeleted = 0;
   private waiters = new Set<() => void>();
 
   private wake(): void {
@@ -511,27 +537,49 @@ class MockStreamDOStub {
     return Array.from(this.registry).toSorted();
   }
 
-  async expireRegistry(runId: string): Promise<{ streams: string[] }> {
+  async expireRegistry(
+    runId: string,
+    _expiredAt: number,
+    options?: { limit?: number },
+  ): Promise<{ streams: string[] }> {
     if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Registry owner mismatch');
     this.ownerRunId = runId;
     this.expired = true;
-    return { streams: Array.from(this.registry) };
+    const streams = Array.from(this.registry);
+    return { streams: streams.slice(0, options?.limit ?? streams.length) };
   }
 
-  async finalizeRegistry(runId: string): Promise<void> {
+  async finalizeRegistry(
+    runId: string,
+    streams: string[],
+  ): Promise<{ deleted: number; done: boolean }> {
     if (this.ownerRunId !== runId || !this.expired) throw new Error('Registry is not expired');
-    this.registry.clear();
+    for (const stream of streams) this.registryDeleted += Number(this.registry.delete(stream));
+    return { deleted: this.registryDeleted, done: this.registry.size === 0 };
   }
 
-  async expireStream(runId: string): Promise<{ deleted: boolean; chunks: number }> {
+  async expireStream(
+    runId: string,
+    _expiredAt: number,
+    options?: { limit?: number; byteLimit?: number },
+  ): Promise<{ deleted: boolean; chunks: number; bytes: number; done: boolean }> {
     if (this.ownerRunId && this.ownerRunId !== runId) throw new Error('Stream owner mismatch');
-    const chunks = this.chunks.length;
+    const firstFence = !this.expired;
+    const limit = Math.min(this.chunks.length, options?.limit ?? this.chunks.length);
+    const byteLimit = options?.byteLimit ?? Number.POSITIVE_INFINITY;
+    let chunks = 0;
+    let bytes = 0;
+    for (const chunk of this.chunks.slice(0, limit)) {
+      if (chunks > 0 && bytes + chunk.byteLength > byteLimit) break;
+      chunks++;
+      bytes += chunk.byteLength;
+    }
     this.ownerRunId = runId;
-    this.chunks = [];
+    this.chunks.splice(0, chunks);
     this.state = 'expired';
     this.expired = true;
     this.wake();
-    return { deleted: true, chunks };
+    return { deleted: firstFence, chunks, bytes, done: this.chunks.length === 0 };
   }
 }
 
@@ -559,8 +607,8 @@ class MockQueueCellStub implements QueueCellStub {
     return { ok: true, messageId: request.messageId, deduped: false };
   }
 
-  async expireRun(): Promise<{ deleted: number }> {
-    return { deleted: 0 };
+  async expireRun(): Promise<{ deleted: number; done: boolean }> {
+    return { deleted: 0, done: true };
   }
 }
 

--- a/src/testing/fake-cell.ts
+++ b/src/testing/fake-cell.ts
@@ -37,6 +37,13 @@ export interface FakeStorageListCall {
   transactional: boolean;
 }
 
+export interface FakeStorageOperationCall {
+  operation: 'get' | 'put' | 'delete';
+  keys: string[];
+  transactional: boolean;
+  synchronous: boolean;
+}
+
 function applyListOptions(keys: string[], options: FakeListOptions): string[] {
   let result = keys.toSorted();
   if (options.prefix !== undefined) {
@@ -86,6 +93,7 @@ export class FakeStorage {
   private transactionTail: Promise<void> = Promise.resolve();
   /** Deterministic query-shape instrumentation for storage scaling tests. */
   listCalls: FakeStorageListCall[] = [];
+  operationCalls: FakeStorageOperationCall[] = [];
   private mutationFailure?: {
     predicate: (mutation: FakeStorageMutation) => boolean;
     error: Error;
@@ -99,11 +107,13 @@ export class FakeStorage {
     if (Array.isArray(keyOrKeys)) {
       this.operationCounts.getMany += 1;
       this.getManyCalls.push([...keyOrKeys]);
+      this.recordStorageCall('get', keyOrKeys, false);
       return new Map(
         keyOrKeys.filter((key) => this.data.has(key)).map((key) => [key, this.data.get(key) as T]),
       );
     }
     this.operationCounts.get += 1;
+    this.recordStorageCall('get', [keyOrKeys], false);
     return this.data.get(keyOrKeys) as T | undefined;
   }
 
@@ -113,6 +123,7 @@ export class FakeStorage {
     if (typeof keyOrEntries === 'string') {
       this.operationCounts.put += 1;
       this.maybeFailMutation({ operation: 'put', key: keyOrEntries, value });
+      this.recordStorageCall('put', [keyOrEntries], false);
       this.data.set(keyOrEntries, structuredClone(value));
       return;
     }
@@ -120,6 +131,7 @@ export class FakeStorage {
     for (const [key, entryValue] of Object.entries(keyOrEntries)) {
       this.maybeFailMutation({ operation: 'put', key, value: entryValue });
     }
+    this.recordStorageCall('put', Object.keys(keyOrEntries), false);
     for (const [key, entryValue] of Object.entries(keyOrEntries)) {
       this.data.set(key, structuredClone(entryValue));
     }
@@ -131,10 +143,12 @@ export class FakeStorage {
     if (typeof keyOrKeys === 'string') {
       this.operationCounts.delete += 1;
       this.maybeFailMutation({ operation: 'delete', key: keyOrKeys });
+      this.recordStorageCall('delete', [keyOrKeys], false);
       return this.data.delete(keyOrKeys);
     }
     this.operationCounts.deleteMany += 1;
     for (const key of keyOrKeys) this.maybeFailMutation({ operation: 'delete', key });
+    this.recordStorageCall('delete', keyOrKeys, false);
     let deleted = 0;
     for (const key of keyOrKeys) if (this.data.delete(key)) deleted += 1;
     return deleted;
@@ -190,11 +204,21 @@ export class FakeStorage {
       this.operationCounts[key] = 0;
     }
     this.getManyCalls.length = 0;
+    this.operationCalls.length = 0;
   }
 
   /** @internal Used by FakeTransaction to count the same platform operations. */
   recordOperation(operation: keyof FakeStorageOperationCounts): void {
     this.operationCounts[operation] += 1;
+  }
+
+  /** @internal Shared with FakeTransaction for deterministic key tracing. */
+  recordStorageCall(
+    operation: FakeStorageOperationCall['operation'],
+    keys: string[],
+    transactional: boolean,
+  ): void {
+    this.operationCalls.push({ operation, keys: [...keys], transactional, synchronous: false });
   }
 
   /** Inject one matching write failure, including writes inside transactions. */
@@ -231,6 +255,8 @@ class FakeTransaction {
   async get<T>(keyOrKeys: string | string[]): Promise<T | undefined | Map<string, T>> {
     if (Array.isArray(keyOrKeys)) {
       this.storage.recordOperation('getMany');
+      this.storage.getManyCalls.push([...keyOrKeys]);
+      this.storage.recordStorageCall('get', keyOrKeys, true);
       const result = new Map<string, T>();
       for (const key of keyOrKeys) {
         if (this.deleted.has(key)) continue;
@@ -241,6 +267,7 @@ class FakeTransaction {
     }
     this.storage.recordOperation('get');
     const key = keyOrKeys;
+    this.storage.recordStorageCall('get', [key], true);
     if (this.deleted.has(key)) return undefined;
     if (this.staged.has(key)) return this.staged.get(key) as T;
     return this.storage.data.get(key) as T | undefined;
@@ -252,6 +279,7 @@ class FakeTransaction {
     if (typeof keyOrEntries === 'string') {
       this.storage.recordOperation('put');
       this.storage.maybeFailMutation({ operation: 'put', key: keyOrEntries, value });
+      this.storage.recordStorageCall('put', [keyOrEntries], true);
       this.deleted.delete(keyOrEntries);
       this.staged.set(keyOrEntries, structuredClone(value));
       return;
@@ -260,6 +288,7 @@ class FakeTransaction {
     for (const [key, entryValue] of Object.entries(keyOrEntries)) {
       this.storage.maybeFailMutation({ operation: 'put', key, value: entryValue });
     }
+    this.storage.recordStorageCall('put', Object.keys(keyOrEntries), true);
     for (const [key, entryValue] of Object.entries(keyOrEntries)) {
       this.deleted.delete(key);
       this.staged.set(key, structuredClone(entryValue));
@@ -271,9 +300,11 @@ class FakeTransaction {
   async delete(keyOrKeys: string | string[]): Promise<boolean | number> {
     if (typeof keyOrKeys === 'string') {
       this.storage.recordOperation('delete');
+      this.storage.recordStorageCall('delete', [keyOrKeys], true);
       return this.deleteOne(keyOrKeys);
     }
     this.storage.recordOperation('deleteMany');
+    this.storage.recordStorageCall('delete', keyOrKeys, true);
     let deleted = 0;
     for (const key of keyOrKeys) if (this.deleteOne(key)) deleted += 1;
     return deleted;

--- a/src/worker/durable-objects/IndexDO.ts
+++ b/src/worker/durable-objects/IndexDO.ts
@@ -2,11 +2,43 @@ import type { Hook } from '@workflow/world';
 import type { HookTokenOwner } from '../../config.js';
 import { parse } from '../../vendor/shared/index.js';
 import { DurableObject } from '../do-base.js';
-import type { ExpireRunIndexesRequest, ExpireRunIndexesResult } from '../../retention.js';
+import type {
+  ExpireRunIndexesRequest,
+  ExpireRunIndexesResult,
+  HookIndexReference,
+  ReleaseHookIndexesRequest,
+  ReleaseHookIndexesResult,
+} from '../../retention.js';
 
 interface HookClaim {
   owner: HookTokenOwner;
   reservedAt: number;
+}
+
+const STORAGE_BATCH_SIZE = 128;
+const MAX_INDEX_CLEANUP_KEYS = 66;
+const MAX_INDEX_CLEANUP_HOOKS = 64;
+const MAX_INDEX_LIST_SIZE = 1000;
+
+async function getMany<T>(
+  storage: DurableObjectTransaction,
+  keys: string[],
+): Promise<Map<string, T>> {
+  const result = new Map<string, T>();
+  for (let offset = 0; offset < keys.length; offset += STORAGE_BATCH_SIZE) {
+    const page = await storage.get<T>(keys.slice(offset, offset + STORAGE_BATCH_SIZE));
+    for (const [key, value] of page) result.set(key, value);
+  }
+  return result;
+}
+
+async function deleteMany(storage: DurableObjectTransaction, keys: string[]): Promise<number> {
+  let deleted = 0;
+  const unique = Array.from(new Set(keys));
+  for (let offset = 0; offset < unique.length; offset += STORAGE_BATCH_SIZE) {
+    deleted += await storage.delete(unique.slice(offset, offset + STORAGE_BATCH_SIZE));
+  }
+  return deleted;
 }
 
 function sameOwner(left: HookTokenOwner, right: HookTokenOwner): boolean {
@@ -16,6 +48,39 @@ function sameOwner(left: HookTokenOwner, right: HookTokenOwner): boolean {
 function ownerFromHook(raw: string): HookTokenOwner {
   const hook = parse<Hook>(raw);
   return { runId: hook.runId, hookId: hook.hookId };
+}
+
+async function ownedHookIndexDeletes(
+  txn: DurableObjectTransaction,
+  runId: string,
+  hooks: HookIndexReference[],
+): Promise<string[]> {
+  const hookKeys = hooks.flatMap((hook) => [
+    `hook:${hook.token}`,
+    `hookid:${hook.hookId}`,
+    `hookclaim:${hook.token}`,
+  ]);
+  const values = await getMany<string | HookClaim>(txn, hookKeys);
+  const deletes: string[] = [];
+  for (const hook of hooks) {
+    const owner = { runId, hookId: hook.hookId };
+    const tokenKey = `hook:${hook.token}`;
+    const idKey = `hookid:${hook.hookId}`;
+    const claimKey = `hookclaim:${hook.token}`;
+    const byToken = values.get(tokenKey) as string | undefined;
+    const byId = values.get(idKey) as string | undefined;
+    const claim = values.get(claimKey) as HookClaim | undefined;
+    if (byToken !== undefined && sameOwner(ownerFromHook(byToken), owner)) {
+      deletes.push(tokenKey);
+    }
+    if (byId !== undefined && sameOwner(ownerFromHook(byId), owner)) {
+      deletes.push(idKey);
+    }
+    if (claim !== undefined && sameOwner(claim.owner, owner)) {
+      deletes.push(claimKey);
+    }
+  }
+  return deletes;
 }
 
 /**
@@ -34,6 +99,14 @@ function ownerFromHook(raw: string): HookTokenOwner {
 export class IndexDO extends DurableObject {
   async get(key: string): Promise<string | null> {
     const value = await this.ctx.storage.get<string>(key);
+    if (value && (key.startsWith('hook:') || key.startsWith('hookid:'))) {
+      const owner = ownerFromHook(value);
+      const fences = await this.ctx.storage.get([
+        `terminal:${owner.runId}`,
+        `expired:${owner.runId}`,
+      ]);
+      if (fences.size > 0) return null;
+    }
     return value ?? null;
   }
 
@@ -67,7 +140,12 @@ export class IndexDO extends DurableObject {
     cursor?: string;
   }> {
     const prefix = options?.prefix ?? '';
-    const limit = options?.limit ?? 1000;
+    const suppliedLimit = options?.limit;
+    const requestedLimit =
+      typeof suppliedLimit === 'number' && Number.isFinite(suppliedLimit)
+        ? Math.floor(suppliedLimit)
+        : MAX_INDEX_LIST_SIZE;
+    const limit = Math.min(MAX_INDEX_LIST_SIZE, Math.max(1, requestedLimit));
 
     // Fetch one extra key to learn whether the listing is complete without
     // advancing past the page (the "exact limit + list_complete" contract
@@ -95,14 +173,15 @@ export class IndexDO extends DurableObject {
     owner: HookTokenOwner,
   ): Promise<{ claimed: boolean; holder?: HookTokenOwner }> {
     return this.ctx.storage.transaction(async (txn) => {
-      const indexedHook = await txn.get<string>(`hook:${token}`);
+      const claimKey = `hookclaim:${token}`;
+      const values = await txn.get<string | HookClaim>([`hook:${token}`, claimKey]);
+      const indexedHook = values.get(`hook:${token}`) as string | undefined;
       if (indexedHook !== undefined) {
         const holder = ownerFromHook(indexedHook);
         return { claimed: false, holder };
       }
 
-      const claimKey = `hookclaim:${token}`;
-      const claim = await txn.get<HookClaim>(claimKey);
+      const claim = values.get(claimKey) as HookClaim | undefined;
       if (claim !== undefined && !sameOwner(claim.owner, owner)) {
         return { claimed: false, holder: claim.owner };
       }
@@ -119,24 +198,32 @@ export class IndexDO extends DurableObject {
     owner: HookTokenOwner,
   ): Promise<void> {
     await this.ctx.storage.transaction(async (txn) => {
-      if ((await txn.get(`expired:${owner.runId}`)) !== undefined) {
-        const claim = await txn.get<HookClaim>(`hookclaim:${token}`);
+      const expiredKey = `expired:${owner.runId}`;
+      const terminalKey = `terminal:${owner.runId}`;
+      const tokenKey = `hook:${token}`;
+      const claimKey = `hookclaim:${token}`;
+      const values = await txn.get<number | string | HookClaim>([
+        expiredKey,
+        terminalKey,
+        tokenKey,
+        claimKey,
+      ]);
+      const claim = values.get(claimKey) as HookClaim | undefined;
+      if (values.get(expiredKey) !== undefined || values.get(terminalKey) !== undefined) {
         if (claim !== undefined && sameOwner(claim.owner, owner)) {
-          await txn.delete(`hookclaim:${token}`);
+          await txn.delete(claimKey);
         }
         return;
       }
-      const indexedHook = await txn.get<string>(`hook:${token}`);
+      const indexedHook = values.get(tokenKey) as string | undefined;
       if (indexedHook !== undefined && !sameOwner(ownerFromHook(indexedHook), owner)) {
         throw new Error(`Hook token ${token} is owned by another hook`);
       }
-      const claim = await txn.get<HookClaim>(`hookclaim:${token}`);
       if (claim !== undefined && !sameOwner(claim.owner, owner)) {
         throw new Error(`Hook token ${token} is reserved by another hook`);
       }
 
-      await txn.put(`hook:${token}`, serializedHook);
-      await txn.put(`hookid:${hookId}`, serializedHook);
+      await txn.put({ [tokenKey]: serializedHook, [`hookid:${hookId}`]: serializedHook });
       if (claim !== undefined) {
         await txn.delete(`hookclaim:${token}`);
       }
@@ -153,25 +240,14 @@ export class IndexDO extends DurableObject {
     });
   }
 
-  async deleteHookIndexes(token: string, hookId: string, owner: HookTokenOwner): Promise<void> {
-    await this.ctx.storage.transaction(async (txn) => {
-      const tokenKey = `hook:${token}`;
-      const idKey = `hookid:${hookId}`;
-      const claimKey = `hookclaim:${token}`;
-      const [byToken, byId, claim] = await Promise.all([
-        txn.get<string>(tokenKey),
-        txn.get<string>(idKey),
-        txn.get<HookClaim>(claimKey),
-      ]);
-      if (byToken !== undefined && sameOwner(ownerFromHook(byToken), owner)) {
-        await txn.delete(tokenKey);
-      }
-      if (byId !== undefined && sameOwner(ownerFromHook(byId), owner)) {
-        await txn.delete(idKey);
-      }
-      if (claim !== undefined && sameOwner(claim.owner, owner)) {
-        await txn.delete(claimKey);
-      }
+  async releaseHookIndexes(request: ReleaseHookIndexesRequest): Promise<ReleaseHookIndexesResult> {
+    if (request.hooks.length > MAX_INDEX_CLEANUP_HOOKS) {
+      throw new Error('Hook index release page exceeds its bounded request limit');
+    }
+    return await this.ctx.storage.transaction(async (txn) => {
+      if (request.terminal) await txn.put(`terminal:${request.runId}`, Date.now());
+      const deletes = await ownedHookIndexDeletes(txn, request.runId, request.hooks);
+      return { deleted: await deleteMany(txn, deletes) };
     });
   }
 
@@ -181,36 +257,21 @@ export class IndexDO extends DurableObject {
    * entries from a delayed request.
    */
   async expireRun(request: ExpireRunIndexesRequest): Promise<ExpireRunIndexesResult> {
+    if (
+      request.keys.length > MAX_INDEX_CLEANUP_KEYS ||
+      request.hooks.length > MAX_INDEX_CLEANUP_HOOKS
+    ) {
+      throw new Error('Index cleanup page exceeds its bounded request limit');
+    }
     return await this.ctx.storage.transaction(async (txn) => {
       await txn.put(`expired:${request.runId}`, request.expiredAt);
-      let deleted = 0;
+      const deletes = [
+        ...request.keys,
+        `terminal:${request.runId}`,
+        ...(await ownedHookIndexDeletes(txn, request.runId, request.hooks)),
+      ];
 
-      for (const key of new Set(request.keys)) {
-        if (await txn.delete(key)) deleted++;
-      }
-
-      for (const hook of request.hooks) {
-        const owner = { runId: request.runId, hookId: hook.hookId };
-        const tokenKey = `hook:${hook.token}`;
-        const idKey = `hookid:${hook.hookId}`;
-        const claimKey = `hookclaim:${hook.token}`;
-        const [byToken, byId, claim] = await Promise.all([
-          txn.get<string>(tokenKey),
-          txn.get<string>(idKey),
-          txn.get<HookClaim>(claimKey),
-        ]);
-        if (byToken !== undefined && sameOwner(ownerFromHook(byToken), owner)) {
-          if (await txn.delete(tokenKey)) deleted++;
-        }
-        if (byId !== undefined && sameOwner(ownerFromHook(byId), owner)) {
-          if (await txn.delete(idKey)) deleted++;
-        }
-        if (claim !== undefined && sameOwner(claim.owner, owner)) {
-          if (await txn.delete(claimKey)) deleted++;
-        }
-      }
-
-      return { deleted };
+      return { deleted: await deleteMany(txn, deletes) };
     });
   }
 }

--- a/src/worker/durable-objects/QueueDO.ts
+++ b/src/worker/durable-objects/QueueDO.ts
@@ -94,6 +94,9 @@ const INFLIGHT_GRACE_MS = 30_000;
 const MIN_ALARM_DELAY_MS = 1;
 /** Bound expiry recovery so one alarm cannot monopolize the cell. */
 const EXPIRED_INFLIGHT_BATCH = 128;
+const STORAGE_BATCH_SIZE = 128;
+const EXPIRE_RUN_REFERENCE_BATCH = 64;
+const PURGE_DEAD_LETTER_BATCH = 128;
 
 const INFLIGHT_DEADLINE_PREFIX = 'inflight-deadline:';
 
@@ -126,6 +129,42 @@ function expiredRunKey(runId: string): string {
   return `expired-run:${runId}`;
 }
 
+function boundedLimit(value: number | undefined, fallback: number, maximum: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(maximum, Math.floor(value)));
+}
+
+async function getMany<T>(
+  storage: DurableObjectTransaction,
+  keys: string[],
+): Promise<Map<string, T>> {
+  const result = new Map<string, T>();
+  for (let offset = 0; offset < keys.length; offset += STORAGE_BATCH_SIZE) {
+    const page = await storage.get<T>(keys.slice(offset, offset + STORAGE_BATCH_SIZE));
+    for (const [key, value] of page) result.set(key, value);
+  }
+  return result;
+}
+
+async function putMany(
+  storage: DurableObjectTransaction,
+  entries: Iterable<readonly [string, unknown]>,
+): Promise<void> {
+  const all = Array.from(entries);
+  for (let offset = 0; offset < all.length; offset += STORAGE_BATCH_SIZE) {
+    await storage.put(Object.fromEntries(all.slice(offset, offset + STORAGE_BATCH_SIZE)));
+  }
+}
+
+async function deleteMany(storage: DurableObjectTransaction, keys: string[]): Promise<number> {
+  let deleted = 0;
+  const unique = Array.from(new Set(keys));
+  for (let offset = 0; offset < unique.length; offset += STORAGE_BATCH_SIZE) {
+    deleted += await storage.delete(unique.slice(offset, offset + STORAGE_BATCH_SIZE));
+  }
+  return deleted;
+}
+
 function backoffSeconds(attempt: number): number {
   return Math.min(60, 2 ** attempt);
 }
@@ -149,6 +188,8 @@ interface QueueCellEnv {
   fetch?: typeof fetch;
 }
 
+const MAX_QUEUE_INFLIGHT = 128;
+
 export class QueueDO extends DurableObject {
   #now(): number {
     const clock = (this.env as QueueCellEnv)?.clock;
@@ -169,7 +210,16 @@ export class QueueDO extends DurableObject {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
   }
 
+  #maxInflight(): number {
+    const configured = this.#intVar('QUEUE_MAX_INFLIGHT', DEFAULT_MAX_INFLIGHT);
+    if (configured > MAX_QUEUE_INFLIGHT) {
+      throw new Error(`QUEUE_MAX_INFLIGHT must be at most ${MAX_QUEUE_INFLIGHT}`);
+    }
+    return configured;
+  }
+
   async enqueue(request: EnqueueRequest): Promise<EnqueueOutcome> {
+    this.#maxInflight();
     const storage = this.ctx.storage;
     const now = this.#now();
 
@@ -276,7 +326,7 @@ export class QueueDO extends DurableObject {
   async #claimPhase(): Promise<InflightClaim[]> {
     const storage = this.ctx.storage;
     const now = this.#now();
-    const maxInflight = this.#intVar('QUEUE_MAX_INFLIGHT', DEFAULT_MAX_INFLIGHT);
+    const maxInflight = this.#maxInflight();
     const claimed = await storage.transaction<InflightClaim[]>(async (txn) => {
       // 1. Recover: an inflight entry past its deadline is a lost delivery
       // (node crash, deploy restart) — back to due for redelivery.
@@ -286,21 +336,33 @@ export class QueueDO extends DurableObject {
         limit: EXPIRED_INFLIGHT_BATCH + 1,
       });
       const expired = Array.from(expiredPage.entries()).slice(0, EXPIRED_INFLIGHT_BATCH);
-      for (const [key, messageId] of expired) {
-        await txn.delete(key);
-        const row = await txn.get<MessageRow>(`msg:${messageId}`);
+      const expiredRows = await getMany<MessageRow>(
+        txn,
+        expired.map(([, messageId]) => `msg:${messageId}`),
+      );
+      await deleteMany(
+        txn,
+        expired.map(([key]) => key),
+      );
+      const recoveryWrites: Array<readonly [string, unknown]> = [];
+      for (const [, messageId] of expired) {
+        const row = expiredRows.get(`msg:${messageId}`);
         if (row) {
           const scheduleKey = dueKey(now, messageId);
-          await txn.put(scheduleKey, messageId);
+          recoveryWrites.push([scheduleKey, messageId]);
           if (row.runId) {
-            await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
-              messageId: row.messageId,
-              dueKey: scheduleKey,
-              idempotencyKey: row.idempotencyKey,
-            });
+            recoveryWrites.push([
+              runReferenceKey(row.runId, row.messageId),
+              {
+                messageId: row.messageId,
+                dueKey: scheduleKey,
+                idempotencyKey: row.idempotencyKey,
+              } satisfies QueueRunReference,
+            ]);
           }
         }
       }
+      await putMany(txn, recoveryWrites);
       if (expiredPage.size > EXPIRED_INFLIGHT_BATCH) {
         await txn.setAlarm(now + MIN_ALARM_DELAY_MS);
         return [];
@@ -323,21 +385,30 @@ export class QueueDO extends DurableObject {
           limit: maxInflight - inflightCount,
         });
         const timeoutMs = this.#intVar('QUEUE_DELIVERY_TIMEOUT_MS', DEFAULT_DELIVERY_TIMEOUT_MS);
-        for (const [key, messageId] of due) {
-          await txn.delete(key);
-          const row = await txn.get<MessageRow>(`msg:${messageId}`);
+        const dueRows = await getMany<MessageRow>(
+          txn,
+          Array.from(due.values(), (messageId) => `msg:${messageId}`),
+        );
+        await deleteMany(txn, Array.from(due.keys()));
+        const claimWrites: Array<readonly [string, unknown]> = [];
+        for (const [, messageId] of due) {
+          const row = dueRows.get(`msg:${messageId}`);
           if (!row) continue; // orphaned schedule entry
           const claimKey = inflightKey(now + timeoutMs + INFLIGHT_GRACE_MS, messageId);
-          await txn.put(claimKey, messageId);
+          claimWrites.push([claimKey, messageId]);
           if (row.runId) {
-            await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
-              messageId: row.messageId,
-              inflightKey: claimKey,
-              idempotencyKey: row.idempotencyKey,
-            });
+            claimWrites.push([
+              runReferenceKey(row.runId, row.messageId),
+              {
+                messageId: row.messageId,
+                inflightKey: claimKey,
+                idempotencyKey: row.idempotencyKey,
+              } satisfies QueueRunReference,
+            ]);
           }
           rows.push({ row, inflightKey: claimKey });
         }
+        await putMany(txn, claimWrites);
       }
       await this.#scheduleNextAlarm(txn, now);
       return rows;
@@ -630,18 +701,20 @@ export class QueueDO extends DurableObject {
     return outcome;
   }
 
-  async purgeDeadLetters(): Promise<{ purged: number }> {
+  async purgeDeadLetters(): Promise<{ purged: number; hasMore: boolean }> {
     const storage = this.ctx.storage;
     return await storage.transaction(async (txn) => {
-      const dlq = await txn.list({ prefix: 'dlq:' });
-      for (const [key, value] of dlq) {
-        await txn.delete(key);
-        const dead = value as DeadLetterRow;
-        if (dead.runId) {
-          await txn.delete(runReferenceKey(dead.runId, dead.messageId));
-        }
-      }
-      return { purged: dlq.size };
+      const entries = await txn.list<DeadLetterRow>({
+        prefix: 'dlq:',
+        limit: PURGE_DEAD_LETTER_BATCH + 1,
+      });
+      const page = Array.from(entries).slice(0, PURGE_DEAD_LETTER_BATCH);
+      const keys = page.flatMap(([key, dead]) => [
+        key,
+        ...(dead.runId ? [runReferenceKey(dead.runId, dead.messageId)] : []),
+      ]);
+      await deleteMany(txn, keys);
+      return { purged: page.length, hasMore: entries.size > PURGE_DEAD_LETTER_BATCH };
     });
   }
 
@@ -655,30 +728,45 @@ export class QueueDO extends DurableObject {
   }
 
   /** Fence a run and purge every live, inflight, and dead-letter message it owns. */
-  async expireRun(runId: string, expiredAt: number): Promise<ExpireQueueRunResult> {
+  async expireRun(
+    runId: string,
+    expiredAt: number,
+    options?: { limit?: number },
+  ): Promise<ExpireQueueRunResult> {
     const storage = this.ctx.storage;
-    const deleted = await storage.transaction(async (txn) => {
+    const limit = boundedLimit(
+      options?.limit,
+      EXPIRE_RUN_REFERENCE_BATCH,
+      EXPIRE_RUN_REFERENCE_BATCH,
+    );
+    return await storage.transaction(async (txn) => {
       const existing = await txn.get<ExpiredRunFence>(expiredRunKey(runId));
-      const references = await txn.list<QueueRunReference>({ prefix: `run:${runId}:` });
+      const references = await txn.list<QueueRunReference>({
+        prefix: `run:${runId}:`,
+        limit: limit + 1,
+      });
+      const page = Array.from(references).slice(0, limit);
+      const dedupKeys = page.flatMap(([, reference]) =>
+        reference.idempotencyKey ? [`key:${reference.idempotencyKey}`] : [],
+      );
+      const dedupHolders = await getMany<string>(txn, dedupKeys);
+      const keys: string[] = [];
       let count = existing?.deleted ?? 0;
-      for (const [key, reference] of references) {
-        await txn.delete(`msg:${reference.messageId}`);
-        if (reference.inflightKey) await txn.delete(reference.inflightKey);
-        if (reference.dueKey) await txn.delete(reference.dueKey);
-        if (reference.dlqKey) await txn.delete(reference.dlqKey);
+      for (const [key, reference] of page) {
+        keys.push(`msg:${reference.messageId}`, key);
+        if (reference.inflightKey) keys.push(reference.inflightKey);
+        if (reference.dueKey) keys.push(reference.dueKey);
+        if (reference.dlqKey) keys.push(reference.dlqKey);
         if (reference.idempotencyKey) {
           const dedupKey = `key:${reference.idempotencyKey}`;
-          if ((await txn.get<string>(dedupKey)) === reference.messageId) {
-            await txn.delete(dedupKey);
-          }
+          if (dedupHolders.get(dedupKey) === reference.messageId) keys.push(dedupKey);
         }
-        await txn.delete(key);
         count++;
       }
+      await deleteMany(txn, keys);
       await txn.put<ExpiredRunFence>(expiredRunKey(runId), { expiredAt, deleted: count });
       await this.#scheduleNextAlarm(txn, this.#now());
-      return count;
+      return { deleted: count, done: references.size <= limit };
     });
-    return { deleted };
   }
 }

--- a/src/worker/durable-objects/StreamDO.ts
+++ b/src/worker/durable-objects/StreamDO.ts
@@ -1,4 +1,8 @@
-import type { ExpireRunStreamsResult, ExpireStreamResult } from '../../retention.js';
+import type {
+  ExpireRunStreamsResult,
+  ExpireStreamResult,
+  FinalizeRunStreamsResult,
+} from '../../retention.js';
 import {
   MAX_STREAM_CHUNK_BYTES,
   normalizeStreamError,
@@ -30,6 +34,11 @@ interface StreamWaiter {
   onAbort?: () => void;
 }
 
+interface RegistryExpiry {
+  expiredAt: number;
+  deleted: number;
+}
+
 const META_KEY = 'meta';
 const CHUNK_KEY_PREFIX = 'chunk:';
 const CHUNK_SIZE_KEY_PREFIX = 'chunk-size:';
@@ -37,7 +46,17 @@ const CHUNK_SIZE_KEY_PREFIX = 'chunk-size:';
 const STREAM_REGISTRY_PREFIX = 'stream:';
 const REGISTRY_OWNER_KEY = 'registry:owner';
 const REGISTRY_EXPIRED_KEY = 'registry:expired';
-const RETENTION_DELETE_BATCH = 128;
+/** Each chunk occupies a payload key and a size key; one delete accepts at most 128 keys. */
+const DEFAULT_EXPIRE_CHUNK_LIMIT = 64;
+const MAX_EXPIRE_CHUNK_LIMIT = 64;
+/** Bound storage deletion work as well as item count; one oversized chunk still makes progress. */
+const DEFAULT_EXPIRE_BYTE_LIMIT = 16 * 1024 * 1024;
+const MAX_EXPIRE_BYTE_LIMIT = DEFAULT_EXPIRE_BYTE_LIMIT;
+
+function boundedLimit(value: number | undefined, fallback: number, maximum: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(maximum, Math.floor(value)));
+}
 
 function emptyMeta(): StreamMeta {
   return { count: 0, state: 'open' };
@@ -65,6 +84,15 @@ function chunkKey(index: number): string {
 
 function chunkSizeKey(index: number): string {
   return `${CHUNK_SIZE_KEY_PREFIX}${index.toString().padStart(12, '0')}`;
+}
+
+function indexFromChunkSizeKey(key: string): number {
+  const suffix = key.slice(CHUNK_SIZE_KEY_PREFIX.length);
+  const index = Number(suffix);
+  if (!/^\d{12}$/.test(suffix) || !Number.isSafeInteger(index) || index < 0) {
+    throw new Error(`Invalid persisted stream chunk size key "${key}"`);
+  }
+  return index;
 }
 
 function validateChunkSize(size: unknown, index: number): number {
@@ -369,89 +397,124 @@ export class StreamDO extends DurableObject {
   }
 
   /** Fence a run's registry before any stream cells are removed. */
-  async expireRegistry(runId: string, expiredAt: number): Promise<ExpireRunStreamsResult> {
+  async expireRegistry(
+    runId: string,
+    expiredAt: number,
+    options?: { limit?: number },
+  ): Promise<ExpireRunStreamsResult> {
+    const limit = boundedLimit(options?.limit, 16, 128);
     return await this.ctx.storage.transaction(async (txn) => {
-      const owner = await txn.get<string>(REGISTRY_OWNER_KEY);
+      const state = await txn.get<string | RegistryExpiry>([
+        REGISTRY_OWNER_KEY,
+        REGISTRY_EXPIRED_KEY,
+      ]);
+      const owner = state.get(REGISTRY_OWNER_KEY) as string | undefined;
       if (owner !== undefined && owner !== runId) {
         throw new Error(`Stream registry is owned by workflow run "${owner}"`);
       }
-      await txn.put(REGISTRY_OWNER_KEY, runId);
-      await txn.put(REGISTRY_EXPIRED_KEY, expiredAt);
-      const entries = await txn.list<boolean>({ prefix: STREAM_REGISTRY_PREFIX });
+      const expiry = state.get(REGISTRY_EXPIRED_KEY) as RegistryExpiry | undefined;
+      await txn.put({
+        [REGISTRY_OWNER_KEY]: runId,
+        [REGISTRY_EXPIRED_KEY]: expiry ?? { expiredAt, deleted: 0 },
+      });
+      const entries = await txn.list<boolean>({ prefix: STREAM_REGISTRY_PREFIX, limit });
       return {
         streams: Array.from(entries.keys()).map((key) => key.slice(STREAM_REGISTRY_PREFIX.length)),
       };
     });
   }
 
-  /** Remove the registry payload after every referenced stream was fenced. */
-  async finalizeRegistry(runId: string): Promise<void> {
-    await this.ctx.storage.transaction(async (txn) => {
-      const owner = await txn.get<string>(REGISTRY_OWNER_KEY);
-      const expiredAt = await txn.get<number>(REGISTRY_EXPIRED_KEY);
-      if (owner !== runId || expiredAt === undefined) {
+  /** Remove completed registry entries in a bounded, retry-safe batch. */
+  async finalizeRegistry(runId: string, streams: string[]): Promise<FinalizeRunStreamsResult> {
+    return await this.ctx.storage.transaction(async (txn) => {
+      const state = await txn.get<string | RegistryExpiry>([
+        REGISTRY_OWNER_KEY,
+        REGISTRY_EXPIRED_KEY,
+      ]);
+      const owner = state.get(REGISTRY_OWNER_KEY) as string | undefined;
+      const expiry = state.get(REGISTRY_EXPIRED_KEY) as RegistryExpiry | undefined;
+      if (owner !== runId || expiry === undefined) {
         throw new Error(`Stream registry for workflow run "${runId}" is not expired`);
       }
-      const entries = await txn.list({ prefix: STREAM_REGISTRY_PREFIX });
-      const keys = Array.from(entries.keys());
-      for (let offset = 0; offset < keys.length; offset += RETENTION_DELETE_BATCH) {
-        await txn.delete(keys.slice(offset, offset + RETENTION_DELETE_BATCH));
-      }
+      const keys = Array.from(new Set(streams.map((name) => `${STREAM_REGISTRY_PREFIX}${name}`)));
+      const removed = keys.length === 0 ? 0 : await txn.delete(keys);
+      const deleted = expiry.deleted + removed;
+      await txn.put<RegistryExpiry>(REGISTRY_EXPIRED_KEY, { ...expiry, deleted });
+      const remaining = await txn.list({ prefix: STREAM_REGISTRY_PREFIX, limit: 1 });
+      return { deleted, done: remaining.size === 0 };
     });
   }
 
   /**
-   * Fence first, wake readers, then delete known chunk keys in bounded groups.
-   * The tombstone records progress so restart/retry remains idempotent.
+   * Fence the stream and delete one bounded page. Listing size keys avoids
+   * loading payloads, and the transaction makes a crash retry resume safely.
    */
-  async expireStream(runId: string, expiredAt: number): Promise<ExpireStreamResult> {
+  async expireStream(
+    runId: string,
+    expiredAt: number,
+    options?: { limit?: number; byteLimit?: number },
+  ): Promise<ExpireStreamResult> {
+    const limit = boundedLimit(options?.limit, DEFAULT_EXPIRE_CHUNK_LIMIT, MAX_EXPIRE_CHUNK_LIMIT);
+    const byteLimit = boundedLimit(
+      options?.byteLimit,
+      DEFAULT_EXPIRE_BYTE_LIMIT,
+      MAX_EXPIRE_BYTE_LIMIT,
+    );
     return await this.runMutation(async () => {
-      const fenced = await this.ctx.storage.transaction(async (txn) => {
+      const result = await this.ctx.storage.transaction(async (txn) => {
         const stored = await txn.get<StreamMeta>(META_KEY);
         const meta = stored ? validateMeta(stored) : emptyMeta();
         this.assertOwner(meta, runId);
-        const chunkCount = meta.expiredChunkCount ?? meta.count;
+        const firstFence = meta.state !== 'expired';
         if (meta.state === 'expired' && meta.payloadDeleted) {
-          return { meta, chunkCount, alreadyDeleted: true };
+          return {
+            meta,
+            result: { deleted: false, chunks: 0, bytes: 0, done: true },
+          };
         }
+
+        const candidates = await txn.list<number>({
+          prefix: CHUNK_SIZE_KEY_PREFIX,
+          limit: limit + 1,
+        });
+        const page: Array<{ index: number; size: number }> = [];
+        let bytes = 0;
+        for (const [key, storedSize] of Array.from(candidates).slice(0, limit)) {
+          const index = indexFromChunkSizeKey(key);
+          const size = validateChunkSize(storedSize, index);
+          if (page.length > 0 && bytes + size > byteLimit) break;
+          page.push({ index, size });
+          bytes += size;
+        }
+        const keys = page.flatMap(({ index }) => [chunkKey(index), chunkSizeKey(index)]);
+        if (keys.length > 0) await txn.delete(keys);
+        const done = candidates.size === page.length;
         const nextMeta: StreamMeta = {
           ...meta,
+          count: done ? 0 : meta.count,
           ownerRunId: runId,
           state: 'expired',
           error: undefined,
-          expiredAt,
-          expiredChunkCount: chunkCount,
-          payloadDeleted: false,
+          expiredAt: meta.expiredAt ?? expiredAt,
+          expiredChunkCount: meta.expiredChunkCount ?? meta.count,
+          payloadDeleted: done,
         };
         await txn.put(META_KEY, nextMeta);
-        return { meta: nextMeta, chunkCount, alreadyDeleted: false };
+        return {
+          meta: nextMeta,
+          result: {
+            deleted: firstFence,
+            chunks: page.length,
+            bytes,
+            done,
+          } satisfies ExpireStreamResult,
+        };
       });
 
-      this.meta = fenced.meta;
-      this.metaLoad = Promise.resolve(fenced.meta);
+      this.meta = result.meta;
+      this.metaLoad = Promise.resolve(result.meta);
       this.wakeReaders();
-
-      if (!fenced.alreadyDeleted) {
-        const deleteIndexesPerBatch = Math.floor(RETENTION_DELETE_BATCH / 2);
-        for (let offset = 0; offset < fenced.chunkCount; offset += deleteIndexesPerBatch) {
-          const keys: string[] = [];
-          const end = Math.min(fenced.chunkCount, offset + deleteIndexesPerBatch);
-          for (let index = offset; index < end; index++) {
-            keys.push(chunkKey(index), chunkSizeKey(index));
-          }
-          await this.ctx.storage.delete(keys);
-        }
-        const tombstone: StreamMeta = {
-          ...fenced.meta,
-          count: 0,
-          payloadDeleted: true,
-        };
-        await this.ctx.storage.put(META_KEY, tombstone);
-        this.meta = tombstone;
-        this.metaLoad = Promise.resolve(tombstone);
-      }
-
-      return { deleted: true, chunks: fenced.chunkCount };
+      return result.result;
     });
   }
 }

--- a/src/worker/durable-objects/WorkflowRunDO.ts
+++ b/src/worker/durable-objects/WorkflowRunDO.ts
@@ -14,6 +14,7 @@ import {
   listByPrefix,
   STEP_CREATED_KEY_PREFIX,
   STEP_KEY_PREFIX,
+  WAIT_KEY_PREFIX,
 } from '../../apply-event.js';
 import {
   CLEANUP_RECORD_KEY,
@@ -24,15 +25,19 @@ import {
   type ExpireRunIndexesResult,
   type ExpireRunStreamsResult,
   type ExpireStreamResult,
+  type FinalizeRunStreamsResult,
   expiredRead,
   globalRunIndexKey,
   HOOK_MARKER_PREFIX,
   type HookIndexReference,
   hookMarkerKey,
-  INDEX_MARKER_PREFIX,
+  type ReleaseHookIndexesRequest,
+  type ReleaseHookIndexesResult,
   type RunReadOutcome,
   type RunTombstone,
   type ScheduleCleanupRequest,
+  TERMINAL_CLEANUP_KEY,
+  type TerminalCleanupRecord,
   TOMBSTONE_KEY,
   workflowRunIndexKey,
 } from '../../retention.js';
@@ -48,16 +53,29 @@ interface CellNamespace<T> {
 
 interface IndexCleanupStub {
   expireRun(request: ExpireRunIndexesRequest): Promise<ExpireRunIndexesResult>;
+  releaseHookIndexes(request: ReleaseHookIndexesRequest): Promise<ReleaseHookIndexesResult>;
 }
 
 interface StreamCleanupStub {
-  expireRegistry(runId: string, expiredAt: number): Promise<ExpireRunStreamsResult>;
-  finalizeRegistry(runId: string): Promise<void>;
-  expireStream(runId: string, expiredAt: number): Promise<ExpireStreamResult>;
+  expireRegistry(
+    runId: string,
+    expiredAt: number,
+    options?: { limit?: number },
+  ): Promise<ExpireRunStreamsResult>;
+  finalizeRegistry(runId: string, streams: string[]): Promise<FinalizeRunStreamsResult>;
+  expireStream(
+    runId: string,
+    expiredAt: number,
+    options?: { limit?: number; byteLimit?: number },
+  ): Promise<ExpireStreamResult>;
 }
 
 interface QueueCleanupStub {
-  expireRun(runId: string, expiredAt: number): Promise<ExpireQueueRunResult>;
+  expireRun(
+    runId: string,
+    expiredAt: number,
+    options?: { limit?: number },
+  ): Promise<ExpireQueueRunResult>;
 }
 
 interface WorkflowRunDOEnv {
@@ -68,10 +86,24 @@ interface WorkflowRunDOEnv {
   clock?: () => number;
 }
 
-const PAYLOAD_DELETE_BATCH = 256;
-const STREAM_DELETE_CONCURRENCY = 16;
+const STORAGE_BATCH_SIZE = 128;
+const PAYLOAD_DELETE_BATCH = STORAGE_BATCH_SIZE;
+const HOOK_MARKER_PAGE_SIZE = 64;
+const TERMINAL_HOOK_PAGE_SIZE = 64;
+const TERMINAL_WAIT_PAGE_SIZE = STORAGE_BATCH_SIZE;
+const STREAMS_PER_CLEANUP_PAGE = 16;
+const STREAM_CHUNKS_PER_CLEANUP_PAGE = STORAGE_BATCH_SIZE;
+const STREAM_BYTES_PER_CLEANUP_PAGE = 16 * 1024 * 1024;
+const QUEUE_REFERENCES_PER_CLEANUP_PAGE = 64;
+const QUEUE_SHARDS_PER_CLEANUP_PAGE = 8;
 const CLEANUP_RETRY_MAX_MS = 60 * 60 * 1000;
+const CLEANUP_PROGRESS_KEY = 'retention:progress';
 type TerminalRun = Extract<WorkflowRun, { status: 'completed' | 'failed' | 'cancelled' }>;
+
+interface CleanupProgress {
+  queueShard: number;
+  queueShardDeleted: number;
+}
 
 /**
  * Adapt DO storage (or a transaction) to the {@link EventStore} interface
@@ -81,10 +113,27 @@ type TerminalRun = Extract<WorkflowRun, { status: 'completed' | 'failed' | 'canc
 function storeFrom(storage: DurableObjectStorage | DurableObjectTransaction): EventStore {
   return {
     get: (key) => storage.get(key),
+    getMany: (keys) => storage.get(keys),
     put: (key, value) => storage.put(key, value),
     delete: (key) => storage.delete(key),
+    deleteMany: (keys) => storage.delete(keys),
     list: (options) => storage.list(options),
+    deferTerminalCleanup: true,
   };
+}
+
+function hookCreationIndexKey(hook: Hook): string {
+  return `${HOOK_CREATED_KEY_PREFIX}${hook.createdAt.toISOString()}:${hook.hookId}`;
+}
+
+async function putStorageEntries(
+  storage: DurableObjectTransaction,
+  entries: Iterable<readonly [string, unknown]>,
+): Promise<void> {
+  const all = Array.from(entries);
+  for (let offset = 0; offset < all.length; offset += STORAGE_BATCH_SIZE) {
+    await storage.put(Object.fromEntries(all.slice(offset, offset + STORAGE_BATCH_SIZE)));
+  }
 }
 
 interface InflightClaim {
@@ -108,28 +157,60 @@ export class WorkflowRunDO extends DurableObject {
     return typeof clock === 'function' ? clock() : Date.now();
   }
 
-  private async expiredTombstone(
-    storage: Pick<DurableObjectStorage, 'get'>,
+  private tombstoneFrom(
+    values: Map<string, RunTombstone | CleanupRecord>,
     now = this.now(),
-  ): Promise<RunTombstone | null> {
-    const tombstone = await storage.get<RunTombstone>(TOMBSTONE_KEY);
+  ): RunTombstone | null {
+    const tombstone = values.get(TOMBSTONE_KEY) as RunTombstone | undefined;
     if (tombstone) return tombstone;
-    const cleanup = await storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+    const cleanup = values.get(CLEANUP_RECORD_KEY) as CleanupRecord | undefined;
     if (!cleanup || (cleanup.phase === 'retained' && cleanup.dueAt.getTime() > now)) return null;
     return cleanupTombstone(cleanup, cleanup.tombstonedAt ?? cleanup.dueAt);
   }
 
-  private async read<T>(reader: () => Promise<T>): Promise<RunReadOutcome<T>> {
-    const tombstone = await this.expiredTombstone(this.ctx.storage);
-    if (tombstone) return expiredRead(tombstone);
-    return { ok: true, value: await reader() };
+  private async retentionState(
+    storage: DurableObjectStorage | DurableObjectTransaction,
+    now = this.now(),
+  ): Promise<{ cleanup?: CleanupRecord; tombstone: RunTombstone | null }> {
+    const values = await storage.get<RunTombstone | CleanupRecord>([
+      TOMBSTONE_KEY,
+      CLEANUP_RECORD_KEY,
+    ]);
+    return {
+      cleanup: values.get(CLEANUP_RECORD_KEY) as CleanupRecord | undefined,
+      tombstone: this.tombstoneFrom(values, now),
+    };
+  }
+
+  private async read<T>(
+    reader: (storage: DurableObjectTransaction) => Promise<T>,
+  ): Promise<RunReadOutcome<T>> {
+    return await this.ctx.storage.transaction(async (txn) => {
+      const { tombstone } = await this.retentionState(txn);
+      if (tombstone) return expiredRead(tombstone);
+      return { ok: true, value: await reader(txn) };
+    });
+  }
+
+  private async readKey<T>(key: string): Promise<RunReadOutcome<T | null>> {
+    return await this.ctx.storage.transaction(async (txn) => {
+      const values = await txn.get<RunTombstone | CleanupRecord | T>([
+        TOMBSTONE_KEY,
+        CLEANUP_RECORD_KEY,
+        key,
+      ]);
+      const tombstone = this.tombstoneFrom(values as Map<string, RunTombstone | CleanupRecord>);
+      if (tombstone) return expiredRead<T | null>(tombstone);
+      return { ok: true, value: (values.get(key) as T | undefined) ?? null };
+    });
   }
 
   /** Apply an event and capture all retention metadata in the same transaction. */
   async applyEvent(request: ApplyEventRequest): Promise<ApplyEventOutcome> {
     return await this.ctx.storage.transaction(async (txn) => {
       const now = new Date(this.now());
-      const tombstone = await this.expiredTombstone(txn, now.getTime());
+      const retention = await this.retentionState(txn, now.getTime());
+      const { tombstone } = retention;
       if (tombstone) {
         return {
           ok: false,
@@ -147,23 +228,26 @@ export class WorkflowRunDO extends DurableObject {
       if (!outcome.ok) return outcome;
 
       await txn.put('event_sequence', eventSequence);
-      if (outcome.hookToIndex) {
-        const reference = {
-          hookId: outcome.hookToIndex.hookId,
-          token: outcome.hookToIndex.token,
-        };
-        await txn.put(hookMarkerKey(reference), reference);
-      }
-      for (const reference of outcome.releasedHooks) {
-        await txn.put(hookMarkerKey(reference), reference);
-      }
+      const hookReferences: HookIndexReference[] = outcome.hookToIndex
+        ? [
+            {
+              hookId: outcome.hookToIndex.hookId,
+              token: outcome.hookToIndex.token,
+            },
+            ...outcome.releasedHooks,
+          ]
+        : outcome.releasedHooks;
+      await putStorageEntries(
+        txn,
+        hookReferences.map((reference) => [hookMarkerKey(reference), reference] as const),
+      );
 
       const retentionMs = request.cleanup?.retentionMs ?? 0;
       if (
         retentionMs > 0 &&
         outcome.run &&
         isTerminalWorkflowRunStatus(outcome.run.status) &&
-        !(await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY))
+        !retention.cleanup
       ) {
         const terminalRun = outcome.run as TerminalRun;
         const dueAt = new Date(terminalRun.completedAt.getTime() + retentionMs);
@@ -178,6 +262,7 @@ export class WorkflowRunDO extends DurableObject {
           dueAt,
           queueShards: request.cleanup?.queueShards ?? 1,
           phase: 'retained',
+          generation: 0,
           attempts: 0,
           deletedPayloadKeys: 0,
           deletedStreams: 0,
@@ -188,18 +273,29 @@ export class WorkflowRunDO extends DurableObject {
         await txn.setAlarm(dueAt);
         outcome.run = run;
       }
+      if (outcome.run && isTerminalWorkflowRunStatus(outcome.run.status)) {
+        const terminalCleanup = await txn.get<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY);
+        if (!terminalCleanup) {
+          await txn.put<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY, {
+            version: 1,
+            runId: outcome.run.runId,
+            phase: 'hooks',
+            generation: 0,
+            attempts: 0,
+          });
+        }
+        await txn.setAlarm(this.now() + 1);
+      }
       return finalizeEventPage(storeFrom(txn), outcome, request.params);
     });
   }
 
   async getRun(): Promise<RunReadOutcome<WorkflowRun | null>> {
-    return this.read(async () => (await this.ctx.storage.get<WorkflowRun>('run')) ?? null);
+    return this.readKey<WorkflowRun>('run');
   }
 
   async getStep(stepId: string): Promise<RunReadOutcome<Step | null>> {
-    return this.read(
-      async () => (await this.ctx.storage.get<Step>(`${STEP_KEY_PREFIX}${stepId}`)) ?? null,
-    );
+    return this.readKey<Step>(`${STEP_KEY_PREFIX}${stepId}`);
   }
 
   async listSteps(params?: {
@@ -207,24 +303,17 @@ export class WorkflowRunDO extends DurableObject {
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
   }): Promise<RunReadOutcome<{ data: Step[]; cursor: string | null; hasMore: boolean }>> {
-    return this.read(() =>
-      listByCreationTime<Step>(
-        storeFrom(this.ctx.storage),
-        STEP_CREATED_KEY_PREFIX,
-        STEP_KEY_PREFIX,
-        {
-          limit: params?.limit ?? 20,
-          cursor: params?.cursor,
-          sortOrder: params?.sortOrder ?? 'asc',
-        },
-      ),
+    return this.read((txn) =>
+      listByCreationTime<Step>(storeFrom(txn), STEP_CREATED_KEY_PREFIX, STEP_KEY_PREFIX, {
+        limit: params?.limit ?? 20,
+        cursor: params?.cursor,
+        sortOrder: params?.sortOrder ?? 'asc',
+      }),
     );
   }
 
   async getEvent(eventId: string): Promise<RunReadOutcome<Event | null>> {
-    return this.read(
-      async () => (await this.ctx.storage.get<Event>(`${EVENT_KEY_PREFIX}${eventId}`)) ?? null,
-    );
+    return this.readKey<Event>(`${EVENT_KEY_PREFIX}${eventId}`);
   }
 
   async listEvents(params?: {
@@ -232,9 +321,9 @@ export class WorkflowRunDO extends DurableObject {
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
   }): Promise<RunReadOutcome<{ data: Event[]; cursor: string | null; hasMore: boolean }>> {
-    return this.read(() =>
+    return this.read((txn) =>
       listByPrefix<Event>(
-        storeFrom(this.ctx.storage),
+        storeFrom(txn),
         EVENT_KEY_PREFIX,
         {
           limit: params?.limit ?? 100,
@@ -251,17 +340,12 @@ export class WorkflowRunDO extends DurableObject {
     cursor?: string;
     sortOrder?: 'asc' | 'desc';
   }): Promise<RunReadOutcome<{ data: Hook[]; cursor: string | null; hasMore: boolean }>> {
-    return this.read(() =>
-      listByCreationTime<Hook>(
-        storeFrom(this.ctx.storage),
-        HOOK_CREATED_KEY_PREFIX,
-        HOOK_KEY_PREFIX,
-        {
-          limit: params?.limit ?? 100,
-          cursor: params?.cursor,
-          sortOrder: params?.sortOrder ?? 'asc',
-        },
-      ),
+    return this.read((txn) =>
+      listByCreationTime<Hook>(storeFrom(txn), HOOK_CREATED_KEY_PREFIX, HOOK_KEY_PREFIX, {
+        limit: params?.limit ?? 100,
+        cursor: params?.cursor,
+        sortOrder: params?.sortOrder ?? 'asc',
+      }),
     );
   }
 
@@ -273,10 +357,13 @@ export class WorkflowRunDO extends DurableObject {
   async scheduleCleanup(request: ScheduleCleanupRequest): Promise<CleanupRecord | null> {
     if (request.retentionMs <= 0) return this.getCleanupStatus();
     return await this.ctx.storage.transaction(async (txn) => {
-      const existing = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      const values = await txn.get<
+        CleanupRecord | RunTombstone | TerminalCleanupRecord | WorkflowRun
+      >([CLEANUP_RECORD_KEY, TOMBSTONE_KEY, TERMINAL_CLEANUP_KEY, 'run']);
+      const existing = values.get(CLEANUP_RECORD_KEY) as CleanupRecord | undefined;
       if (existing) return existing;
-      if (await txn.get<RunTombstone>(TOMBSTONE_KEY)) return null;
-      const current = await txn.get<WorkflowRun>('run');
+      if (values.get(TOMBSTONE_KEY)) return null;
+      const current = values.get('run') as WorkflowRun | undefined;
       if (!current || !isTerminalWorkflowRunStatus(current.status)) return null;
       const terminalRun = current as TerminalRun;
       const dueAt = new Date(terminalRun.completedAt.getTime() + request.retentionMs);
@@ -291,6 +378,7 @@ export class WorkflowRunDO extends DurableObject {
         dueAt,
         queueShards: request.queueShards,
         phase: 'retained',
+        generation: 0,
         attempts: 0,
         deletedPayloadKeys: 0,
         deletedStreams: 0,
@@ -298,7 +386,9 @@ export class WorkflowRunDO extends DurableObject {
       };
       await txn.put('run', run);
       await txn.put(CLEANUP_RECORD_KEY, cleanup);
-      await txn.setAlarm(dueAt.getTime() <= this.now() ? this.now() + 1 : dueAt);
+      await txn.setAlarm(
+        values.get(TERMINAL_CLEANUP_KEY) || dueAt.getTime() <= this.now() ? this.now() + 1 : dueAt,
+      );
       return cleanup;
     });
   }
@@ -313,34 +403,36 @@ export class WorkflowRunDO extends DurableObject {
       const dueAt = new Date(this.now());
       const run = await txn.get<WorkflowRun>('run');
       if (run) await txn.put('run', WorkflowRunSchema.parse({ ...run, expiredAt: dueAt }));
-      await txn.put(CLEANUP_RECORD_KEY, { ...cleanup, dueAt });
+      await txn.put(CLEANUP_RECORD_KEY, {
+        ...cleanup,
+        dueAt,
+        generation: cleanup.generation + 1,
+      });
       await txn.setAlarm(this.now() + 1);
     });
-    try {
-      await this.executeCleanup();
-    } catch (error) {
-      await this.recordCleanupFailure(error);
-    }
+    await this.executeScheduledCleanupPage();
     return this.getCleanupStatus();
   }
 
   async rearmCleanup(): Promise<CleanupRecord | null> {
-    const cleanup = await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
-    if (!cleanup) return null;
-    if (cleanup.phase === 'tombstoned') {
+    const values = await this.ctx.storage.get<CleanupRecord | TerminalCleanupRecord>([
+      CLEANUP_RECORD_KEY,
+      TERMINAL_CLEANUP_KEY,
+    ]);
+    const cleanup = values.get(CLEANUP_RECORD_KEY) as CleanupRecord | undefined;
+    const terminalCleanup = values.get(TERMINAL_CLEANUP_KEY) as TerminalCleanupRecord | undefined;
+    if (terminalCleanup) {
+      await this.ctx.storage.setAlarm(this.now() + 1);
+    } else if (!cleanup || cleanup.phase === 'tombstoned') {
       await this.ctx.storage.deleteAlarm();
     } else {
       await this.ctx.storage.setAlarm(Math.max(this.now() + 1, cleanup.dueAt.getTime()));
     }
-    return cleanup;
+    return cleanup ?? null;
   }
 
   async alarm(): Promise<void> {
-    try {
-      await this.executeCleanup();
-    } catch (error) {
-      await this.recordCleanupFailure(error);
-    }
+    await this.executeScheduledCleanupPage();
   }
 
   private namespace<T>(name: keyof WorkflowRunDOEnv): CellNamespace<T> {
@@ -352,130 +444,342 @@ export class WorkflowRunDO extends DurableObject {
   }
 
   private async setCleanupPhase(
-    expected: CleanupRecord['phase'],
+    expected: CleanupRecord,
     next: CleanupRecord['phase'],
     updates: Partial<CleanupRecord> = {},
+    continueAt?: number,
   ): Promise<void> {
     await this.ctx.storage.transaction(async (txn) => {
       const cleanup = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
-      if (!cleanup || cleanup.phase !== expected) return;
+      if (
+        !cleanup ||
+        cleanup.phase !== expected.phase ||
+        cleanup.generation !== expected.generation
+      ) {
+        return;
+      }
       await txn.put(CLEANUP_RECORD_KEY, {
         ...cleanup,
         ...updates,
         phase: next,
+        generation: cleanup.generation + 1,
         attempts: 0,
         lastError: undefined,
       });
+      if (continueAt !== undefined) await txn.setAlarm(continueAt);
     });
   }
 
-  private async executeCleanup(): Promise<void> {
-    for (;;) {
-      const cleanup = await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
-      if (!cleanup) {
-        await this.ctx.storage.deleteAlarm();
-        return;
+  private async executeScheduledCleanupPage(): Promise<void> {
+    const terminalCleanup = await this.ctx.storage.get<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY);
+    if (terminalCleanup) {
+      try {
+        await this.executeTerminalCleanup(terminalCleanup);
+      } catch (error) {
+        await this.recordTerminalCleanupFailure(error, terminalCleanup);
       }
-      if (cleanup.phase === 'tombstoned') {
-        await this.ctx.storage.deleteAlarm();
-        return;
-      }
-      if (cleanup.phase === 'retained') {
-        if (cleanup.dueAt.getTime() > this.now()) {
-          await this.ctx.storage.setAlarm(cleanup.dueAt);
-          return;
-        }
-        await this.setCleanupPhase('retained', 'index');
-        continue;
-      }
-
-      if (cleanup.phase === 'index') {
-        // Older deployments wrote correlation-index keys plus per-run markers.
-        // New events no longer create either, but keep consuming old markers so
-        // retention still removes already-persisted global keys.
-        const [indexMarkers, hookMarkers] = await Promise.all([
-          this.ctx.storage.list<string>({ prefix: INDEX_MARKER_PREFIX }),
-          this.ctx.storage.list<HookIndexReference>({ prefix: HOOK_MARKER_PREFIX }),
-        ]);
-        const indexNamespace = this.namespace<IndexCleanupStub>('WORKFLOW_INDEX');
-        const index = indexNamespace.get(indexNamespace.idFromName('index'));
-        await index.expireRun({
-          runId: cleanup.runId,
-          keys: [
-            workflowRunIndexKey(cleanup),
-            globalRunIndexKey(cleanup),
-            ...indexMarkers.values(),
-          ],
-          hooks: Array.from(hookMarkers.values()),
-          expiredAt: cleanup.dueAt.getTime(),
-        });
-        await this.setCleanupPhase('index', 'streams');
-        continue;
-      }
-
-      if (cleanup.phase === 'streams') {
-        const streamsNamespace = this.namespace<StreamCleanupStub>('WORKFLOW_STREAMS');
-        const registry = streamsNamespace.get(
-          streamsNamespace.idFromName(`run-streams:${cleanup.runId}`),
-        );
-        const { streams } = await registry.expireRegistry(cleanup.runId, cleanup.dueAt.getTime());
-        let deletedStreams = streams.length === 0 ? cleanup.deletedStreams : 0;
-        for (let offset = 0; offset < streams.length; offset += STREAM_DELETE_CONCURRENCY) {
-          const batch = streams.slice(offset, offset + STREAM_DELETE_CONCURRENCY);
-          const results = await Promise.all(
-            batch.map((name) => {
-              const stream = streamsNamespace.get(streamsNamespace.idFromName(`stream:${name}`));
-              return stream.expireStream(cleanup.runId, cleanup.dueAt.getTime());
-            }),
-          );
-          deletedStreams += results.filter((result) => result.deleted).length;
-        }
-        await this.ctx.storage.transaction(async (txn) => {
-          const current = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
-          if (current?.phase === 'streams') {
-            await txn.put(CLEANUP_RECORD_KEY, { ...current, deletedStreams });
-          }
-        });
-        await registry.finalizeRegistry(cleanup.runId);
-        await this.setCleanupPhase('streams', 'queues');
-        continue;
-      }
-
-      if (cleanup.phase === 'queues') {
-        const queues = this.namespace<QueueCleanupStub>('WORKFLOW_QUEUE');
-        let deletedQueueMessages = 0;
-        for (let shard = 0; shard < cleanup.queueShards; shard++) {
-          const queue = queues.get(queues.idFromName(`q:${shard}`));
-          const result = await queue.expireRun(cleanup.runId, cleanup.dueAt.getTime());
-          deletedQueueMessages += result.deleted;
-        }
-        await this.setCleanupPhase('queues', 'payload', { deletedQueueMessages });
-        continue;
-      }
-
-      if (cleanup.phase === 'payload') {
-        const finished = await this.deletePayloadBatch();
-        if (!finished) return;
-      }
+      return;
     }
+
+    const cleanup = await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+    if (!cleanup || cleanup.phase === 'tombstoned') {
+      await this.ctx.storage.deleteAlarm();
+      return;
+    }
+    try {
+      await this.executeCleanup(cleanup);
+    } catch (error) {
+      await this.recordCleanupFailure(error, cleanup);
+    }
+  }
+
+  private async executeCleanup(cleanup: CleanupRecord): Promise<void> {
+    if (cleanup.phase === 'retained') {
+      if (cleanup.dueAt.getTime() > this.now()) {
+        await this.ctx.storage.setAlarm(cleanup.dueAt);
+        return;
+      }
+      await this.setCleanupPhase(cleanup, 'index', {}, this.now() + 1);
+      return;
+    }
+
+    if (cleanup.phase === 'index') {
+      await this.deleteIndexPage(cleanup);
+      return;
+    }
+
+    if (cleanup.phase === 'streams') {
+      await this.deleteStreamPage(cleanup);
+      return;
+    }
+
+    if (cleanup.phase === 'queues') {
+      await this.deleteQueuePage(cleanup);
+      return;
+    }
+
+    if (cleanup.phase === 'payload') {
+      await this.deletePayloadBatch();
+    }
+  }
+
+  private async executeTerminalCleanup(cleanup: TerminalCleanupRecord): Promise<void> {
+    if (cleanup.phase === 'hooks') {
+      await this.deleteTerminalHookPage(cleanup);
+    } else {
+      await this.deleteTerminalWaitPage(cleanup);
+    }
+  }
+
+  private async deleteTerminalHookPage(cleanup: TerminalCleanupRecord): Promise<void> {
+    const entries = await this.ctx.storage.list<Hook>({
+      prefix: HOOK_KEY_PREFIX,
+      limit: TERMINAL_HOOK_PAGE_SIZE + 1,
+    });
+    const page = Array.from(entries.values()).slice(0, TERMINAL_HOOK_PAGE_SIZE);
+    const indexNamespace = this.namespace<IndexCleanupStub>('WORKFLOW_INDEX');
+    const index = indexNamespace.get(indexNamespace.idFromName('index'));
+    await index.releaseHookIndexes({
+      runId: cleanup.runId,
+      hooks: page.map((hook) => ({ hookId: hook.hookId, token: hook.token })),
+      terminal: true,
+    });
+
+    await this.ctx.storage.transaction(async (txn) => {
+      const current = await txn.get<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY);
+      if (
+        !current ||
+        current.phase !== cleanup.phase ||
+        current.generation !== cleanup.generation
+      ) {
+        return;
+      }
+      const keys = page.flatMap((hook) => [
+        `${HOOK_KEY_PREFIX}${hook.hookId}`,
+        hookCreationIndexKey(hook),
+      ]);
+      if (keys.length > 0) await txn.delete(keys);
+      await txn.put<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY, {
+        ...current,
+        phase: entries.size <= TERMINAL_HOOK_PAGE_SIZE ? 'waits' : 'hooks',
+        generation: current.generation + 1,
+        attempts: 0,
+        lastError: undefined,
+      });
+      await txn.setAlarm(this.now() + 1);
+    });
+  }
+
+  private async deleteTerminalWaitPage(cleanup: TerminalCleanupRecord): Promise<void> {
+    await this.ctx.storage.transaction(async (txn) => {
+      const current = await txn.get<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY);
+      if (
+        !current ||
+        current.phase !== cleanup.phase ||
+        current.generation !== cleanup.generation
+      ) {
+        return;
+      }
+      const entries = await txn.list({
+        prefix: WAIT_KEY_PREFIX,
+        limit: TERMINAL_WAIT_PAGE_SIZE + 1,
+      });
+      const keys = Array.from(entries.keys()).slice(0, TERMINAL_WAIT_PAGE_SIZE);
+      if (keys.length > 0) await txn.delete(keys);
+
+      if (entries.size > TERMINAL_WAIT_PAGE_SIZE) {
+        await txn.put<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY, {
+          ...current,
+          generation: current.generation + 1,
+          attempts: 0,
+          lastError: undefined,
+        });
+        await txn.setAlarm(this.now() + 1);
+        return;
+      }
+
+      await txn.delete(TERMINAL_CLEANUP_KEY);
+      const retention = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (retention && retention.phase !== 'tombstoned') {
+        await txn.setAlarm(Math.max(this.now() + 1, retention.dueAt.getTime()));
+      } else {
+        await txn.deleteAlarm();
+      }
+    });
+  }
+
+  private async deleteIndexPage(cleanup: CleanupRecord): Promise<void> {
+    const hookEntries = await this.ctx.storage.list<HookIndexReference>({
+      prefix: HOOK_MARKER_PREFIX,
+      limit: HOOK_MARKER_PAGE_SIZE + 1,
+    });
+    const hookMarkers = Array.from(hookEntries).slice(0, HOOK_MARKER_PAGE_SIZE);
+    const indexNamespace = this.namespace<IndexCleanupStub>('WORKFLOW_INDEX');
+    const index = indexNamespace.get(indexNamespace.idFromName('index'));
+    await index.expireRun({
+      runId: cleanup.runId,
+      keys: [workflowRunIndexKey(cleanup), globalRunIndexKey(cleanup)],
+      hooks: hookMarkers.map(([, value]) => value),
+      expiredAt: cleanup.dueAt.getTime(),
+    });
+    const markerKeys = hookMarkers.map(([key]) => key);
+    await this.ctx.storage.transaction(async (txn) => {
+      const current = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (current?.phase !== 'index' || current.generation !== cleanup.generation) return;
+      if (markerKeys.length > 0) await txn.delete(markerKeys);
+      if (hookEntries.size <= HOOK_MARKER_PAGE_SIZE) {
+        await txn.put(CLEANUP_RECORD_KEY, {
+          ...current,
+          phase: 'streams',
+          generation: current.generation + 1,
+          attempts: 0,
+          lastError: undefined,
+        });
+      } else {
+        await txn.put(CLEANUP_RECORD_KEY, {
+          ...current,
+          generation: current.generation + 1,
+          attempts: 0,
+          lastError: undefined,
+        });
+      }
+      await txn.setAlarm(this.now() + 1);
+    });
+  }
+
+  private async deleteStreamPage(cleanup: CleanupRecord): Promise<void> {
+    const streamsNamespace = this.namespace<StreamCleanupStub>('WORKFLOW_STREAMS');
+    const registry = streamsNamespace.get(
+      streamsNamespace.idFromName(`run-streams:${cleanup.runId}`),
+    );
+    const { streams } = await registry.expireRegistry(cleanup.runId, cleanup.dueAt.getTime(), {
+      limit: STREAMS_PER_CLEANUP_PAGE,
+    });
+    const completed: string[] = [];
+    let remainingChunks = STREAM_CHUNKS_PER_CLEANUP_PAGE;
+    let remainingBytes = STREAM_BYTES_PER_CLEANUP_PAGE;
+    for (const name of streams) {
+      if (remainingChunks <= 0 || remainingBytes <= 0) break;
+      const stream = streamsNamespace.get(streamsNamespace.idFromName(`stream:${name}`));
+      const result = await stream.expireStream(cleanup.runId, cleanup.dueAt.getTime(), {
+        limit: remainingChunks,
+        byteLimit: remainingBytes,
+      });
+      remainingChunks -= result.chunks;
+      remainingBytes -= result.bytes;
+      if (result.done) completed.push(name);
+    }
+    const registryResult = await registry.finalizeRegistry(cleanup.runId, completed);
+    await this.ctx.storage.transaction(async (txn) => {
+      const current = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (current?.phase !== 'streams' || current.generation !== cleanup.generation) return;
+      await txn.put(CLEANUP_RECORD_KEY, {
+        ...current,
+        deletedStreams: registryResult.deleted,
+        phase: registryResult.done ? 'queues' : 'streams',
+        generation: current.generation + 1,
+        attempts: 0,
+        lastError: undefined,
+      });
+      await txn.setAlarm(this.now() + 1);
+    });
+  }
+
+  private async deleteQueuePage(cleanup: CleanupRecord): Promise<void> {
+    const queues = this.namespace<QueueCleanupStub>('WORKFLOW_QUEUE');
+    let progress =
+      (await this.ctx.storage.get<CleanupProgress>(CLEANUP_PROGRESS_KEY)) ??
+      ({ queueShard: 0, queueShardDeleted: 0 } satisfies CleanupProgress);
+    let remainingShards = QUEUE_SHARDS_PER_CLEANUP_PAGE;
+    let expectedGeneration = cleanup.generation;
+
+    while (progress.queueShard < cleanup.queueShards && remainingShards-- > 0) {
+      const requestedShard = progress.queueShard;
+      const queue = queues.get(queues.idFromName(`q:${requestedShard}`));
+      const result = await queue.expireRun(cleanup.runId, cleanup.dueAt.getTime(), {
+        limit: QUEUE_REFERENCES_PER_CLEANUP_PAGE,
+      });
+      const reconciled = await this.ctx.storage.transaction(async (txn) => {
+        const current = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+        if (current?.phase !== 'queues') return null;
+        if (current.generation !== expectedGeneration) {
+          return { stale: true as const };
+        }
+        const persisted =
+          (await txn.get<CleanupProgress>(CLEANUP_PROGRESS_KEY)) ??
+          ({ queueShard: 0, queueShardDeleted: 0 } satisfies CleanupProgress);
+        if (persisted.queueShard !== requestedShard) {
+          return { stale: true as const };
+        }
+        if (result.deleted < persisted.queueShardDeleted) {
+          return { stale: true as const };
+        }
+        const next: CleanupProgress = result.done
+          ? { queueShard: persisted.queueShard + 1, queueShardDeleted: 0 }
+          : { ...persisted, queueShardDeleted: result.deleted };
+        const delta = result.deleted - persisted.queueShardDeleted;
+        await txn.put(CLEANUP_RECORD_KEY, {
+          ...current,
+          deletedQueueMessages: current.deletedQueueMessages + delta,
+          generation: current.generation + 1,
+          attempts: 0,
+          lastError: undefined,
+        });
+        await txn.put(CLEANUP_PROGRESS_KEY, next);
+        await txn.setAlarm(this.now() + 1);
+        return {
+          stale: false as const,
+          progress: next,
+          generation: current.generation + 1,
+          applied:
+            result.done ||
+            next.queueShard !== persisted.queueShard ||
+            next.queueShardDeleted !== persisted.queueShardDeleted,
+        };
+      });
+      if (!reconciled) return;
+      if (reconciled.stale) return;
+      progress = reconciled.progress;
+      expectedGeneration = reconciled.generation;
+      if (!reconciled.applied && progress.queueShard === requestedShard) break;
+      if (!result.done && progress.queueShard === requestedShard) break;
+    }
+
+    await this.ctx.storage.transaction(async (txn) => {
+      const current = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+      if (current?.phase !== 'queues') return;
+      const persisted =
+        (await txn.get<CleanupProgress>(CLEANUP_PROGRESS_KEY)) ??
+        ({ queueShard: 0, queueShardDeleted: 0 } satisfies CleanupProgress);
+      if (persisted.queueShard >= current.queueShards) {
+        await txn.put(CLEANUP_RECORD_KEY, {
+          ...current,
+          phase: 'payload',
+          generation: current.generation + 1,
+        });
+        await txn.delete(CLEANUP_PROGRESS_KEY);
+        await txn.setAlarm(this.now() + 1);
+      }
+    });
   }
 
   private async deletePayloadBatch(): Promise<boolean> {
     return await this.ctx.storage.transaction(async (txn) => {
       const cleanup = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
       if (!cleanup || cleanup.phase !== 'payload') return true;
-      const entries = await txn.list({ limit: PAYLOAD_DELETE_BATCH + 3 });
+      const entries = await txn.list({ limit: PAYLOAD_DELETE_BATCH + 3, noCache: true });
       const keys = Array.from(entries.keys())
         .filter((key) => key !== CLEANUP_RECORD_KEY && key !== TOMBSTONE_KEY)
         .slice(0, PAYLOAD_DELETE_BATCH);
       const now = new Date(this.now());
       await txn.put(TOMBSTONE_KEY, cleanupTombstone(cleanup, now));
-      for (const key of keys) await txn.delete(key);
+      if (keys.length > 0) await txn.delete(keys);
 
       if (keys.length > 0) {
         await txn.put(CLEANUP_RECORD_KEY, {
           ...cleanup,
           deletedPayloadKeys: cleanup.deletedPayloadKeys + keys.length,
+          generation: cleanup.generation + 1,
           lastError: undefined,
         });
         await txn.setAlarm(this.now() + 1);
@@ -485,6 +789,7 @@ export class WorkflowRunDO extends DurableObject {
       await txn.put(CLEANUP_RECORD_KEY, {
         ...cleanup,
         phase: 'tombstoned',
+        generation: cleanup.generation + 1,
         attempts: 0,
         lastError: undefined,
         tombstonedAt: now,
@@ -494,14 +799,48 @@ export class WorkflowRunDO extends DurableObject {
     });
   }
 
-  private async recordCleanupFailure(error: unknown): Promise<void> {
+  private async recordCleanupFailure(error: unknown, expected: CleanupRecord): Promise<void> {
     await this.ctx.storage.transaction(async (txn) => {
       const cleanup = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);
-      if (!cleanup || cleanup.phase === 'tombstoned') return;
+      if (
+        !cleanup ||
+        cleanup.phase !== expected.phase ||
+        cleanup.generation !== expected.generation ||
+        cleanup.phase === 'tombstoned'
+      ) {
+        return;
+      }
       const attempts = cleanup.attempts + 1;
       const delay = Math.min(CLEANUP_RETRY_MAX_MS, 1000 * 2 ** Math.min(attempts - 1, 12));
       await txn.put(CLEANUP_RECORD_KEY, {
         ...cleanup,
+        generation: cleanup.generation + 1,
+        attempts,
+        lastError: error instanceof Error ? error.message : String(error),
+        lastAttemptAt: new Date(this.now()),
+      });
+      await txn.setAlarm(this.now() + delay);
+    });
+  }
+
+  private async recordTerminalCleanupFailure(
+    error: unknown,
+    expected: TerminalCleanupRecord,
+  ): Promise<void> {
+    await this.ctx.storage.transaction(async (txn) => {
+      const cleanup = await txn.get<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY);
+      if (
+        !cleanup ||
+        cleanup.phase !== expected.phase ||
+        cleanup.generation !== expected.generation
+      ) {
+        return;
+      }
+      const attempts = cleanup.attempts + 1;
+      const delay = Math.min(CLEANUP_RETRY_MAX_MS, 1000 * 2 ** Math.min(attempts - 1, 12));
+      await txn.put<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY, {
+        ...cleanup,
+        generation: cleanup.generation + 1,
         attempts,
         lastError: error instanceof Error ? error.message : String(error),
         lastAttemptAt: new Date(this.now()),

--- a/src/worker/router.ts
+++ b/src/worker/router.ts
@@ -86,7 +86,7 @@ const BINDINGS: Record<string, { env: keyof WorkerEnv; methods: ReadonlySet<stri
       'reserveHookToken',
       'finalizeHookIndexes',
       'releaseHookToken',
-      'deleteHookIndexes',
+      'releaseHookIndexes',
     ]),
   },
   queue: {

--- a/test/index-do.test.ts
+++ b/test/index-do.test.ts
@@ -6,6 +6,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { IndexDO } from '../src/worker/durable-objects/IndexDO.js';
 import { FakeFleet } from '../src/testing/fake-cell.js';
+import { stringify } from '../src/vendor/shared/index.js';
 
 describe('IndexDO', () => {
   let fleet: FakeFleet;
@@ -76,6 +77,18 @@ describe('IndexDO', () => {
     expect(page.cursor).toBeUndefined();
   });
 
+  it('caps direct index listings at the public pagination limit', async () => {
+    const storage = fleet.cell('index', 'index').storage;
+    for (let item = 0; item < 1_001; item++) {
+      storage.data.set(`run:bounded:${String(item).padStart(4, '0')}`, String(item));
+    }
+
+    const page = await index.list({ prefix: 'run:bounded:', limit: 10_000 });
+    expect(page.keys).toHaveLength(1_000);
+    expect(page.list_complete).toBe(false);
+    expect(page.cursor).toBe('run:bounded:0999');
+  });
+
   it('atomically deletes owned indexes and fences delayed publication', async () => {
     await index.putOwned('wrun_expired', 'run:wf:1:wrun_expired', 'run');
     await index.putOwned('wrun_expired', 'correlation:c:1:e:wrun_expired', 'event');
@@ -94,5 +107,78 @@ describe('IndexDO', () => {
       stored: false,
     });
     expect(await index.get('run:wf:2:wrun_expired')).toBeNull();
+  });
+
+  it('hides a hook immediately behind an expiration fence before its cleanup page', async () => {
+    const runId = 'wrun_expired_hook';
+    const owner = { runId, hookId: 'hook-expired' };
+    const serialized = stringify({ ...owner, token: 'token-expired' });
+    await index.finalizeHookIndexes('token-expired', owner.hookId, serialized, owner);
+
+    await index.expireRun({ runId, keys: [], hooks: [], expiredAt: 123 });
+
+    expect(fleet.cell('index', 'index').storage.data.has('hook:token-expired')).toBe(true);
+    expect(await index.get('hook:token-expired')).toBeNull();
+    expect(await index.get(`hookid:${owner.hookId}`)).toBeNull();
+  });
+
+  it('bounds hook cleanup reads and deletes to native 128-key batches', async () => {
+    const runId = 'wrun_many_hooks';
+    const keys = [`run:wf:1:${runId}`, `runall:1:${runId}`];
+    for (const key of keys) await index.putOwned(runId, key, runId);
+    const hooks = Array.from({ length: 64 }, (_, hookIndex) => ({
+      hookId: `hook-${hookIndex}`,
+      token: `token-${hookIndex}`,
+    }));
+    for (const hook of hooks) {
+      const owner = { runId, hookId: hook.hookId };
+      await index.finalizeHookIndexes(
+        hook.token,
+        hook.hookId,
+        stringify({ ...owner, token: hook.token }),
+        owner,
+      );
+    }
+    const storage = fleet.cell('index', 'index').storage;
+    storage.operationCalls.length = 0;
+
+    expect(await index.expireRun({ runId, keys, hooks, expiredAt: 123 })).toEqual({
+      deleted: 130,
+    });
+    expect(
+      storage.operationCalls
+        .filter((call) => call.operation === 'get')
+        .map((call) => call.keys.length),
+    ).toEqual([128, 64]);
+    expect(
+      storage.operationCalls
+        .filter((call) => call.operation === 'delete')
+        .map((call) => call.keys.length),
+    ).toEqual([128, 3]);
+  });
+
+  it('batches terminal hook release and fences delayed finalization', async () => {
+    const runId = 'wrun_terminal_hooks';
+    const owner = { runId, hookId: 'hook-terminal' };
+    await index.reserveHookToken('token-terminal', owner);
+
+    expect(
+      await index.releaseHookIndexes({
+        runId,
+        hooks: [{ hookId: owner.hookId, token: 'token-terminal' }],
+        terminal: true,
+      }),
+    ).toEqual({ deleted: 1 });
+    await index.finalizeHookIndexes(
+      'token-terminal',
+      owner.hookId,
+      stringify({ ...owner, token: 'token-terminal' }),
+      owner,
+    );
+
+    expect(await index.get(`terminal:${runId}`)).not.toBeNull();
+    expect(await index.get('hook:token-terminal')).toBeNull();
+    expect(await index.get(`hookid:${owner.hookId}`)).toBeNull();
+    expect(await index.get('hookclaim:token-terminal')).toBeNull();
   });
 });

--- a/test/queue-do.test.ts
+++ b/test/queue-do.test.ts
@@ -87,6 +87,22 @@ describe('QueueDO', () => {
     expect(await queue.stats()).toMatchObject({ pending: 0, inflight: 0, deadLetters: 0 });
   });
 
+  it('rejects an inflight configuration above the bounded transaction limit', async () => {
+    const invalidFleet = new FakeFleet(
+      { queue: QueueDO },
+      {
+        QUEUE_MAX_INFLIGHT: '129',
+        clock: () => invalidFleet.now,
+        fetch: fetchStub,
+      },
+    );
+    const invalidQueue = invalidFleet.namespace('queue').get({ toString: () => 'q:0' }) as QueueDO;
+
+    await expect(invalidQueue.enqueue(enqueueReq())).rejects.toThrow(
+      'QUEUE_MAX_INFLIGHT must be at most 128',
+    );
+  });
+
   it('dedups on idempotencyKey while active and releases after ack', async () => {
     await queue.enqueue(enqueueReq({ messageId: 'msg_a', idempotencyKey: 'k1' }));
     const dup = await queue.enqueue(enqueueReq({ messageId: 'msg_b', idempotencyKey: 'k1' }));
@@ -640,7 +656,7 @@ describe('QueueDO', () => {
       idempotencyKey: 'dead-key',
     });
 
-    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 3 });
+    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 3, done: true });
     expect(await queue.stats()).toMatchObject({ pending: 0, inflight: 0, deadLetters: 0 });
     expect(Array.from(data.keys()).filter((key) => key.startsWith(`run:${runId}:`))).toEqual([]);
     expect(data.has(`expired-run:${runId}`)).toBe(true);
@@ -650,6 +666,53 @@ describe('QueueDO', () => {
 
     const late = await queue.enqueue(enqueueReq({ messageId: 'msg_late', runId }));
     expect(late).toMatchObject({ ok: false, code: 'RUN_EXPIRED' });
+  });
+
+  it('pages large run expiration with batch reads/deletes and retries atomically', async () => {
+    const runId = 'wrun_large_queue_cleanup';
+    const cellStorage = fleet.cell('queue', 'q:0').storage;
+    const data = cellStorage.data;
+    for (let index = 0; index < 150; index++) {
+      const messageId = `msg_large_${String(index).padStart(3, '0')}`;
+      const idempotencyKey = `large-key-${index}`;
+      const scheduleKey = `due:${padded(fleet.now + 60_000)}:${messageId}`;
+      data.set(`msg:${messageId}`, {
+        ...storedMessage(messageId, fleet.now),
+        runId,
+        idempotencyKey,
+      });
+      data.set(scheduleKey, messageId);
+      data.set(`key:${idempotencyKey}`, messageId);
+      data.set(`run:${runId}:${messageId}`, { messageId, dueKey: scheduleKey, idempotencyKey });
+    }
+
+    cellStorage.failNextMutation(
+      (mutation) => mutation.operation === 'put' && mutation.key === `expired-run:${runId}`,
+      new Error('injected queue cleanup crash'),
+    );
+    await expect(queue.expireRun(runId, fleet.now)).rejects.toThrow('injected queue cleanup crash');
+    expect(Array.from(data.keys()).filter((key) => key.startsWith(`run:${runId}:`))).toHaveLength(
+      150,
+    );
+
+    cellStorage.operationCalls.length = 0;
+    cellStorage.listCalls.length = 0;
+    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 64, done: false });
+    expect(cellStorage.listCalls[0]).toMatchObject({ options: { limit: 65 }, resultSize: 65 });
+    expect(
+      cellStorage.operationCalls.filter(
+        (call) => call.operation === 'get' && call.keys[0]?.startsWith('key:large-key-'),
+      ),
+    ).toEqual([expect.objectContaining({ keys: expect.any(Array) })]);
+    expect(
+      cellStorage.operationCalls.find(
+        (call) => call.operation === 'get' && call.keys[0]?.startsWith('key:large-key-'),
+      )?.keys,
+    ).toHaveLength(64);
+
+    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 128, done: false });
+    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 150, done: true });
+    expect(Array.from(data.keys()).filter((key) => key.startsWith(`run:${runId}:`))).toEqual([]);
   });
 
   it('does not let an in-flight retry resurrect an expired run', async () => {
@@ -668,7 +731,7 @@ describe('QueueDO', () => {
 
     const delivery = tick();
     await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledOnce());
-    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 1 });
+    expect(await queue.expireRun(runId, fleet.now)).toEqual({ deleted: 1, done: true });
     finishDelivery(jsonResponse(500, { error: 'late failure' }));
     await delivery;
 

--- a/test/retention.test.ts
+++ b/test/retention.test.ts
@@ -1,10 +1,16 @@
 import { HookNotFoundError, RunExpiredError } from '@workflow/errors';
-import { afterEach, describe, expect, it } from 'vitest';
+import type { Hook } from '@workflow/world';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createCelldWorld } from '../src/index.js';
-import { INDEX_MARKER_PREFIX } from '../src/retention.js';
+import { CLEANUP_RECORD_KEY, type CleanupRecord } from '../src/retention.js';
+import { FakeFleet } from '../src/testing/fake-cell.js';
 import { startHarness, type Harness } from '../src/testing/http-harness.js';
+import { stringify } from '../src/vendor/shared/index.js';
 import type { IndexDO } from '../src/worker/durable-objects/IndexDO.js';
 import type { QueueDO } from '../src/worker/durable-objects/QueueDO.js';
+import type { StreamDO } from '../src/worker/durable-objects/StreamDO.js';
+import { WorkflowRunDO } from '../src/worker/durable-objects/WorkflowRunDO.js';
 
 async function createCompletedRun(world: ReturnType<typeof createCelldWorld>, suffix: string) {
   const created = await world.events.create(null, {
@@ -46,6 +52,15 @@ async function driveCleanup(
   throw new Error('cleanup did not reach tombstoned state');
 }
 
+async function driveTerminalCleanup(harness: Harness, runId: string) {
+  for (let page = 0; page < 20; page++) {
+    if (!harness.fleet.cell('runs', runId).storage.data.has('terminal:cleanup')) return;
+    harness.fleet.advance(1);
+    await harness.fleet.fireDueAlarms();
+  }
+  throw new Error('terminal cleanup did not complete');
+}
+
 describe('terminal workflow retention', () => {
   let harness: Harness | undefined;
 
@@ -79,18 +94,6 @@ describe('terminal workflow retention', () => {
       { runId },
       { delaySeconds: 3_600, idempotencyKey: `wake:${runId}` },
     );
-    // Simulate an index and marker written by an older deployment. New
-    // correlated events create neither, but retention must still clean old
-    // persisted state after an in-place upgrade.
-    const legacyCorrelationKey = `correlation:legacy:1:evnt_legacy:${runId}`;
-    const index = harness.fleet.namespace('index').get({ toString: () => 'index' }) as IndexDO;
-    await index.putOwned(runId, legacyCorrelationKey, JSON.stringify({ runId }));
-    await harness.fleet
-      .cell('runs', runId)
-      .storage.put(
-        `${INDEX_MARKER_PREFIX}${encodeURIComponent(legacyCorrelationKey)}`,
-        legacyCorrelationKey,
-      );
     await finishRun(world, runId);
 
     const retained = await world.runs.get(runId);
@@ -119,8 +122,6 @@ describe('terminal workflow retention', () => {
     await expect(world.hooks.getByToken('retention-token')).rejects.toSatisfy((error) =>
       HookNotFoundError.is(error),
     );
-    expect(await index.get(legacyCorrelationKey)).toBeNull();
-
     const listed = await world.runs.list({ workflowName: 'retention-complete' });
     expect(listed.data).toEqual([]);
     const queue = harness.fleet.namespace('queue').get({ toString: () => 'q:0' }) as QueueDO;
@@ -171,6 +172,7 @@ describe('terminal workflow retention', () => {
     });
     const runId = await createCompletedRun(world, 'retry');
     await finishRun(world, runId);
+    await driveTerminalCleanup(harness, runId);
 
     const indexSlot = harness.fleet.cell('index', 'index');
     indexSlot.storage.failNextMutation(
@@ -178,6 +180,8 @@ describe('terminal workflow retention', () => {
       new Error('injected index cleanup failure'),
     );
     harness.fleet.advance(101);
+    await harness.fleet.fireDueAlarms();
+    harness.fleet.advance(1);
     await harness.fleet.fireDueAlarms();
 
     expect(await world.retention.getStatus(runId)).toMatchObject({
@@ -193,5 +197,319 @@ describe('terminal workflow retention', () => {
     const index = harness.fleet.namespace('index').get({ toString: () => 'index' }) as IndexDO;
     const entries = await index.list({ prefix: 'run:retention-retry:' });
     expect(entries.keys).toEqual([]);
+  });
+
+  it('does at most one bounded cleanup page per alarm and resumes a large stream', async () => {
+    harness = await startHarness({ secret: 'retention-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-secret',
+      deploymentId: 'retention-tests',
+      runRetentionMs: 100,
+    });
+    const runId = await createCompletedRun(world, 'paged-stream');
+    const streamName = 'retention-paged-stream';
+    const registry = harness.fleet.namespace('streams').get({
+      toString: () => `run-streams:${runId}`,
+    }) as StreamDO;
+    const stream = harness.fleet.namespace('streams').get({
+      toString: () => `stream:${streamName}`,
+    }) as StreamDO;
+    await registry.registerStream(runId, streamName);
+    for (let offset = 0; offset < 300; offset += 32) {
+      await stream.writeChunks(
+        runId,
+        Array.from({ length: Math.min(32, 300 - offset) }, () => new Uint8Array(1024)),
+      );
+    }
+    await finishRun(world, runId);
+    await driveTerminalCleanup(harness, runId);
+
+    harness.fleet.advance(101);
+    await harness.fleet.fireDueAlarms();
+    expect(await world.retention.getStatus(runId)).toMatchObject({ phase: 'index' });
+    const streamStorage = harness.fleet.cell('streams', `stream:${streamName}`).storage;
+    const remainingChunks = () =>
+      Array.from(streamStorage.data.keys()).filter((key) => key.startsWith('chunk:')).length;
+    expect(remainingChunks()).toBe(300);
+
+    harness.fleet.advance(1);
+    await harness.fleet.fireDueAlarms();
+    expect(await world.retention.getStatus(runId)).toMatchObject({ phase: 'streams' });
+    expect(remainingChunks()).toBe(300);
+
+    harness.fleet.advance(1);
+    await harness.fleet.fireDueAlarms();
+    expect(await world.retention.getStatus(runId)).toMatchObject({
+      phase: 'streams',
+      deletedStreams: 0,
+    });
+    expect(remainingChunks()).toBe(236);
+
+    const status = await driveCleanup(harness, world, runId);
+    expect(status).toMatchObject({ phase: 'tombstoned', deletedStreams: 1 });
+    expect(remainingChunks()).toBe(0);
+  });
+
+  it('pages terminal hooks and waits with bounded operations until cleanup completes', async () => {
+    harness = await startHarness({ secret: 'retention-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-secret',
+      deploymentId: 'retention-tests',
+    });
+    const runId = await createCompletedRun(world, 'terminal-pages');
+    const runStorage = harness.fleet.cell('runs', runId).storage;
+    const indexStorage = harness.fleet.cell('index', 'index').storage;
+
+    for (let hookIndex = 0; hookIndex < 150; hookIndex++) {
+      const hookId = `hook-${String(hookIndex).padStart(3, '0')}`;
+      const token = `token-${String(hookIndex).padStart(3, '0')}`;
+      const createdAt = new Date(harness.fleet.now + hookIndex);
+      const hook = {
+        runId,
+        hookId,
+        token,
+        ownerId: '',
+        projectId: '',
+        environment: '',
+        createdAt,
+        specVersion: SPEC_VERSION_CURRENT,
+        isWebhook: false,
+      } as Hook;
+      runStorage.data.set(`hook:${hookId}`, hook);
+      runStorage.data.set(`hookcreated:${createdAt.toISOString()}:${hookId}`, hookId);
+      const serialized = stringify(hook);
+      indexStorage.data.set(`hook:${token}`, serialized);
+      indexStorage.data.set(`hookid:${hookId}`, serialized);
+    }
+    for (let waitIndex = 0; waitIndex < 300; waitIndex++) {
+      runStorage.data.set(`wait:wait-${String(waitIndex).padStart(3, '0')}`, { waitIndex });
+    }
+
+    await finishRun(world, runId);
+    expect(runStorage.data.has('terminal:cleanup')).toBe(true);
+    await expect(world.hooks.getByToken('token-000')).rejects.toSatisfy((error) =>
+      HookNotFoundError.is(error),
+    );
+
+    const hookCounts: number[] = [];
+    const waitCounts: number[] = [];
+    for (let page = 0; page < 10 && runStorage.data.has('terminal:cleanup'); page++) {
+      runStorage.operationCalls.length = 0;
+      runStorage.listCalls.length = 0;
+      harness.fleet.advance(1);
+      await harness.fleet.fireDueAlarms();
+
+      expect(
+        runStorage.operationCalls
+          .filter((call) => call.operation === 'delete')
+          .every((call) => call.keys.length <= 128),
+      ).toBe(true);
+      expect(runStorage.listCalls.every((call) => (call.options.limit ?? 0) <= 129)).toBe(true);
+      hookCounts.push(
+        Array.from(runStorage.data.keys()).filter((key) => key.startsWith('hook:')).length,
+      );
+      waitCounts.push(
+        Array.from(runStorage.data.keys()).filter((key) => key.startsWith('wait:')).length,
+      );
+    }
+
+    expect(hookCounts).toEqual([86, 22, 0, 0, 0, 0]);
+    expect(waitCounts).toEqual([300, 300, 300, 172, 44, 0]);
+    expect(runStorage.data.has('terminal:cleanup')).toBe(false);
+    expect(runStorage.alarmAt).toBeNull();
+    expect(
+      Array.from(indexStorage.data.keys()).filter(
+        (key) => key.startsWith('hook:') || key.startsWith('hookid:'),
+      ),
+    ).toEqual([]);
+    expect(indexStorage.data.has(`terminal:${runId}`)).toBe(true);
+  });
+
+  it('retries a failed terminal page without losing its local cursor', async () => {
+    harness = await startHarness({ secret: 'retention-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-secret',
+      deploymentId: 'retention-tests',
+    });
+    const runId = await createCompletedRun(world, 'terminal-retry');
+    const runStorage = harness.fleet.cell('runs', runId).storage;
+    const indexStorage = harness.fleet.cell('index', 'index').storage;
+    const hookId = 'hook-retry';
+    const token = 'token-retry';
+    const hook = {
+      runId,
+      hookId,
+      token,
+      ownerId: '',
+      projectId: '',
+      environment: '',
+      createdAt: new Date(harness.fleet.now),
+      specVersion: SPEC_VERSION_CURRENT,
+      isWebhook: false,
+    } as Hook;
+    runStorage.data.set(`hook:${hookId}`, hook);
+    runStorage.data.set(`hookcreated:${hook.createdAt.toISOString()}:${hookId}`, hookId);
+    indexStorage.data.set(`hook:${token}`, stringify(hook));
+    indexStorage.data.set(`hookid:${hookId}`, stringify(hook));
+    await finishRun(world, runId);
+
+    indexStorage.failNextMutation(
+      (mutation) => mutation.operation === 'delete' && mutation.key === `hook:${token}`,
+      new Error('injected terminal cleanup crash'),
+    );
+    harness.fleet.advance(1);
+    await harness.fleet.fireDueAlarms();
+
+    expect(runStorage.data.get('terminal:cleanup')).toMatchObject({
+      phase: 'hooks',
+      attempts: 1,
+      lastError: 'injected terminal cleanup crash',
+    });
+    expect(runStorage.data.has(`hook:${hookId}`)).toBe(true);
+    expect(indexStorage.data.has(`hook:${token}`)).toBe(true);
+
+    harness.fleet.advance(1_000);
+    await harness.fleet.fireDueAlarms();
+    harness.fleet.advance(1);
+    await harness.fleet.fireDueAlarms();
+    expect(runStorage.data.has('terminal:cleanup')).toBe(false);
+    expect(runStorage.data.has(`hook:${hookId}`)).toBe(false);
+    expect(indexStorage.data.has(`hook:${token}`)).toBe(false);
+    expect(indexStorage.data.has(`hookid:${hookId}`)).toBe(false);
+  });
+
+  it('does not regress queue cleanup progress when concurrent pages resolve out of order', async () => {
+    let fleet!: FakeFleet;
+    let firstStarted!: () => void;
+    let releaseFirst!: () => void;
+    const firstStartedPromise = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const firstReleasePromise = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let calls = 0;
+    const expireRun = vi.fn<() => Promise<{ deleted: number; done: boolean }>>(async () => {
+      calls++;
+      if (calls === 1) {
+        firstStarted();
+        await firstReleasePromise;
+        return { deleted: 64, done: false };
+      }
+      return { deleted: 128, done: false };
+    });
+    const queueNamespace = {
+      idFromName: (name: string) => ({ toString: () => name }),
+      get: () => ({ expireRun }),
+    };
+    fleet = new FakeFleet(
+      { runs: WorkflowRunDO },
+      { clock: () => fleet.now, WORKFLOW_QUEUE: queueNamespace },
+    );
+    const runId = 'wrun_concurrent_queue_cleanup';
+    const run = fleet.namespace('runs').get({ toString: () => runId }) as WorkflowRunDO;
+    const storage = fleet.cell('runs', runId).storage;
+    storage.data.set(CLEANUP_RECORD_KEY, {
+      version: 1,
+      runId,
+      workflowName: 'concurrent-cleanup',
+      createdAt: new Date(fleet.now - 2_000),
+      completedAt: new Date(fleet.now - 1_000),
+      terminalStatus: 'completed',
+      dueAt: new Date(fleet.now),
+      queueShards: 1,
+      phase: 'queues',
+      generation: 0,
+      attempts: 0,
+      deletedPayloadKeys: 0,
+      deletedStreams: 0,
+      deletedQueueMessages: 0,
+    } satisfies CleanupRecord);
+
+    const first = run.cleanupNow({ retentionMs: 1, queueShards: 1 });
+    await firstStartedPromise;
+    const second = run.cleanupNow({ retentionMs: 1, queueShards: 1 });
+    await vi.waitFor(() => expect(expireRun).toHaveBeenCalledTimes(2));
+    await second;
+    releaseFirst();
+    await first;
+
+    expect(storage.data.get(CLEANUP_RECORD_KEY)).toMatchObject({
+      phase: 'queues',
+      deletedQueueMessages: 128,
+    });
+    expect(storage.data.get('retention:progress')).toEqual({
+      queueShard: 0,
+      queueShardDeleted: 128,
+    });
+  });
+
+  it('ignores a late cleanup failure after a concurrent page advances the generation', async () => {
+    let fleet!: FakeFleet;
+    let firstStarted!: () => void;
+    let rejectFirst!: () => void;
+    const firstStartedPromise = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const firstFailurePromise = new Promise<void>((resolve) => {
+      rejectFirst = resolve;
+    });
+    let calls = 0;
+    const expireRun = vi.fn<() => Promise<{ deleted: number; done: boolean }>>(async () => {
+      calls++;
+      if (calls === 1) {
+        firstStarted();
+        await firstFailurePromise;
+        throw new Error('late queue failure');
+      }
+      return { deleted: 128, done: false };
+    });
+    fleet = new FakeFleet(
+      { runs: WorkflowRunDO },
+      {
+        clock: () => fleet.now,
+        WORKFLOW_QUEUE: {
+          idFromName: (name: string) => ({ toString: () => name }),
+          get: () => ({ expireRun }),
+        },
+      },
+    );
+    const runId = 'wrun_late_queue_failure';
+    const run = fleet.namespace('runs').get({ toString: () => runId }) as WorkflowRunDO;
+    const storage = fleet.cell('runs', runId).storage;
+    storage.data.set(CLEANUP_RECORD_KEY, {
+      version: 1,
+      runId,
+      workflowName: 'late-failure',
+      createdAt: new Date(fleet.now - 2_000),
+      completedAt: new Date(fleet.now - 1_000),
+      terminalStatus: 'completed',
+      dueAt: new Date(fleet.now),
+      queueShards: 1,
+      phase: 'queues',
+      generation: 0,
+      attempts: 0,
+      deletedPayloadKeys: 0,
+      deletedStreams: 0,
+      deletedQueueMessages: 0,
+    } satisfies CleanupRecord);
+
+    const first = run.cleanupNow({ retentionMs: 1, queueShards: 1 });
+    await firstStartedPromise;
+    const second = run.cleanupNow({ retentionMs: 1, queueShards: 1 });
+    await vi.waitFor(() => expect(expireRun).toHaveBeenCalledTimes(2));
+    await second;
+    rejectFirst();
+    await first;
+
+    expect(storage.data.get(CLEANUP_RECORD_KEY)).toMatchObject({
+      phase: 'queues',
+      deletedQueueMessages: 128,
+      attempts: 0,
+    });
+    expect(storage.data.get(CLEANUP_RECORD_KEY)).toMatchObject({ lastError: undefined });
   });
 });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -307,6 +307,57 @@ describe('full stack: vendored storage over the wire', () => {
     expect(paths).toEqual(new Map([[`/v1/rpc/runs/${created.run.runId}/listEvents`, 1]]));
   });
 
+  it('batches terminal hook release into one index RPC', async () => {
+    let publicRpcs = 0;
+    const paths = new Map<string, number>();
+    const countedFetch: typeof fetch = async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      publicRpcs++;
+      paths.set(url.pathname, (paths.get(url.pathname) ?? 0) + 1);
+      return fetch(input, init);
+    };
+    const env = createRemoteEnv({
+      fleetUrl: harness.url,
+      secret: SECRET,
+      fetchImpl: countedFetch,
+    });
+    const storage = createStorage({
+      env: { WORKFLOW_DB: env.WORKFLOW_DB, WORKFLOW_INDEX: env.WORKFLOW_INDEX },
+      deploymentId: 'wire-test',
+    });
+    const created = await storage.events.create(null, {
+      eventType: 'run_created',
+      eventData: {
+        deploymentId: 'wire-test',
+        workflowName: 'wire-terminal-hook-batch',
+        input: [],
+      },
+    });
+    for (let hook = 0; hook < 3; hook++) {
+      await storage.events.create(created.run.runId, {
+        eventType: 'hook_created',
+        correlationId: `hook-${hook}`,
+        eventData: { token: `terminal-token-${hook}` },
+      });
+    }
+
+    publicRpcs = 0;
+    paths.clear();
+    await storage.events.create(created.run.runId, {
+      eventType: 'run_completed',
+      eventData: { output: [] },
+    });
+
+    expect(publicRpcs).toBe(4);
+    expect(paths).toEqual(
+      new Map([
+        [`/v1/rpc/runs/${created.run.runId}/applyEvent`, 1],
+        ['/v1/rpc/index/index/putOwned', 2],
+        ['/v1/rpc/index/index/releaseHookIndexes', 1],
+      ]),
+    );
+  });
+
   it('lists runs with N+1 public RPCs, bounded run fanout, and value-bearing index pages', async () => {
     let publicRpcs = 0;
     let activeRunReads = 0;
@@ -357,6 +408,16 @@ describe('full stack: vendored storage over the wire', () => {
     let indexGets = 0;
     let runStorageGets = 0;
     const restorers: Array<() => void> = [];
+    const runStorages = runIds.map((runId) => harness.fleet.cell('runs', runId).storage);
+    const resetRunStorageCalls = () => {
+      for (const runStorage of runStorages) runStorage.operationCalls.length = 0;
+    };
+    const countRunStorageGets = () =>
+      runStorages.reduce(
+        (total, runStorage) =>
+          total + runStorage.operationCalls.filter((call) => call.operation === 'get').length,
+        0,
+      );
     const indexStorage = harness.fleet.cell('index', 'index').storage;
     const originalIndexList = indexStorage.list.bind(indexStorage);
     const originalIndexGet = indexStorage.get.bind(indexStorage);
@@ -372,23 +433,12 @@ describe('full stack: vendored storage over the wire', () => {
       indexStorage.list = originalIndexList;
       indexStorage.get = originalIndexGet;
     });
-    for (const runId of runIds) {
-      const runStorage = harness.fleet.cell('runs', runId).storage;
-      const originalGet = runStorage.get.bind(runStorage);
-      runStorage.get = async <T>(key: string) => {
-        runStorageGets++;
-        return originalGet<T>(key);
-      };
-      restorers.push(() => {
-        runStorage.get = originalGet;
-      });
-    }
-
     try {
       // Reproduce the legacy 2N+1 protocol against the same cells so the
       // before/after counts include identical router and storage layers.
       publicRpcs = 0;
       paths.clear();
+      resetRunStorageCalls();
       const legacyPage = await env.WORKFLOW_INDEX.list({
         prefix: 'run:wire-list-fanout:',
         limit: 50,
@@ -403,7 +453,8 @@ describe('full stack: vendored storage over the wire', () => {
       expect(maxActiveRunReads).toBe(1);
       expect(indexLists).toBe(1);
       expect(indexGets).toBe(20);
-      expect(runStorageGets).toBe(60);
+      runStorageGets = countRunStorageGets();
+      expect(runStorageGets).toBe(20);
 
       publicRpcs = 0;
       maxActiveRunReads = 0;
@@ -411,6 +462,7 @@ describe('full stack: vendored storage over the wire', () => {
       indexLists = 0;
       indexGets = 0;
       runStorageGets = 0;
+      resetRunStorageCalls();
       const listed = await storage.runs.list({
         workflowName: 'wire-list-fanout',
         pagination: { limit: 20 },
@@ -426,7 +478,8 @@ describe('full stack: vendored storage over the wire', () => {
       expect(maxActiveRunReads).toBe(8);
       expect(indexLists).toBe(1);
       expect(indexGets).toBe(0);
-      expect(runStorageGets).toBe(60);
+      runStorageGets = countRunStorageGets();
+      expect(runStorageGets).toBe(20);
 
       await Promise.all(
         runIds.map((runId) =>
@@ -442,6 +495,7 @@ describe('full stack: vendored storage over the wire', () => {
       indexLists = 0;
       indexGets = 0;
       runStorageGets = 0;
+      resetRunStorageCalls();
 
       const pending = await storage.runs.list({
         workflowName: 'wire-list-fanout',
@@ -454,6 +508,7 @@ describe('full stack: vendored storage over the wire', () => {
       expect(maxActiveRunReads).toBe(0);
       expect(indexLists).toBe(1);
       expect(indexGets).toBe(0);
+      runStorageGets = countRunStorageGets();
       expect(runStorageGets).toBe(0);
     } finally {
       for (const restore of restorers) restore();

--- a/test/storage-operation-counts.test.ts
+++ b/test/storage-operation-counts.test.ts
@@ -1,0 +1,86 @@
+import type { WorkflowRun } from '@workflow/world';
+import { describe, expect, it } from 'vitest';
+import {
+  HOOK_CREATED_KEY_PREFIX,
+  HOOK_KEY_PREFIX,
+  STEP_CREATED_KEY_PREFIX,
+  STEP_KEY_PREFIX,
+} from '../src/apply-event.js';
+import { FakeFleet } from '../src/testing/fake-cell.js';
+import { WorkflowRunDO } from '../src/worker/durable-objects/WorkflowRunDO.js';
+
+function creationKey(prefix: string, index: number, id: string): string {
+  return `${prefix}2026-01-01T00:${String(index).padStart(4, '0')}:00.000Z:${id}`;
+}
+
+describe('WorkflowRunDO hot-path storage operations', () => {
+  it('reads a run and both retention fences in one batch operation', async () => {
+    const fleet = new FakeFleet({ runs: WorkflowRunDO });
+    const run = fleet.namespace('runs').get({ toString: () => 'wrun_batch' }) as WorkflowRunDO;
+    const storage = fleet.cell('runs', 'wrun_batch').storage;
+    storage.data.set('run', { runId: 'wrun_batch' } satisfies Partial<WorkflowRun>);
+    storage.resetOperationCounts();
+
+    expect(await run.getRun()).toMatchObject({ ok: true, value: { runId: 'wrun_batch' } });
+    expect(storage.operationCounts.getMany).toBe(1);
+    expect(storage.operationCounts.get).toBe(0);
+    expect(storage.getManyCalls).toEqual([['retention:tombstone', 'retention:cleanup', 'run']]);
+  });
+
+  it.each([
+    ['steps', STEP_CREATED_KEY_PREFIX, STEP_KEY_PREFIX, 'stepId'],
+    ['hooks', HOOK_CREATED_KEY_PREFIX, HOOK_KEY_PREFIX, 'hookId'],
+  ] as const)(
+    'hydrates 100 %s with one bounded multi-get',
+    async (kind, indexPrefix, entityPrefix, idKey) => {
+      const fleet = new FakeFleet({ runs: WorkflowRunDO });
+      const run = fleet.namespace('runs').get({ toString: () => `wrun_${kind}` }) as WorkflowRunDO;
+      const storage = fleet.cell('runs', `wrun_${kind}`).storage;
+      for (let index = 0; index < 100; index++) {
+        const id = `${kind}-${String(index).padStart(3, '0')}`;
+        storage.data.set(creationKey(indexPrefix, index, id), id);
+        storage.data.set(`${entityPrefix}${id}`, { [idKey]: id });
+      }
+      storage.resetOperationCounts();
+      storage.listCalls.length = 0;
+
+      const result =
+        kind === 'steps'
+          ? await run.listSteps({ limit: 100 })
+          : await run.listHooks({ limit: 100 });
+      expect(result.ok && result.value.data).toHaveLength(100);
+      expect(storage.listCalls).toHaveLength(1);
+      expect(storage.operationCounts.getMany).toBe(2);
+      expect(storage.operationCounts.get).toBe(0);
+      expect(storage.getManyCalls).toEqual([
+        ['retention:tombstone', 'retention:cleanup'],
+        expect.arrayContaining([`${entityPrefix}${kind}-000`]),
+      ]);
+      expect(storage.getManyCalls[1]).toHaveLength(100);
+    },
+  );
+
+  it('caps a direct listSteps request and hydrates it in bounded native batches', async () => {
+    const fleet = new FakeFleet({ runs: WorkflowRunDO });
+    const run = fleet
+      .namespace('runs')
+      .get({ toString: () => 'wrun_large_steps' }) as WorkflowRunDO;
+    const storage = fleet.cell('runs', 'wrun_large_steps').storage;
+    for (let index = 0; index < 1_001; index++) {
+      const id = `step-${String(index).padStart(4, '0')}`;
+      storage.data.set(creationKey(STEP_CREATED_KEY_PREFIX, index, id), id);
+      storage.data.set(`${STEP_KEY_PREFIX}${id}`, { stepId: id });
+    }
+    storage.resetOperationCounts();
+
+    const result = await run.listSteps({ limit: 10_000 });
+    expect(result.ok && result.value.data).toHaveLength(1_000);
+    expect(result.ok && result.value.hasMore).toBe(true);
+
+    const entityReads = storage.getManyCalls
+      .filter((keys) => keys[0]?.startsWith(STEP_KEY_PREFIX))
+      .map((keys) => keys.length);
+    expect(entityReads).toEqual([128, 128, 128, 128, 128, 128, 128, 104]);
+    expect(entityReads.every((size) => size <= 128)).toBe(true);
+  });
+});

--- a/test/stream-do-cleanup.test.ts
+++ b/test/stream-do-cleanup.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { FakeFleet } from '../src/testing/fake-cell.js';
+import { StreamDO } from '../src/worker/durable-objects/StreamDO.js';
+
+const readRequest = {
+  runId: 'wrun_large',
+  startIndex: 299,
+  maxChunks: 1,
+  maxBytes: 1024 * 1024,
+  waitMs: 0,
+};
+
+function countKeys(storage: { data: Map<string, unknown> }, prefix: string): number {
+  return Array.from(storage.data.keys()).filter((key) => key.startsWith(prefix)).length;
+}
+
+describe('StreamDO paged KV cleanup', () => {
+  it('bounds each chunk page, resumes to completion, and rolls back an interrupted page', async () => {
+    const fleet = new FakeFleet({ streams: StreamDO });
+    const stream = fleet.namespace('streams').get({ toString: () => 'stream:large' }) as StreamDO;
+    const storage = fleet.cell('streams', 'stream:large').storage;
+    const chunk = new Uint8Array(1024);
+    for (let offset = 0; offset < 300; offset += 32) {
+      await stream.writeChunks(
+        'wrun_large',
+        Array.from({ length: Math.min(32, 300 - offset) }, () => chunk),
+      );
+    }
+
+    storage.listCalls.length = 0;
+    storage.resetOperationCounts();
+    storage.failNextMutation(
+      (mutation) => mutation.operation === 'put' && mutation.key === 'meta',
+      new Error('injected crash after staged deletes'),
+    );
+    await expect(stream.expireStream('wrun_large', 123)).rejects.toThrow(
+      'injected crash after staged deletes',
+    );
+    expect(countKeys(storage, 'chunk:')).toBe(300);
+    expect(countKeys(storage, 'chunk-size:')).toBe(300);
+    expect(await stream.readChunks(readRequest)).toMatchObject({
+      tailIndex: 299,
+      state: 'open',
+      chunks: [chunk],
+    });
+
+    storage.listCalls.length = 0;
+    storage.resetOperationCounts();
+    expect(await stream.expireStream('wrun_large', 123)).toEqual({
+      deleted: true,
+      chunks: 64,
+      bytes: 64 * 1024,
+      done: false,
+    });
+    expect(countKeys(storage, 'chunk:')).toBe(236);
+    for (let page = 0; page < 3; page++) {
+      expect(await stream.expireStream('wrun_large', 123)).toEqual({
+        deleted: false,
+        chunks: 64,
+        bytes: 64 * 1024,
+        done: false,
+      });
+    }
+    expect(await stream.expireStream('wrun_large', 123)).toEqual({
+      deleted: false,
+      chunks: 44,
+      bytes: 44 * 1024,
+      done: true,
+    });
+    expect(countKeys(storage, 'chunk:')).toBe(0);
+    expect(countKeys(storage, 'chunk-size:')).toBe(0);
+    expect(await stream.readChunks(readRequest)).toMatchObject({
+      tailIndex: -1,
+      state: 'expired',
+      chunks: [],
+    });
+
+    expect(storage.listCalls).toHaveLength(5);
+    expect(
+      storage.listCalls.every(
+        (call) =>
+          call.transactional &&
+          call.options.prefix === 'chunk-size:' &&
+          call.options.limit === 65 &&
+          call.resultSize <= 65,
+      ),
+    ).toBe(true);
+    expect(storage.operationCounts.deleteMany).toBe(5);
+  });
+
+  it('bounds a page by payload bytes without reading chunk values', async () => {
+    const fleet = new FakeFleet({ streams: StreamDO });
+    const stream = fleet.namespace('streams').get({ toString: () => 'stream:bytes' }) as StreamDO;
+    const storage = fleet.cell('streams', 'stream:bytes').storage;
+    await stream.writeChunks(
+      'wrun_bytes',
+      Array.from({ length: 4 }, () => new Uint8Array(1024)),
+    );
+    storage.listCalls.length = 0;
+    storage.resetOperationCounts();
+
+    expect(await stream.expireStream('wrun_bytes', 123, { limit: 128, byteLimit: 2500 })).toEqual({
+      deleted: true,
+      chunks: 2,
+      bytes: 2048,
+      done: false,
+    });
+    expect(countKeys(storage, 'chunk:')).toBe(2);
+    expect(countKeys(storage, 'chunk-size:')).toBe(2);
+    expect(storage.getManyCalls).toEqual([]);
+    expect(storage.listCalls).toEqual([
+      {
+        options: { prefix: 'chunk-size:', limit: 65 },
+        resultSize: 4,
+        transactional: true,
+      },
+    ]);
+  });
+
+  it('pages the registry and counts completed streams idempotently', async () => {
+    const fleet = new FakeFleet({ streams: StreamDO });
+    const registry = fleet.namespace('streams').get({
+      toString: () => 'run-streams:wrun_registry',
+    }) as StreamDO;
+    for (let index = 0; index < 40; index++) {
+      await registry.registerStream('wrun_registry', `stream-${String(index).padStart(2, '0')}`);
+    }
+
+    const first = await registry.expireRegistry('wrun_registry', 123, { limit: 16 });
+    expect(first.streams).toHaveLength(16);
+    expect(await registry.finalizeRegistry('wrun_registry', first.streams)).toEqual({
+      deleted: 16,
+      done: false,
+    });
+    expect(await registry.finalizeRegistry('wrun_registry', first.streams)).toEqual({
+      deleted: 16,
+      done: false,
+    });
+
+    const second = await registry.expireRegistry('wrun_registry', 123, { limit: 16 });
+    expect(await registry.finalizeRegistry('wrun_registry', second.streams)).toEqual({
+      deleted: 32,
+      done: false,
+    });
+    const third = await registry.expireRegistry('wrun_registry', 123, { limit: 16 });
+    expect(third.streams).toHaveLength(8);
+    expect(await registry.finalizeRegistry('wrun_registry', third.streams)).toEqual({
+      deleted: 40,
+      done: true,
+    });
+  });
+});

--- a/test/stream-do.test.ts
+++ b/test/stream-do.test.ts
@@ -258,12 +258,16 @@ describe('StreamDO binary batch and long-poll protocol', () => {
     await expect(get().expireStream(RUN_ID, Date.now())).resolves.toEqual({
       deleted: true,
       chunks: 2,
+      bytes: 2,
+      done: true,
     });
     await expect(pending).resolves.toMatchObject({ state: 'expired', chunks: [] });
     expect(Array.from(fleet.cell('streams', name).storage.data.keys())).toEqual(['meta']);
     await expect(get().expireStream(RUN_ID, Date.now())).resolves.toEqual({
-      deleted: true,
-      chunks: 2,
+      deleted: false,
+      chunks: 0,
+      bytes: 0,
+      done: true,
     });
   });
 

--- a/test/streamer.test.ts
+++ b/test/streamer.test.ts
@@ -325,10 +325,15 @@ describe('Streamer (StreamDO RPC integration)', () => {
         registerStream: vi.fn<StreamDOStub['registerStream']>(),
         listStreams: vi.fn<StreamDOStub['listStreams']>(async () => []),
         expireRegistry: vi.fn<StreamDOStub['expireRegistry']>(async () => ({ streams: [] })),
-        finalizeRegistry: vi.fn<StreamDOStub['finalizeRegistry']>(),
+        finalizeRegistry: vi.fn<StreamDOStub['finalizeRegistry']>(async () => ({
+          deleted: 0,
+          done: true,
+        })),
         expireStream: vi.fn<StreamDOStub['expireStream']>(async () => ({
           deleted: true,
           chunks: 0,
+          bytes: 0,
+          done: true,
         })),
       };
       const boundedStreamer = createStreamer({


### PR DESCRIPTION
## Summary
- make retention and terminal cleanup a persisted, generation-checked state machine that executes one bounded page per alarm and re-arms until complete
- page StreamDO registry/chunk cleanup over the batched long-poll stream layout, list only chunk-size keys, and bulk-delete at most 128 KV keys / 64 chunks / 16 MiB per stream call
- batch QueueDO and IndexDO multi-key reads, writes, and deletes; bound queue expiration, dead-letter purging, inflight recovery, and hook-index cleanup
- collapse WorkflowRunDO retention fences plus entity reads into native multi-get operations and hydrate listSteps/listHooks in bounded 128-key batches
- defer terminal hook/wait disposal to alarms so terminal event application cannot create an unbounded transaction
- hard-cut the internal cleanup RPC/state contracts; no legacy decoders, migrations, or dual read/write paths

## Operation counts

Public protocol / RPC:
- getRun, listSteps, and listHooks remain one public RPC each (1 -> 1); this change is internal DO storage work
- completing a run with 3 hooks uses 4 public RPCs instead of 6: one run apply, two retained index puts, and one batched hook-release RPC instead of three release RPCs
- the existing runs.list(limit=20) protocol remains 21 RPCs on this base (one index list plus 20 run reads); this slice reduces the 20 run-cell reads from 60 storage gets to 20
- a 300-chunk expiration changes from one unbounded StreamDO cleanup RPC to five resumable 64-chunk RPC pages across alarms

Internal World / DO storage:
- getRun: 3 reads -> 1 multi-key read (run + cleanup + tombstone)
- listSteps/listHooks with 100 entities: 103 operations -> 3 (one fence multi-get, one index list, one entity multi-get)
- listSteps with 1,000 entities is capped and hydrated with 8 native multi-gets of at most 128 keys, rather than 1,000 serial entity reads
- 64-hook index cleanup uses 2 bounded multi-gets and 2 bounded bulk deletes instead of per-hook serial reads/deletes
- each stream cleanup page performs one size-key list capped at 65 entries and one bulk delete capped at 128 keys; chunk payload values are never loaded

No wall-clock latency or CPU benchmark is claimed in this change; the improvements above are deterministic operation-count measurements from the focused tests.

## Correctness
- expiration fences are installed transactionally before cleanup becomes externally visible
- cleanup progress is persisted or derived from remaining keys and guarded by generation tokens
- failed transactions roll back the page; retries and post-commit response loss resume idempotently
- alarms re-arm after every incomplete page and retain capped retry backoff
- delayed hook publication, queue retry, stream write, and run mutation cannot resurrect terminal or expired state
- portable EventStore behavior remains intact through optional batch/deferred-cleanup capabilities

## Validation
- `pnpm check`
  - format
  - type-aware lint
  - TypeScript
  - build
  - 19 test files / 258 tests
  - Worker bundle check
  - package check
