### PR TITLE
feat: add configurable workflow retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ the same secret to the fleet and the application:
 
 ```sh
 CELLD_VAR_WORLD_SECRET="$CELLD_WORLD_SECRET" \
+CELLD_VAR_WORKFLOW_RETENTION_MS=7776000000 \
 celld --bucket s3://my-cells-bucket \
   --listen 0.0.0.0:8080 \
   --internal-listen 10.0.0.12:8081 \
@@ -108,6 +109,9 @@ celld --bucket s3://my-cells-bucket \
 Use a secret manager rather than putting the value in `wrangler.jsonc`. Keep
 celld's internal listener on a trusted network; the World bearer token protects
 the worker RPC routes, not celld's administrative endpoints.
+
+The example sets a fleet-wide maximum workflow age of 90 days. Leave
+`WORKFLOW_RETENTION_MS` at `0` to disable that policy.
 
 More deployment detail is in [`celld-worker/README.md`](./celld-worker/README.md).
 
@@ -119,6 +123,7 @@ Workflow application
   | authenticated HTTP RPC + binary stream batches
   v
 celld worker router
+  |-- scheduled       hourly maximum-age retention discovery
   |-- WorkflowRunDO  one cell per workflow run
   |-- RunCatalogDO   16 stable run-id shards; merged ordered listing
   |-- HookTokenDO    32 stable token-ownership shards
@@ -175,18 +180,47 @@ variable is shown below.
 
 The deployed worker also accepts these celld variables:
 
-| Variable                    | Default  | Purpose                                              |
-| --------------------------- | -------- | ---------------------------------------------------- |
-| `WORLD_SECRET`              | none     | Required bearer secret for RPC routes                |
-| `WORKFLOW_CALLBACK_SECRET`  | none     | Sent with deliveries as `x-workflow-callback-secret` |
-| `QUEUE_MAX_ATTEMPTS`        | `5`      | Attempts before a message is dead-lettered           |
-| `QUEUE_MAX_INFLIGHT`        | `5`      | Concurrent deliveries per queue cell (maximum `128`) |
-| `QUEUE_DELIVERY_TIMEOUT_MS` | `300000` | Callback timeout (maximum `300000`)                  |
+| Variable                          | Default  | Purpose                                                  |
+| --------------------------------- | -------- | -------------------------------------------------------- |
+| `WORLD_SECRET`                    | none     | Required bearer secret for RPC routes                    |
+| `WORKFLOW_CALLBACK_SECRET`        | none     | Sent with deliveries as `x-workflow-callback-secret`     |
+| `QUEUE_MAX_ATTEMPTS`              | `5`      | Attempts before a message is dead-lettered               |
+| `QUEUE_MAX_INFLIGHT`              | `5`      | Concurrent deliveries per queue cell (maximum `128`)     |
+| `QUEUE_DELIVERY_TIMEOUT_MS`       | `300000` | Callback timeout (maximum `300000`)                      |
+| `WORKFLOW_RETENTION_MS`           | `0`      | Maximum run age from creation; includes active runs      |
+| `WORKFLOW_RETENTION_BATCH_SIZE`   | `128`    | Runs admitted by each cron sweep (maximum `1000`)        |
+| `WORKFLOW_RETENTION_QUEUE_SHARDS` | `1`      | Queue-shard fallback for runs created before this policy |
 
 `queueShards` is part of queue placement and is pinned when a queue cell is
 first used. Drain pending work before changing it.
 
-## Terminal run retention
+## Workflow retention
+
+### Fleet-wide maximum age
+
+Set the deployed worker's `WORKFLOW_RETENTION_MS` variable to expire every
+workflow after a maximum age measured from `createdAt`. For example,
+`7776000000` is 90 days. This policy applies to pending, running, completed,
+failed, and cancelled runs.
+
+The packaged worker declares an hourly UTC celld cron trigger. Each occurrence
+scans one bounded creation-time catalog page and asks the authoritative run
+cells to enforce the cutoff. A run cell immediately fences reads, writes, stream
+activity, and queue work, removes its catalog entry, then finishes the existing
+bounded stream, queue, and payload cleanup phases through its durable alarm.
+Repeated cron invocations and alarm retries are idempotent.
+
+One occurrence admits at most `WORKFLOW_RETENTION_BATCH_SIZE` runs (default
+`128`, maximum `1000`). If the fleet was down or a shorter policy creates a
+backlog, later occurrences continue with the next oldest entries. Edit
+`triggers.crons` in the copied `celld-worker/wrangler.jsonc` if hourly discovery
+does not provide the desired expiration resolution or catch-up rate.
+
+New runs persist the application's `queueShards` value for complete queue
+cleanup. `WORKFLOW_RETENTION_QUEUE_SHARDS` is the fallback for runs created
+before that metadata existed and must match the placement used by those runs.
+
+### Terminal payload retention
 
 When `runRetentionMs` is greater than zero, a terminal transition atomically
 records the run's `expiredAt` and arms its cell alarm. The complete run, event,
@@ -220,7 +254,8 @@ await world.retention.rearm(runId); // recover a missed or abandoned alarm
 
 The retention deadline is pinned when the run becomes terminal. Changing the
 configuration affects newly terminal runs; call `schedule()` explicitly for
-an existing terminal run that has no cleanup record.
+an existing terminal run that has no cleanup record. If terminal retention and
+fleet-wide maximum age are both enabled, the earlier deadline wins.
 
 ## Operational notes
 

--- a/celld-worker/README.md
+++ b/celld-worker/README.md
@@ -25,6 +25,27 @@ Requirements:
 - `WORLD_SECRET` injected at the node level (`CELLD_VAR_WORLD_SECRET=...`) —
   the router fails closed with 503 while it is empty.
 
+## Fleet-wide retention
+
+The bundled `wrangler.jsonc` declares an hourly UTC cron trigger. It does no
+catalog work by default. Set `CELLD_VAR_WORKFLOW_RETENTION_MS` on every node to
+enable a maximum workflow age measured from run creation:
+
+```sh
+CELLD_VAR_WORKFLOW_RETENTION_MS=7776000000 \
+celld --bucket s3://my-cells-bucket
+```
+
+`7776000000` is 90 days. The policy includes pending and running workflows as
+well as terminal ones. Each cron occurrence admits at most
+`WORKFLOW_RETENTION_BATCH_SIZE` runs (default `128`); the existing per-run alarm
+state machine finishes bounded index, stream, queue, and payload cleanup.
+
+New runs persist the application's `queueShards` placement. Set
+`WORKFLOW_RETENTION_QUEUE_SHARDS` to the historical queue-shard count when
+cleaning runs created before this worker version. Edit `triggers.crons` in the
+copied config if hourly discovery is not the desired resolution.
+
 Point the app at any node's public listener:
 
 ```ts

--- a/celld-worker/wrangler.jsonc
+++ b/celld-worker/wrangler.jsonc
@@ -28,6 +28,10 @@
       ],
     },
   ],
+  // Fleet-wide maximum-age retention is discovered hourly. The handler is a
+  // no-op while WORKFLOW_RETENTION_MS is "0". Change this expression if a
+  // different sweep cadence is required; celld cron schedules are UTC.
+  "triggers": { "crons": ["0 * * * *"] },
   "vars": {
     // REQUIRED: bearer secret for the world's RPC and binary stream surface.
     // Authenticated routes fail closed with 503 while this is empty. Inject the real value
@@ -35,6 +39,14 @@
     "WORLD_SECRET": "",
     // Optional: forwarded as x-workflow-callback-secret on queue deliveries.
     "WORKFLOW_CALLBACK_SECRET": "",
+    // Optional fleet-wide maximum workflow age, measured from run creation.
+    // Applies to pending, running, and terminal runs. "0" disables it.
+    "WORKFLOW_RETENTION_MS": "0",
+    // Maximum runs admitted to cleanup by one hourly sweep (1..1000).
+    "WORKFLOW_RETENTION_BATCH_SIZE": "128",
+    // Must match createCelldWorld({ queueShards }) so every queue shard is
+    // included in cleanup for active runs discovered by the sweep.
+    "WORKFLOW_RETENTION_QUEUE_SHARDS": "1",
     // Optional queue tuning (strings): QUEUE_MAX_ATTEMPTS, QUEUE_MAX_INFLIGHT,
     // QUEUE_DELIVERY_TIMEOUT_MS.
   },

--- a/docs/lifecycle-compaction.md
+++ b/docs/lifecycle-compaction.md
@@ -29,19 +29,19 @@ there is no cached non-expired proof which can outlive a retention boundary.
 
 ## Producer and consumer map
 
-| State                                          | Producers                                                                             | Consumers and replay behavior                                                                                                        | Terminal state                                                                          |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| `retention:cleanup`                            | terminal `WorkflowRunDO.applyEvent`, `scheduleCleanup`, `cleanupNow`                  | `retentionState`, the RunDO alarm phase machine, status/rearm RPCs, generation checks after every cross-cell await, retry accounting | folded into and deleted beside the final tombstone                                      |
-| `retention:tombstone`                          | payload cleanup, before each bounded delete page and again on completion              | every RunDO read/write guard, `getLifecycleStatus`, queue fallback, hook read/finalize fallback                                      | one permanent record per expired run                                                    |
-| terminal cleanup marker                        | terminal `applyEvent`                                                                 | hook entity pages, durable hook-marker pages, wait pages, failure backoff                                                            | deleted when all terminal pages finish                                                  |
-| hook entity/marker                             | hook event transaction                                                                | terminal and retention cleanup replays; exact token and ID release batches                                                           | deleted in pages of at most 64 hooks                                                    |
-| exact hook claim plus deadline                 | token/ID `reserve`                                                                    | `finalize`/`publish`, exact cancellation release, hook cleanup, shard alarm                                                          | finalized/released immediately or alarm-deleted after its protocol lease                |
-| RunDO exact cancellation                       | ambiguous `applyEvent` resolution when the hook is absent and the run has not expired | replayed `hook_created` guard                                                                                                        | payload cleanup deletes it; resolvers never recreate it after the logical tombstone     |
-| catalog expiry marker plus GC deadline         | RunDO index cleanup calling `RunCatalogDO.expireRun`                                  | catalog `upsertRun`; catalog alarm                                                                                                   | deleted after the publication horizon                                                   |
-| queue run reference                            | enqueue, claim recovery, retry, DLQ transition, redrive                               | paged `expireRun`, ack, purge                                                                                                        | deleted with its message lifecycle                                                      |
-| queue exact expiry receipt                     | each queue shard's paged `expireRun`                                                  | enqueue, 503 reschedule, retry/DLQ, redrive; RunDO cumulative-count reconciliation and replay                                        | retained without a deadline until RunDO persists the final receipt                      |
-| queue receipt acknowledgement plus GC deadline | RunDO after persisting the final shard receipt                                        | idempotent `acknowledgeExpireRun`; bounded queue compaction alarm                                                                    | exact receipt and deadline are deleted; all later operations use RunDO authority        |
-| stream registry/stream expiry metadata         | RunDO stream cleanup                                                                  | stream read/write guards and bounded stream cleanup replay                                                                           | retained as the stream entity's terminal metadata, not a duplicated per-shard run fence |
+| State                                          | Producers                                                                                          | Consumers and replay behavior                                                                                                        | Terminal state                                                                          |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `retention:cleanup`                            | terminal `WorkflowRunDO.applyEvent`, maximum-age cron enforcement, `scheduleCleanup`, `cleanupNow` | `retentionState`, the RunDO alarm phase machine, status/rearm RPCs, generation checks after every cross-cell await, retry accounting | folded into and deleted beside the final tombstone                                      |
+| `retention:tombstone`                          | payload cleanup, before each bounded delete page and again on completion                           | every RunDO read/write guard, `getLifecycleStatus`, queue fallback, hook read/finalize fallback                                      | one permanent record per expired run                                                    |
+| terminal cleanup marker                        | terminal `applyEvent`                                                                              | hook entity pages, durable hook-marker pages, wait pages, failure backoff                                                            | deleted when all terminal pages finish                                                  |
+| hook entity/marker                             | hook event transaction                                                                             | terminal and retention cleanup replays; exact token and ID release batches                                                           | deleted in pages of at most 64 hooks                                                    |
+| exact hook claim plus deadline                 | token/ID `reserve`                                                                                 | `finalize`/`publish`, exact cancellation release, hook cleanup, shard alarm                                                          | finalized/released immediately or alarm-deleted after its protocol lease                |
+| RunDO exact cancellation                       | ambiguous `applyEvent` resolution when the hook is absent and the run has not expired              | replayed `hook_created` guard                                                                                                        | payload cleanup deletes it; resolvers never recreate it after the logical tombstone     |
+| catalog expiry marker plus GC deadline         | RunDO index cleanup calling `RunCatalogDO.expireRun`                                               | catalog `upsertRun`; catalog alarm                                                                                                   | deleted after the publication horizon                                                   |
+| queue run reference                            | enqueue, claim recovery, retry, DLQ transition, redrive                                            | paged `expireRun`, ack, purge                                                                                                        | deleted with its message lifecycle                                                      |
+| queue exact expiry receipt                     | each queue shard's paged `expireRun`                                                               | enqueue, 503 reschedule, retry/DLQ, redrive; RunDO cumulative-count reconciliation and replay                                        | retained without a deadline until RunDO persists the final receipt                      |
+| queue receipt acknowledgement plus GC deadline | RunDO after persisting the final shard receipt                                                     | idempotent `acknowledgeExpireRun`; bounded queue compaction alarm                                                                    | exact receipt and deadline are deleted; all later operations use RunDO authority        |
+| stream registry/stream expiry metadata         | RunDO stream cleanup                                                                               | stream read/write guards and bounded stream cleanup replay                                                                           | retained as the stream entity's terminal metadata, not a duplicated per-shard run fence |
 
 `RunFenceDO`, `WORKFLOW_RUN_FENCES`, and hook-shard `runfence:<runId>` keys no
 longer exist. A hard cutover is intentional; there is no decoder, dual write,
@@ -68,8 +68,16 @@ replay to start a fresh request and be rejected by the tombstone.
 Every compaction alarm lists at most 129 entries, mutates at most 128 items,
 and re-arms for `now + 1` when a page remains. Storage failures schedule a new
 alarm edge before returning or throwing, rather than relying only on the
-platform's finite automatic retry ladder. There are no namespace-wide or
-cross-shard scans.
+platform's finite automatic retry ladder.
+
+Fleet-wide maximum-age discovery is the deliberate cross-shard exception. One
+celld cron occurrence performs a bounded creation-time merge across the 16 run
+catalog shards, admits at most `WORKFLOW_RETENTION_BATCH_SIZE` runs, then
+rechecks each candidate's authoritative `createdAt` in its RunDO. The RunDO
+removes its catalog entry before the enforcement RPC returns when possible;
+the remaining cleanup stays paged and alarm-driven. Repeated cron occurrences
+therefore advance through a backlog without turning one invocation into an
+unbounded namespace scan.
 
 ## Measured protocol and storage effects
 
@@ -113,4 +121,7 @@ concurrent expiry/compaction, lost final cleanup responses, unacknowledged
 receipt retention, and convergence of hundreds of exact queue receipts to no
 derivative state. Existing retention tests continue to cover cleanup
 generation races, paged hooks/streams/queues/payload, lost responses, and alarm
-backoff.
+backoff. Maximum-age tests additionally cover pending, running, and terminal
+runs, authoritative cutoff rechecks, bounded sweep progress, the earliest of
+terminal and fleet-wide deadlines, and cleanup across persisted queue-shard
+placement.

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,6 +76,11 @@ export interface ResolvedCelldConfig {
 }
 
 export function resolveConfig(config?: CelldWorldConfig): ResolvedCelldConfig {
+  const queueShards = config?.queueShards ?? 1;
+  if (!Number.isSafeInteger(queueShards) || queueShards < 1) {
+    throw new Error('world-celld: queueShards must be a positive safe integer');
+  }
+
   const retentionRaw = config?.runRetentionMs ?? process.env.CELLD_RUN_RETENTION_MS ?? 0;
   const runRetentionMs =
     typeof retentionRaw === 'number' ? retentionRaw : Number.parseInt(retentionRaw, 10);
@@ -117,7 +122,7 @@ export function resolveConfig(config?: CelldWorldConfig): ResolvedCelldConfig {
     env: config?.env,
     deploymentId: config?.deploymentId ?? process.env.CELLD_DEPLOYMENT_ID ?? 'celld-default',
     baseUrl: config?.baseUrl,
-    queueShards: config?.queueShards ?? 1,
+    queueShards,
     runRetentionMs,
     streamLongPollMs,
     streamFlushIntervalMs,

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -17,6 +17,8 @@ const HOOK_RELEASE_BATCH = 64;
 export interface IndexListOptions {
   prefix?: string;
   cursor?: string;
+  /** Exclusive upper bound for creation-time retention scans. */
+  end?: string;
   limit?: number;
   reverse?: boolean;
 }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -37,6 +37,11 @@ export interface RunCatalogShardStub {
     publicationExpiresAt: number,
   ): Promise<{ stored: boolean }>;
   list(options?: IndexListOptions): Promise<IndexListPage>;
+  deleteStaleGlobalRun(
+    runId: string,
+    key: string,
+    expectedValue: string,
+  ): Promise<{ deleted: boolean }>;
   expireRun(runId: string, keys: string[], expiredAt: number): Promise<ExpireRunIndexesResult>;
 }
 

--- a/src/retention.ts
+++ b/src/retention.ts
@@ -1,4 +1,4 @@
-import type { TerminalWorkflowRunStatus, WorkflowRun } from '@workflow/world';
+import type { TerminalWorkflowRunStatus, WorkflowRun, WorkflowRunStatus } from '@workflow/world';
 
 export const CLEANUP_RECORD_KEY = 'retention:cleanup';
 export const TOMBSTONE_KEY = 'retention:tombstone';
@@ -12,8 +12,13 @@ export interface CleanupRecord {
   runId: string;
   workflowName: string;
   createdAt: Date;
-  completedAt: Date;
-  terminalStatus: TerminalWorkflowRunStatus;
+  /** Last status observed when cleanup was scheduled. */
+  status?: WorkflowRunStatus;
+  /** Present when cleanup was scheduled for a terminal run. */
+  completedAt?: Date;
+  /** Retained for persisted terminal-retention records created before max-age cleanup. */
+  terminalStatus?: TerminalWorkflowRunStatus;
+  reason?: 'terminal-retention' | 'maximum-age' | 'manual';
   dueAt: Date;
   queueShards: number;
   phase: CleanupPhase;
@@ -31,8 +36,10 @@ export interface CleanupRecord {
 export interface RunTombstone {
   version: 1;
   runId: string;
-  terminalStatus: TerminalWorkflowRunStatus;
-  completedAt: Date;
+  /** Last status observed before the run expired. */
+  status?: WorkflowRunStatus;
+  completedAt?: Date;
+  terminalStatus?: TerminalWorkflowRunStatus;
   expiredAt: Date;
   tombstonedAt: Date;
   /** Final cleanup accounting retained inside the single authoritative record. */
@@ -126,6 +133,15 @@ export interface ScheduleCleanupRequest {
   queueShards: number;
 }
 
+export interface EnforceRetentionRequest extends ScheduleCleanupRequest {
+  /** Cron occurrence being enforced. A run is eligible only at/before this time. */
+  scheduledTime: number;
+}
+
+export type EnforceRetentionResult =
+  | { state: 'missing' | 'not-due'; cleanup: null }
+  | { state: 'scheduled' | 'expired'; cleanup: CleanupRecord };
+
 export function sortableTimestamp(date: Date): string {
   return date.getTime().toString().padStart(13, '0');
 }
@@ -153,6 +169,7 @@ export function cleanupTombstone(record: CleanupRecord, now: Date): RunTombstone
   return {
     version: 1,
     runId: record.runId,
+    status: record.status ?? record.terminalStatus,
     terminalStatus: record.terminalStatus,
     completedAt: record.completedAt,
     expiredAt: record.dueAt,

--- a/src/worker/durable-objects/RunCatalogDO.ts
+++ b/src/worker/durable-objects/RunCatalogDO.ts
@@ -89,6 +89,25 @@ export class RunCatalogDO extends DurableObject {
     };
   }
 
+  /** Compare-and-delete one rejected retention discovery candidate. */
+  async deleteStaleGlobalRun(
+    runId: string,
+    key: string,
+    expectedValue: string,
+  ): Promise<{ deleted: boolean }> {
+    if (!key.startsWith('runall:') || !key.endsWith(`:${runId}`)) {
+      throw new Error('Stale run catalog deletion requires the exact global run key');
+    }
+    const metadata = JSON.parse(expectedValue) as { runId?: unknown };
+    if (metadata.runId !== runId) {
+      throw new Error('Stale run catalog deletion requires matching run metadata');
+    }
+    return await this.ctx.storage.transaction(async (txn) => {
+      if ((await txn.get<string>(key)) !== expectedValue) return { deleted: false };
+      return { deleted: await txn.delete(key) };
+    });
+  }
+
   async expireRun(
     runId: string,
     keys: string[],

--- a/src/worker/durable-objects/RunCatalogDO.ts
+++ b/src/worker/durable-objects/RunCatalogDO.ts
@@ -76,8 +76,8 @@ export class RunCatalogDO extends DurableObject {
     const entries = await this.ctx.storage.list<string>({
       prefix: options.prefix ?? '',
       ...(options.reverse
-        ? { reverse: true, end: options.cursor }
-        : { startAfter: options.cursor }),
+        ? { reverse: true, end: options.cursor ?? options.end }
+        : { startAfter: options.cursor, end: options.end }),
       limit: limit + 1,
     });
     const page = Array.from(entries).slice(0, limit);

--- a/src/worker/durable-objects/WorkflowRunDO.ts
+++ b/src/worker/durable-objects/WorkflowRunDO.ts
@@ -30,6 +30,8 @@ import {
   type CleanupRecord,
   cleanupFromTombstone,
   cleanupTombstone,
+  type EnforceRetentionRequest,
+  type EnforceRetentionResult,
   type ExpireQueueRunResult,
   type ExpireRunStreamsResult,
   type ExpireStreamResult,
@@ -107,7 +109,35 @@ const STREAM_BYTES_PER_CLEANUP_PAGE = 16 * 1024 * 1024;
 const QUEUE_REFERENCES_PER_CLEANUP_PAGE = 64;
 const CLEANUP_RETRY_MAX_MS = 60 * 60 * 1000;
 const CLEANUP_PROGRESS_KEY = 'retention:progress';
+const RUN_QUEUE_SHARDS_KEY = 'retention:queue-shards';
 type TerminalRun = Extract<WorkflowRun, { status: 'completed' | 'failed' | 'cancelled' }>;
+
+function cleanupRecord(
+  run: WorkflowRun,
+  dueAt: Date,
+  queueShards: number,
+  reason: NonNullable<CleanupRecord['reason']>,
+): CleanupRecord {
+  const terminal = isTerminalWorkflowRunStatus(run.status) ? (run as TerminalRun) : undefined;
+  return {
+    version: 1,
+    runId: run.runId,
+    workflowName: run.workflowName,
+    createdAt: run.createdAt,
+    status: run.status,
+    completedAt: terminal?.completedAt,
+    terminalStatus: terminal?.status,
+    reason,
+    dueAt,
+    queueShards,
+    phase: 'retained',
+    generation: 0,
+    attempts: 0,
+    deletedPayloadKeys: 0,
+    deletedStreams: 0,
+    deletedQueueMessages: 0,
+  };
+}
 
 interface CleanupProgress {
   queueShard: number;
@@ -240,6 +270,10 @@ export class WorkflowRunDO extends DurableObject {
       });
       if (!outcome.ok) return outcome;
 
+      if (outcome.runCreated && request.cleanup) {
+        await txn.put(RUN_QUEUE_SHARDS_KEY, request.cleanup.queueShards);
+      }
+
       await txn.put('event_sequence', eventSequence);
       const hookReferences: HookIndexReference[] = outcome.hookToIndex
         ? [
@@ -265,22 +299,12 @@ export class WorkflowRunDO extends DurableObject {
         const terminalRun = outcome.run as TerminalRun;
         const dueAt = new Date(terminalRun.completedAt.getTime() + retentionMs);
         const run = WorkflowRunSchema.parse({ ...terminalRun, expiredAt: dueAt }) as TerminalRun;
-        const cleanup: CleanupRecord = {
-          version: 1,
-          runId: run.runId,
-          workflowName: run.workflowName,
-          createdAt: run.createdAt,
-          completedAt: run.completedAt,
-          terminalStatus: run.status,
+        const cleanup = cleanupRecord(
+          run,
           dueAt,
-          queueShards: request.cleanup?.queueShards ?? 1,
-          phase: 'retained',
-          generation: 0,
-          attempts: 0,
-          deletedPayloadKeys: 0,
-          deletedStreams: 0,
-          deletedQueueMessages: 0,
-        };
+          request.cleanup?.queueShards ?? 1,
+          'terminal-retention',
+        );
         await txn.put('run', run);
         await txn.put(CLEANUP_RECORD_KEY, cleanup);
         await txn.setAlarm(dueAt);
@@ -435,22 +459,7 @@ export class WorkflowRunDO extends DurableObject {
       const terminalRun = current as TerminalRun;
       const dueAt = new Date(terminalRun.completedAt.getTime() + request.retentionMs);
       const run = WorkflowRunSchema.parse({ ...terminalRun, expiredAt: dueAt }) as TerminalRun;
-      const cleanup: CleanupRecord = {
-        version: 1,
-        runId: run.runId,
-        workflowName: run.workflowName,
-        createdAt: run.createdAt,
-        completedAt: run.completedAt,
-        terminalStatus: run.status,
-        dueAt,
-        queueShards: request.queueShards,
-        phase: 'retained',
-        generation: 0,
-        attempts: 0,
-        deletedPayloadKeys: 0,
-        deletedStreams: 0,
-        deletedQueueMessages: 0,
-      };
+      const cleanup = cleanupRecord(run, dueAt, request.queueShards, 'manual');
       await txn.put('run', run);
       await txn.put(CLEANUP_RECORD_KEY, cleanup);
       await txn.setAlarm(
@@ -458,6 +467,98 @@ export class WorkflowRunDO extends DurableObject {
       );
       return cleanup;
     });
+  }
+
+  /**
+   * Apply the fleet-wide maximum-age policy to one authoritative run.
+   *
+   * The catalog is only a discovery index: eligibility is rechecked from the
+   * RunDO's own createdAt. Once eligible, the cleanup deadline immediately
+   * becomes an authoritative write/read fence, including for active runs.
+   */
+  async enforceRetention(request: EnforceRetentionRequest): Promise<EnforceRetentionResult> {
+    if (!Number.isSafeInteger(request.retentionMs) || request.retentionMs <= 0) {
+      throw new Error('world-celld retentionMs must be a positive safe integer');
+    }
+    if (!Number.isSafeInteger(request.queueShards) || request.queueShards <= 0) {
+      throw new Error('world-celld retention queueShards must be a positive safe integer');
+    }
+    if (!Number.isSafeInteger(request.scheduledTime) || request.scheduledTime < 0) {
+      throw new Error('world-celld retention scheduledTime must be a non-negative safe integer');
+    }
+
+    const result = await this.ctx.storage.transaction(async (txn) => {
+      const values = await txn.get<CleanupRecord | RunTombstone | WorkflowRun | number>([
+        CLEANUP_RECORD_KEY,
+        TOMBSTONE_KEY,
+        RUN_QUEUE_SHARDS_KEY,
+        'run',
+      ]);
+      const tombstone = values.get(TOMBSTONE_KEY) as RunTombstone | undefined;
+      if (tombstone) {
+        return {
+          state: 'expired',
+          cleanup: cleanupFromTombstone(tombstone),
+        } satisfies EnforceRetentionResult;
+      }
+
+      const run = values.get('run') as WorkflowRun | undefined;
+      if (!run) return { state: 'missing', cleanup: null } satisfies EnforceRetentionResult;
+      const dueAtMs = run.createdAt.getTime() + request.retentionMs;
+      if (!Number.isSafeInteger(dueAtMs) || dueAtMs > 8_640_000_000_000_000) {
+        throw new Error(`world-celld retention deadline is out of range for ${run.runId}`);
+      }
+      if (dueAtMs > request.scheduledTime) {
+        return { state: 'not-due', cleanup: null } satisfies EnforceRetentionResult;
+      }
+
+      const dueAt = new Date(dueAtMs);
+      const existing = values.get(CLEANUP_RECORD_KEY) as CleanupRecord | undefined;
+      const storedQueueShards = values.get(RUN_QUEUE_SHARDS_KEY) as number | undefined;
+      const queueShards =
+        Number.isSafeInteger(storedQueueShards) && (storedQueueShards as number) > 0
+          ? (storedQueueShards as number)
+          : request.queueShards;
+      let cleanup = existing;
+      if (!cleanup) {
+        cleanup = cleanupRecord(run, dueAt, queueShards, 'maximum-age');
+        await txn.put('run', WorkflowRunSchema.parse({ ...run, expiredAt: dueAt }));
+        await txn.put(CLEANUP_RECORD_KEY, cleanup);
+      } else if (cleanup.phase === 'retained' && dueAtMs < cleanup.dueAt.getTime()) {
+        const terminal = isTerminalWorkflowRunStatus(run.status) ? (run as TerminalRun) : undefined;
+        cleanup = {
+          ...cleanup,
+          status: run.status,
+          completedAt: terminal?.completedAt,
+          terminalStatus: terminal?.status,
+          reason: 'maximum-age',
+          dueAt,
+          generation: cleanup.generation + 1,
+        };
+        await txn.put('run', WorkflowRunSchema.parse({ ...run, expiredAt: dueAt }));
+        await txn.put(CLEANUP_RECORD_KEY, cleanup);
+      }
+      await txn.setAlarm(this.now() + 1);
+      return {
+        state: cleanup.dueAt.getTime() <= this.now() ? 'expired' : 'scheduled',
+        cleanup,
+      } satisfies EnforceRetentionResult;
+    });
+
+    // Remove the discovery index before returning when possible. The
+    // remaining stream/queue/payload pages continue through the run's alarm.
+    if (result.state === 'scheduled' || result.state === 'expired') {
+      for (let page = 0; page < 2; page++) {
+        const cleanup = await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
+        if (cleanup?.phase !== 'retained' && cleanup?.phase !== 'index') break;
+        await this.executeScheduledCleanupPage();
+      }
+      return {
+        ...result,
+        cleanup: (await this.getCleanupStatus()) ?? result.cleanup,
+      };
+    }
+    return result;
   }
 
   async cleanupNow(request: ScheduleCleanupRequest): Promise<CleanupRecord | null> {
@@ -546,7 +647,25 @@ export class WorkflowRunDO extends DurableObject {
   }
 
   private async executeScheduledCleanupPage(): Promise<void> {
-    const terminalCleanup = await this.ctx.storage.get<TerminalCleanupRecord>(TERMINAL_CLEANUP_KEY);
+    const values = await this.ctx.storage.get<CleanupRecord | TerminalCleanupRecord>([
+      CLEANUP_RECORD_KEY,
+      TERMINAL_CLEANUP_KEY,
+    ]);
+    const cleanup = values.get(CLEANUP_RECORD_KEY) as CleanupRecord | undefined;
+    const terminalCleanup = values.get(TERMINAL_CLEANUP_KEY) as TerminalCleanupRecord | undefined;
+
+    // Once retention is due it is the lifecycle authority. Do not make an
+    // expired run wait behind terminal hook/wait disposal; payload cleanup
+    // removes that derivative state later in the same bounded state machine.
+    if (cleanup && cleanup.phase !== 'tombstoned' && cleanup.dueAt.getTime() <= this.now()) {
+      try {
+        await this.executeCleanup(cleanup);
+      } catch (error) {
+        await this.recordCleanupFailure(error, cleanup);
+      }
+      return;
+    }
+
     if (terminalCleanup) {
       try {
         await this.executeTerminalCleanup(terminalCleanup);
@@ -556,7 +675,6 @@ export class WorkflowRunDO extends DurableObject {
       return;
     }
 
-    const cleanup = await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY);
     if (!cleanup || cleanup.phase === 'tombstoned') {
       await this.ctx.storage.deleteAlarm();
       return;

--- a/src/worker/retention-sweep.ts
+++ b/src/worker/retention-sweep.ts
@@ -1,0 +1,151 @@
+import {
+  createWorkflowIndex,
+  type CellNamespaceLike,
+  type HookIdShardStub,
+  type HookTokenShardStub,
+  type RunCatalogShardStub,
+} from '../indexes.js';
+import {
+  sortableTimestamp,
+  type EnforceRetentionRequest,
+  type EnforceRetentionResult,
+} from '../retention.js';
+
+export const DEFAULT_RETENTION_SWEEP_BATCH_SIZE = 128;
+export const MAX_RETENTION_SWEEP_BATCH_SIZE = 1000;
+const RETENTION_SWEEP_CONCURRENCY = 8;
+
+interface RetentionRunStub {
+  enforceRetention(request: EnforceRetentionRequest): Promise<EnforceRetentionResult>;
+}
+
+type RetentionNamespace<T> = CellNamespaceLike<T>;
+
+export interface RetentionSweepEnv {
+  WORKFLOW_DB: RetentionNamespace<RetentionRunStub>;
+  WORKFLOW_RUN_CATALOG: RetentionNamespace<RunCatalogShardStub>;
+  WORKFLOW_HOOK_TOKENS: RetentionNamespace<HookTokenShardStub>;
+  WORKFLOW_HOOK_IDS: RetentionNamespace<HookIdShardStub>;
+  /** Fleet-wide maximum age from run creation. Zero disables the sweep. */
+  WORKFLOW_RETENTION_MS?: string | number;
+  /** Maximum catalog entries admitted by one cron occurrence. */
+  WORKFLOW_RETENTION_BATCH_SIZE?: string | number;
+  /** Queue-shard fallback for runs created before placement was persisted. */
+  WORKFLOW_RETENTION_QUEUE_SHARDS?: string | number;
+}
+
+export interface RetentionSweepResult {
+  disabled: boolean;
+  cutoff: number | null;
+  scanned: number;
+  scheduled: number;
+  expired: number;
+  missing: number;
+  notDue: number;
+}
+
+function integerSetting(
+  name: string,
+  raw: string | number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER,
+): number {
+  const value = raw === undefined || raw === '' ? fallback : Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`world-celld: ${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value;
+}
+
+function runIdFromCatalogValue(value: string): string {
+  const parsed = JSON.parse(value) as { runId?: unknown };
+  if (typeof parsed.runId !== 'string' || parsed.runId.length === 0) {
+    throw new Error('world-celld: run catalog entry has no runId');
+  }
+  return parsed.runId;
+}
+
+/**
+ * Discover and fence one bounded page of workflows older than the configured
+ * maximum age. RunDO alarms finish the persisted, idempotent deletion phases.
+ */
+export async function runRetentionSweep(
+  scheduledTime: number,
+  env: RetentionSweepEnv,
+): Promise<RetentionSweepResult> {
+  if (!Number.isSafeInteger(scheduledTime) || scheduledTime < 0) {
+    throw new Error('world-celld: scheduledTime must be a non-negative safe integer');
+  }
+  const retentionMs = integerSetting('WORKFLOW_RETENTION_MS', env.WORKFLOW_RETENTION_MS, 0, 0);
+  if (retentionMs === 0 || scheduledTime < retentionMs) {
+    return {
+      disabled: retentionMs === 0,
+      cutoff: retentionMs === 0 ? null : scheduledTime - retentionMs,
+      scanned: 0,
+      scheduled: 0,
+      expired: 0,
+      missing: 0,
+      notDue: 0,
+    };
+  }
+  const batchSize = integerSetting(
+    'WORKFLOW_RETENTION_BATCH_SIZE',
+    env.WORKFLOW_RETENTION_BATCH_SIZE,
+    DEFAULT_RETENTION_SWEEP_BATCH_SIZE,
+    1,
+    MAX_RETENTION_SWEEP_BATCH_SIZE,
+  );
+  const queueShards = integerSetting(
+    'WORKFLOW_RETENTION_QUEUE_SHARDS',
+    env.WORKFLOW_RETENTION_QUEUE_SHARDS,
+    1,
+    1,
+  );
+  const cutoff = scheduledTime - retentionMs;
+  const index = createWorkflowIndex({
+    runCatalog: env.WORKFLOW_RUN_CATALOG,
+    hookTokens: env.WORKFLOW_HOOK_TOKENS,
+    hookIds: env.WORKFLOW_HOOK_IDS,
+  });
+  const page = await index.listRuns({
+    prefix: 'runall:',
+    end: `runall:${sortableTimestamp(new Date(cutoff + 1))}:`,
+    limit: batchSize,
+  });
+
+  const result: RetentionSweepResult = {
+    disabled: false,
+    cutoff,
+    scanned: page.keys.length,
+    scheduled: 0,
+    expired: 0,
+    missing: 0,
+    notDue: 0,
+  };
+  const failures: unknown[] = [];
+  for (let offset = 0; offset < page.keys.length; offset += RETENTION_SWEEP_CONCURRENCY) {
+    const candidates = page.keys.slice(offset, offset + RETENTION_SWEEP_CONCURRENCY);
+    const settled = await Promise.allSettled(
+      candidates.map(async (entry) => {
+        const runId = runIdFromCatalogValue(entry.value);
+        const run = env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName(runId));
+        return await run.enforceRetention({ retentionMs, queueShards, scheduledTime });
+      }),
+    );
+    for (const outcome of settled) {
+      if (outcome.status === 'rejected') {
+        failures.push(outcome.reason);
+      } else {
+        result[outcome.value.state === 'not-due' ? 'notDue' : outcome.value.state]++;
+      }
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `world-celld retention sweep failed for ${failures.length} run(s)`,
+    );
+  }
+  return result;
+}

--- a/src/worker/retention-sweep.ts
+++ b/src/worker/retention-sweep.ts
@@ -3,6 +3,7 @@ import {
   type CellNamespaceLike,
   type HookIdShardStub,
   type HookTokenShardStub,
+  runCatalogShardName,
   type RunCatalogShardStub,
 } from '../indexes.js';
 import {
@@ -130,7 +131,14 @@ export async function runRetentionSweep(
       candidates.map(async (entry) => {
         const runId = runIdFromCatalogValue(entry.value);
         const run = env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName(runId));
-        return await run.enforceRetention({ retentionMs, queueShards, scheduledTime });
+        const outcome = await run.enforceRetention({ retentionMs, queueShards, scheduledTime });
+        if (outcome.state === 'missing' || outcome.state === 'not-due') {
+          const catalog = env.WORKFLOW_RUN_CATALOG.get(
+            env.WORKFLOW_RUN_CATALOG.idFromName(runCatalogShardName(runId)),
+          );
+          await catalog.deleteStaleGlobalRun(runId, entry.name, entry.value);
+        }
+        return outcome;
       }),
     );
     for (const outcome of settled) {

--- a/src/worker/router.ts
+++ b/src/worker/router.ts
@@ -57,6 +57,9 @@ export interface WorkerEnv {
   WORKFLOW_HOOK_IDS: DONamespaceLike;
   WORKFLOW_QUEUE: DONamespaceLike;
   WORLD_SECRET?: string;
+  WORKFLOW_RETENTION_MS?: string | number;
+  WORKFLOW_RETENTION_BATCH_SIZE?: string | number;
+  WORKFLOW_RETENTION_QUEUE_SHARDS?: string | number;
 }
 
 function workflowIndex(env: WorkerEnv) {

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -4,6 +4,7 @@
  * free of Node built-ins — it runs inside celld's workerd runtime.
  */
 import { createRouter, type WorkerEnv } from './router.js';
+import { runRetentionSweep, type RetentionSweepEnv } from './retention-sweep.js';
 
 export { HookIdDO } from './durable-objects/HookIdDO.js';
 export { HookTokenDO } from './durable-objects/HookTokenDO.js';
@@ -13,8 +14,27 @@ export { StreamDO } from './durable-objects/StreamDO.js';
 export { WorkflowRunDO } from './durable-objects/WorkflowRunDO.js';
 export { createRouter, type WorkerEnv } from './router.js';
 
+interface ScheduledControllerLike {
+  scheduledTime: number;
+  cron: string;
+}
+
+async function scheduled(controller: ScheduledControllerLike, env: WorkerEnv): Promise<void> {
+  const result = await runRetentionSweep(
+    controller.scheduledTime,
+    env as unknown as RetentionSweepEnv,
+  );
+  if (result.scanned > 0) {
+    console.info('world-celld retention sweep', {
+      cron: controller.cron,
+      ...result,
+    });
+  }
+}
+
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     return createRouter(env)(request);
   },
+  scheduled,
 };

--- a/test/index-do.test.ts
+++ b/test/index-do.test.ts
@@ -445,6 +445,33 @@ describe('sharded workflow indexes', () => {
     expect(page.keys).toEqual([]);
   });
 
+  it('compare-deletes a rejected global candidate without fencing later publication', async () => {
+    const value = run(997, 'stale-retention-candidate');
+    const key = globalRunIndexKey(value);
+    const staleMetadata = JSON.stringify({ runId: value.runId, status: 'pending' });
+    const currentMetadata = JSON.stringify({ runId: value.runId, status: 'running' });
+    const publicationExpiresAt = fleet.now + MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS;
+    await indexes.commitRun(value, staleMetadata, publicationExpiresAt);
+    await indexes.commitRun(value, currentMetadata, publicationExpiresAt);
+    const catalog = fleet.namespace('run-catalog').get({
+      toString: () => runCatalogShardName(value.runId),
+    }) as RunCatalogDO;
+
+    await expect(catalog.deleteStaleGlobalRun(value.runId, key, staleMetadata)).resolves.toEqual({
+      deleted: false,
+    });
+    expect(fleet.cell('run-catalog', runCatalogShardName(value.runId)).storage.data.get(key)).toBe(
+      currentMetadata,
+    );
+
+    await expect(catalog.deleteStaleGlobalRun(value.runId, key, currentMetadata)).resolves.toEqual({
+      deleted: true,
+    });
+    expect(await indexes.commitRun(value, currentMetadata, publicationExpiresAt)).toEqual({
+      stored: true,
+    });
+  });
+
   it('compacts abandoned exact claims after the protocol lease and survives restart', async () => {
     const owner = { runId: 'wrun_abandoned_claim', hookId: 'hook-abandoned-claim' };
     const token = 'token-abandoned-claim';

--- a/test/retention-sweep.test.ts
+++ b/test/retention-sweep.test.ts
@@ -223,12 +223,9 @@ describe('fleet-wide workflow retention sweep', () => {
     const runId = await createRun(world, 'authoritative-cutoff', 'pending');
     const run = await world.runs.get(runId);
     const falseCreatedAt = new Date(run.createdAt.getTime() - 10_000);
-    harness.fleet
-      .cell('run-catalog', runCatalogShardName(runId))
-      .storage.data.set(
-        `runall:${sortableTimestamp(falseCreatedAt)}:${runId}`,
-        JSON.stringify({ runId }),
-      );
+    const falseKey = `runall:${sortableTimestamp(falseCreatedAt)}:${runId}`;
+    const catalog = harness.fleet.cell('run-catalog', runCatalogShardName(runId)).storage.data;
+    catalog.set(falseKey, JSON.stringify({ runId }));
 
     await expect(
       runRetentionSweep(
@@ -241,6 +238,72 @@ describe('fleet-wide workflow retention sweep', () => {
     ).resolves.toMatchObject({ scanned: 1, notDue: 1, expired: 0 });
     await expect(world.runs.get(runId)).resolves.toMatchObject({ status: 'pending' });
     await expect(world.retention.getStatus(runId)).resolves.toBeNull();
+    expect(catalog.has(falseKey)).toBe(false);
+    await expect(
+      runRetentionSweep(
+        harness.fleet.now,
+        sweepEnv(harness, {
+          WORKFLOW_RETENTION_MS: 1_000,
+          WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+        }),
+      ),
+    ).resolves.toMatchObject({ scanned: 0 });
+  });
+
+  it('advances past a full page of rejected catalog candidates', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+    });
+    const expiredRunId = await createRun(world, 'stale-page-expired', 'pending');
+    const expiredRun = await world.runs.get(expiredRunId);
+    harness.fleet.advance(2_000);
+    const youngRunId = await createRun(world, 'stale-page-young', 'pending');
+    const staleEntries = [
+      {
+        runId: youngRunId,
+        key: `runall:${sortableTimestamp(new Date(expiredRun.createdAt.getTime() - 20_000))}:${youngRunId}`,
+      },
+      {
+        runId: 'wrun_missing_retention_candidate',
+        key: `runall:${sortableTimestamp(new Date(expiredRun.createdAt.getTime() - 10_000))}:wrun_missing_retention_candidate`,
+      },
+    ];
+    for (const entry of staleEntries) {
+      harness.fleet
+        .cell('run-catalog', runCatalogShardName(entry.runId))
+        .storage.data.set(entry.key, JSON.stringify({ runId: entry.runId }));
+    }
+    const env = sweepEnv(harness, {
+      WORKFLOW_RETENTION_MS: 1_000,
+      WORKFLOW_RETENTION_BATCH_SIZE: 2,
+      WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+    });
+
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 2,
+      expired: 0,
+      missing: 1,
+      notDue: 1,
+    });
+    for (const entry of staleEntries) {
+      expect(
+        harness.fleet
+          .cell('run-catalog', runCatalogShardName(entry.runId))
+          .storage.data.has(entry.key),
+      ).toBe(false);
+    }
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 1,
+      expired: 1,
+      missing: 0,
+      notDue: 0,
+    });
+    await expect(world.runs.get(expiredRunId)).rejects.toSatisfy((error) =>
+      RunExpiredError.is(error),
+    );
   });
 
   it('keeps successful progress when one candidate is retried by cron', async () => {

--- a/test/retention-sweep.test.ts
+++ b/test/retention-sweep.test.ts
@@ -1,0 +1,302 @@
+import { RunExpiredError } from '@workflow/errors';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createCelldWorld } from '../src/index.js';
+import { runCatalogShardName } from '../src/indexes.js';
+import { sortableTimestamp } from '../src/retention.js';
+import { startHarness, type Harness } from '../src/testing/http-harness.js';
+import type { QueueDO } from '../src/worker/durable-objects/QueueDO.js';
+import type { WorkflowRunDO } from '../src/worker/durable-objects/WorkflowRunDO.js';
+import { runRetentionSweep, type RetentionSweepEnv } from '../src/worker/retention-sweep.js';
+
+function sweepEnv(
+  harness: Harness,
+  settings: Pick<
+    RetentionSweepEnv,
+    'WORKFLOW_RETENTION_MS' | 'WORKFLOW_RETENTION_BATCH_SIZE' | 'WORKFLOW_RETENTION_QUEUE_SHARDS'
+  >,
+): RetentionSweepEnv {
+  return {
+    WORKFLOW_DB: harness.fleet.namespace('runs') as RetentionSweepEnv['WORKFLOW_DB'],
+    WORKFLOW_RUN_CATALOG: harness.fleet.namespace(
+      'run-catalog',
+    ) as RetentionSweepEnv['WORKFLOW_RUN_CATALOG'],
+    WORKFLOW_HOOK_TOKENS: harness.fleet.namespace(
+      'hook-tokens',
+    ) as RetentionSweepEnv['WORKFLOW_HOOK_TOKENS'],
+    WORKFLOW_HOOK_IDS: harness.fleet.namespace(
+      'hook-ids',
+    ) as RetentionSweepEnv['WORKFLOW_HOOK_IDS'],
+    ...settings,
+  };
+}
+
+async function createRun(
+  world: ReturnType<typeof createCelldWorld>,
+  suffix: string,
+  status: 'pending' | 'running' | 'completed',
+): Promise<string> {
+  const created = await world.events.create(null, {
+    eventType: 'run_created',
+    eventData: {
+      deploymentId: 'retention-sweep-tests',
+      workflowName: `retention-sweep-${suffix}`,
+      input: [suffix],
+    },
+  });
+  if (status === 'running' || status === 'completed') {
+    await world.events.create(created.run.runId, { eventType: 'run_started' });
+  }
+  if (status === 'completed') {
+    await world.events.create(created.run.runId, {
+      eventType: 'run_completed',
+      eventData: { output: ['done'] },
+    });
+  }
+  return created.run.runId;
+}
+
+async function driveCleanup(harness: Harness, runIds: string[]): Promise<void> {
+  for (let page = 0; page < 30; page++) {
+    if (
+      runIds.every(
+        (runId) =>
+          harness.fleet.cell('runs', runId).storage.data.has('retention:tombstone') &&
+          !harness.fleet.cell('runs', runId).storage.data.has('retention:cleanup'),
+      )
+    ) {
+      return;
+    }
+    harness.fleet.advance(1);
+    await harness.fleet.fireDueAlarms();
+  }
+  throw new Error('maximum-age cleanup did not finish');
+}
+
+describe('fleet-wide workflow retention sweep', () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    delete process.env.CELLD_QUEUE_MODE;
+    await harness?.close();
+    harness = undefined;
+  });
+
+  it('expires pending, running, and terminal workflows by creation age', async () => {
+    process.env.CELLD_QUEUE_MODE = 'cells';
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+      baseUrl: 'http://127.0.0.1:1',
+      queueShards: 2,
+    });
+    const pending = await createRun(world, 'pending', 'pending');
+    const running = await createRun(world, 'running', 'running');
+    const completed = await createRun(world, 'completed', 'completed');
+    await world.queue(
+      '__wkf_workflow_retention_sweep',
+      { runId: running },
+      { delaySeconds: 3_600, idempotencyKey: `retention:${running}` },
+    );
+
+    harness.fleet.advance(2_000);
+    const young = await createRun(world, 'young', 'pending');
+    const result = await runRetentionSweep(
+      harness.fleet.now,
+      sweepEnv(harness, {
+        WORKFLOW_RETENTION_MS: 1_000,
+        // New runs persist their application-side shard count, so this is
+        // only a fallback for runs created before the retention sweep exists.
+        WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      disabled: false,
+      scanned: 3,
+      expired: 3,
+      scheduled: 0,
+      missing: 0,
+      notDue: 0,
+    });
+    for (const runId of [pending, running, completed]) {
+      await expect(world.runs.get(runId)).rejects.toSatisfy((error) => RunExpiredError.is(error));
+      expect(await world.retention.getStatus(runId)).toMatchObject({
+        reason: 'maximum-age',
+        phase: 'streams',
+      });
+    }
+    await expect(world.runs.get(young)).resolves.toMatchObject({ status: 'pending' });
+
+    await driveCleanup(harness, [pending, running, completed]);
+    expect(
+      harness.fleet.cell('runs', pending).storage.data.get('retention:tombstone'),
+    ).toMatchObject({ status: 'pending', cleanup: { reason: 'maximum-age' } });
+    expect(
+      harness.fleet.cell('runs', running).storage.data.get('retention:tombstone'),
+    ).toMatchObject({ status: 'running', cleanup: { reason: 'maximum-age' } });
+    expect(
+      harness.fleet.cell('runs', completed).storage.data.get('retention:tombstone'),
+    ).toMatchObject({ status: 'completed', terminalStatus: 'completed' });
+    for (let shard = 0; shard < 2; shard++) {
+      const queue = harness.fleet.namespace('queue').get({
+        toString: () => `q:${shard}`,
+      }) as QueueDO;
+      await expect(queue.stats()).resolves.toMatchObject({
+        pending: 0,
+        inflight: 0,
+        deadLetters: 0,
+      });
+    }
+  });
+
+  it('makes progress across bounded cron occurrences', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+    });
+    const runIds = await Promise.all(
+      Array.from({ length: 5 }, (_, index) => createRun(world, `batch-${index}`, 'pending')),
+    );
+    harness.fleet.advance(1_000);
+    const env = sweepEnv(harness, {
+      WORKFLOW_RETENTION_MS: 100,
+      WORKFLOW_RETENTION_BATCH_SIZE: 2,
+      WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+    });
+
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 2,
+      expired: 2,
+    });
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 2,
+      expired: 2,
+    });
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 1,
+      expired: 1,
+    });
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 0,
+    });
+
+    for (const runId of runIds) {
+      await expect(world.runs.get(runId)).rejects.toSatisfy((error) => RunExpiredError.is(error));
+    }
+  });
+
+  it('uses the earlier terminal or maximum-age deadline', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+      runRetentionMs: 10_000,
+    });
+    const runId = await createRun(world, 'earliest-deadline', 'completed');
+    const terminalDeadline = (await world.retention.getStatus(runId))?.dueAt.getTime();
+    harness.fleet.advance(2_000);
+
+    await runRetentionSweep(
+      harness.fleet.now,
+      sweepEnv(harness, {
+        WORKFLOW_RETENTION_MS: 1_000,
+        WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+      }),
+    );
+    const status = await world.retention.getStatus(runId);
+    expect(status).toMatchObject({ reason: 'maximum-age', phase: 'streams' });
+    expect(status?.dueAt.getTime()).toBeLessThan(terminalDeadline ?? 0);
+  });
+
+  it('rechecks a catalog candidate against the authoritative creation time', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+    });
+    const runId = await createRun(world, 'authoritative-cutoff', 'pending');
+    const run = await world.runs.get(runId);
+    const falseCreatedAt = new Date(run.createdAt.getTime() - 10_000);
+    harness.fleet
+      .cell('run-catalog', runCatalogShardName(runId))
+      .storage.data.set(
+        `runall:${sortableTimestamp(falseCreatedAt)}:${runId}`,
+        JSON.stringify({ runId }),
+      );
+
+    await expect(
+      runRetentionSweep(
+        harness.fleet.now,
+        sweepEnv(harness, {
+          WORKFLOW_RETENTION_MS: 1_000,
+          WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+        }),
+      ),
+    ).resolves.toMatchObject({ scanned: 1, notDue: 1, expired: 0 });
+    await expect(world.runs.get(runId)).resolves.toMatchObject({ status: 'pending' });
+    await expect(world.retention.getStatus(runId)).resolves.toBeNull();
+  });
+
+  it('keeps successful progress when one candidate is retried by cron', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+    });
+    const retryRunId = await createRun(world, 'retry-candidate', 'pending');
+    harness.fleet.advance(1);
+    const successfulRunId = await createRun(world, 'successful-candidate', 'pending');
+    harness.fleet.advance(1_000);
+    const env = sweepEnv(harness, {
+      WORKFLOW_RETENTION_MS: 100,
+      WORKFLOW_RETENTION_BATCH_SIZE: 2,
+      WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+    });
+    const retryRun = harness.fleet.cell('runs', retryRunId).instance as WorkflowRunDO;
+    const originalEnforce = retryRun.enforceRetention.bind(retryRun);
+    retryRun.enforceRetention = async () => {
+      throw new Error('injected retention admission failure');
+    };
+
+    await expect(runRetentionSweep(harness.fleet.now, env)).rejects.toThrow(
+      /retention sweep failed for 1 run/,
+    );
+    await expect(world.runs.get(retryRunId)).resolves.toMatchObject({ status: 'pending' });
+    await expect(world.runs.get(successfulRunId)).rejects.toSatisfy((error) =>
+      RunExpiredError.is(error),
+    );
+
+    retryRun.enforceRetention = originalEnforce;
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 1,
+      expired: 1,
+    });
+    await expect(world.runs.get(retryRunId)).rejects.toSatisfy((error) =>
+      RunExpiredError.is(error),
+    );
+  });
+
+  it('does no catalog work while the policy is disabled', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const result = await runRetentionSweep(
+      harness.fleet.now,
+      sweepEnv(harness, { WORKFLOW_RETENTION_MS: 0 }),
+    );
+    expect(result).toEqual({
+      disabled: true,
+      cutoff: null,
+      scanned: 0,
+      scheduled: 0,
+      expired: 0,
+      missing: 0,
+      notDue: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a fleet-wide maximum workflow age configured with `WORKFLOW_RETENTION_MS`
- use celld v0.3 cron triggers to discover one bounded creation-time page per occurrence
- enforce the cutoff in the authoritative `WorkflowRunDO` for pending, running, and terminal runs
- keep deletion paged and retry-safe through the existing index, stream, queue, and payload cleanup state machine
- persist queue-shard placement for complete cleanup, with a fallback for runs created before this metadata
- preserve terminal payload retention and apply whichever deadline is earlier

The packaged worker runs the sweep hourly in UTC, admits 128 runs per occurrence by default, and leaves the feature disabled while `WORKFLOW_RETENTION_MS` is `0`.

## Validation

- `pnpm check`
  - formatting
  - strict type-aware lint
  - typecheck and build
  - 287 tests
  - workerd bundle check
  - clean package installation
- celld v0.3.0 accepted and bundled the cron-enabled worker configuration during deployment-shape validation

## Test coverage

- pending, running, and terminal maximum-age expiry
- bounded progress across cron occurrences
- authoritative RunDO cutoff recheck and stale-candidate reconciliation
- partial sweep failure and retry progress
- queue cleanup using persisted shard placement
- earliest-deadline behavior with terminal retention