### PR TITLE
fix: harden remote transport failure handling

### DIFF
--- a/src/remote/namespaces.ts
+++ b/src/remote/namespaces.ts
@@ -38,7 +38,13 @@ const RUNS: MethodSpec = {
     'rearmCleanup',
     'resolveHookTokenClaim',
   ],
-  mutating: new Set(['applyEvent', 'scheduleCleanup', 'cleanupNow', 'rearmCleanup']),
+  mutating: new Set([
+    'applyEvent',
+    'scheduleCleanup',
+    'cleanupNow',
+    'rearmCleanup',
+    'resolveHookTokenClaim',
+  ]),
 };
 
 const STREAMS: MethodSpec = {

--- a/src/remote/rpc-client.ts
+++ b/src/remote/rpc-client.ts
@@ -19,6 +19,16 @@ function delayMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export function resolveFleetTimeoutMs(transport: RpcTransport): number {
+  const timeoutMs = transport.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_FLEET_RPC_TIMEOUT_MS) {
+    throw new Error(
+      `world-celld: fleet RPC timeout must be between 1 and ${MAX_FLEET_RPC_TIMEOUT_MS}`,
+    );
+  }
+  return timeoutMs;
+}
+
 /**
  * Invoke one DO method through the worker router.
  *
@@ -53,12 +63,7 @@ export async function callFleetRoute<T>(
   const doFetch = transport.fetchImpl ?? fetch;
   const url = `${transport.fleetUrl.replace(/\/$/, '')}${path}`;
   const attempts = opts?.idempotent ? FLEET_IDEMPOTENT_ATTEMPTS : 1;
-  const timeoutMs = transport.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_FLEET_RPC_TIMEOUT_MS) {
-    throw new Error(
-      `world-celld: fleet RPC timeout must be between 1 and ${MAX_FLEET_RPC_TIMEOUT_MS}`,
-    );
-  }
+  const timeoutMs = resolveFleetTimeoutMs(transport);
 
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt++) {

--- a/src/remote/stream-client.ts
+++ b/src/remote/stream-client.ts
@@ -10,21 +10,33 @@ import {
   type StreamWriteResult,
 } from '../stream-protocol.js';
 import { FleetTransportError, reconstructError, type WireError } from './errors.js';
-import type { RpcTransport } from './rpc-client.js';
+import { resolveFleetTimeoutMs, type RpcTransport } from './rpc-client.js';
 
 const RETRYABLE_STATUSES = new Set([502, 503, 504]);
 const READ_ATTEMPTS = 3;
-const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_WRITE_RESPONSE_BYTES = 64;
 const MAX_READ_RESPONSE_BYTES = MAX_STREAM_READ_BYTES + 64 * 1024;
 const MAX_ERROR_RESPONSE_BYTES = 64 * 1024;
 
-function delayMs(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function delayMs(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  if (signal.aborted) return Promise.reject(aborted(signal));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      reject(aborted(signal));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function requestSignal(timeoutMs: number, signal?: AbortSignal): AbortSignal {
-  const timeout = AbortSignal.timeout(Math.max(1, timeoutMs));
+  const timeout = AbortSignal.timeout(timeoutMs);
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }
 
@@ -90,6 +102,7 @@ export async function writeStreamChunks(
   runId: string,
   chunks: Uint8Array[],
 ): Promise<StreamWriteResult> {
+  const timeoutMs = resolveFleetTimeoutMs(transport);
   const body = encodeStreamWriteBatch(chunks);
   if (body.byteLength > MAX_STREAM_BATCH_BYTES + 1024) {
     throw new Error('world-celld: encoded stream batch exceeds configured limit');
@@ -107,7 +120,7 @@ export async function writeStreamChunks(
         authorization: `Bearer ${transport.secret}`,
       },
       body,
-      signal: requestSignal(transport.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+      signal: requestSignal(timeoutMs),
     });
   } catch (error) {
     throw new FleetTransportError(`world-celld: fleet unreachable at ${url.href}`, error);
@@ -128,6 +141,7 @@ export async function readStreamChunks(
   request: StreamReadRequest,
   signal?: AbortSignal,
 ): Promise<StreamReadResult> {
+  const timeoutMs = resolveFleetTimeoutMs(transport);
   const url = new URL(streamUrl(transport, name));
   url.searchParams.set('runId', request.runId);
   url.searchParams.set('startIndex', String(request.startIndex));
@@ -139,13 +153,13 @@ export async function readStreamChunks(
 
   for (let attempt = 1; attempt <= READ_ATTEMPTS; attempt++) {
     if (signal?.aborted) throw aborted(signal);
-    if (attempt > 1) await delayMs(100 * attempt + Math.random() * 200);
+    if (attempt > 1) await delayMs(100 * attempt + Math.random() * 200, signal);
     let response: Response;
     try {
       response = await doFetch(url, {
         method: 'GET',
         headers: { authorization: `Bearer ${transport.secret}` },
-        signal: requestSignal(transport.timeoutMs ?? DEFAULT_TIMEOUT_MS, signal),
+        signal: requestSignal(timeoutMs, signal),
       });
     } catch (error) {
       if (signal?.aborted) throw aborted(signal);
@@ -153,20 +167,41 @@ export async function readStreamChunks(
       continue;
     }
 
+    if (signal?.aborted) {
+      await response.body?.cancel(aborted(signal)).catch(() => undefined);
+      throw aborted(signal);
+    }
+
     if (response.ok) {
       try {
         return decodeStreamReadResult(await readBoundedResponse(response, MAX_READ_RESPONSE_BYTES));
       } catch (error) {
-        lastError = new FleetTransportError(
-          `world-celld: malformed stream response from ${url.href}`,
-          error,
-        );
+        if (signal?.aborted) throw aborted(signal);
+        lastError =
+          error instanceof FleetTransportError
+            ? error
+            : new FleetTransportError(
+                `world-celld: malformed stream response from ${url.href}`,
+                error,
+              );
         if (attempt < READ_ATTEMPTS) continue;
         throw lastError;
       }
     }
 
-    const error = await errorFromResponse(response);
+    let error: Error;
+    try {
+      error = await errorFromResponse(response);
+    } catch (cause) {
+      if (signal?.aborted) throw aborted(signal);
+      error =
+        cause instanceof FleetTransportError
+          ? cause
+          : new FleetTransportError(
+              `world-celld: malformed stream error response from ${url.href}`,
+              cause,
+            );
+    }
     if (RETRYABLE_STATUSES.has(response.status) && attempt < READ_ATTEMPTS) {
       lastError = error;
       continue;

--- a/test/rpc-client.test.ts
+++ b/test/rpc-client.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { rpcStringify } from '../src/codec.js';
+import { FLEET_IDEMPOTENT_ATTEMPTS, MAX_FLEET_RPC_TIMEOUT_MS } from '../src/lifecycle.js';
 import { FleetTransportError } from '../src/remote/errors.js';
+import { createRemoteEnv } from '../src/remote/namespaces.js';
 import { callDO } from '../src/remote/rpc-client.js';
+
+function rpcResponse(value: unknown, init?: ResponseInit): Response {
+  return new Response(rpcStringify(value), { status: 200, ...init });
+}
 
 async function abortingFetch(_input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   return await new Promise<Response>((_resolve, reject) => {
@@ -8,11 +15,267 @@ async function abortingFetch(_input: RequestInfo | URL, init?: RequestInit): Pro
   });
 }
 
-async function malformedFetch(): Promise<Response> {
-  return new Response('not tagged json', { status: 200 });
-}
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 describe('remote RPC client regressions', () => {
+  it('retries an idempotent read after fetch rejects and succeeds later', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi
+      .fn<typeof fetch>(async () => rpcResponse({ ok: true }))
+      .mockRejectedValueOnce(new TypeError('connection reset'));
+
+    const result = callDO<{ ok: boolean }>(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'runs',
+      'wrun_retry',
+      'getRun',
+      [],
+      { idempotent: true },
+    );
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([502, 503, 504])(
+    'retries an idempotent read after HTTP %s and succeeds later',
+    async (status) => {
+      vi.useFakeTimers();
+      const fetchImpl = vi
+        .fn<typeof fetch>(async () => rpcResponse('recovered'))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ error: { message: `temporary ${status}` } }), { status }),
+        );
+
+      const result = callDO<string>(
+        { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+        'runs',
+        'wrun_status_retry',
+        'getRun',
+        [],
+        { idempotent: true },
+      );
+      await vi.runAllTimersAsync();
+
+      await expect(result).resolves.toBe('recovered');
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it('surfaces the final transport rejection after retry exhaustion', async () => {
+    vi.useFakeTimers();
+    const failures = [new Error('first'), new Error('second'), new Error('final')];
+    let attempt = 0;
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      throw failures[attempt++];
+    });
+
+    const outcome = callDO(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'runs',
+      'wrun_exhausted',
+      'getRun',
+      [],
+      { idempotent: true },
+    ).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(outcome).resolves.toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('fleet unreachable'),
+      cause: failures[2],
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(FLEET_IDEMPOTENT_ATTEMPTS);
+  });
+
+  it('surfaces the final retryable HTTP failure after exhaustion', async () => {
+    vi.useFakeTimers();
+    const statuses = [502, 503, 504];
+    let attempt = 0;
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      const status = statuses[attempt++];
+      return new Response(
+        JSON.stringify({
+          error: { name: `Fleet${status}Error`, message: `failure ${status}`, status },
+        }),
+        { status },
+      );
+    });
+
+    const outcome = callDO(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'runs',
+      'wrun_status_exhausted',
+      'getRun',
+      [],
+      { idempotent: true },
+    ).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(outcome).resolves.toMatchObject({
+      name: 'Fleet504Error',
+      message: 'failure 504',
+      status: 504,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(FLEET_IDEMPOTENT_ATTEMPTS);
+  });
+
+  it('reconstructs structured and non-JSON RPC failures', async () => {
+    const structuredFetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { name: 'EntityConflictError', message: 'already committed', status: 409 },
+          }),
+          { status: 500 },
+        ),
+    );
+    const plainFetch = vi.fn<typeof fetch>(
+      async () => new Response('upstream exploded', { status: 418 }),
+    );
+
+    const structured = await callDO(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl: structuredFetch },
+      'runs',
+      'wrun_structured',
+      'applyEvent',
+      [],
+    ).catch((error) => error);
+    const plain = await callDO(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl: plainFetch },
+      'runs',
+      'wrun_plain',
+      'applyEvent',
+      [],
+    ).catch((error) => error);
+
+    expect(structured).toMatchObject({
+      name: 'EntityConflictError',
+      message: 'already committed',
+      status: 409,
+    });
+    expect(plain).toMatchObject({ message: 'upstream exploded', status: 418 });
+  });
+
+  it('retries malformed successful responses only for idempotent reads', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi
+      .fn<typeof fetch>(async () => rpcResponse({ ok: true }))
+      .mockResolvedValueOnce(new Response('not tagged json', { status: 200 }));
+
+    const result = callDO<{ ok: boolean }>(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'runs',
+      'wrun_malformed',
+      'getRun',
+      [],
+      { idempotent: true },
+    );
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces malformed successful responses after read retry exhaustion', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new Response('not tagged json', { status: 200 }),
+    );
+
+    const outcome = callDO(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'runs',
+      'wrun_malformed_exhausted',
+      'getRun',
+      [],
+      { idempotent: true },
+    ).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(outcome).resolves.toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('malformed successful response'),
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(FLEET_IDEMPOTENT_ATTEMPTS);
+  });
+
+  it('makes one namespace attempt for commit-ambiguous RunDO mutations', async () => {
+    const committedMethods: string[] = [];
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const requestUrl =
+        typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      committedMethods.push(new URL(requestUrl).pathname.split('/').at(-1) ?? '');
+      throw new TypeError('response lost after commit');
+    });
+    const env = createRemoteEnv({ fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl });
+    const id = env.WORKFLOW_DB.idFromName('wrun_ambiguous');
+    const run = env.WORKFLOW_DB.get(id);
+
+    await expect(run.applyEvent({} as never)).rejects.toBeInstanceOf(FleetTransportError);
+    await expect(
+      run.resolveHookTokenClaim({ hookId: 'hook', token: 'token', claimId: 'claim' }),
+    ).rejects.toBeInstanceOf(FleetTransportError);
+
+    expect(committedMethods).toEqual(['applyEvent', 'resolveHookTokenClaim']);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('classifies namespace reads as retryable', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi
+      .fn<typeof fetch>(async () => rpcResponse({ ok: true, value: null }))
+      .mockRejectedValueOnce(new TypeError('connection reset'));
+    const env = createRemoteEnv({ fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl });
+    const result = env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName('wrun_read')).getRun();
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toEqual({ ok: true, value: null });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, MAX_FLEET_RPC_TIMEOUT_MS + 1])(
+    'rejects an invalid fleet timeout (%s) before fetch',
+    async (timeoutMs) => {
+      const fetchImpl = vi.fn<typeof fetch>(async () => rpcResponse(null));
+
+      await expect(
+        callDO(
+          { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl, timeoutMs },
+          'runs',
+          'wrun_timeout_invalid',
+          'getRun',
+          [],
+        ),
+      ).rejects.toThrow(
+        `world-celld: fleet RPC timeout must be between 1 and ${MAX_FLEET_RPC_TIMEOUT_MS}`,
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([1, MAX_FLEET_RPC_TIMEOUT_MS])(
+    'accepts the fleet timeout boundary %s',
+    async (timeoutMs) => {
+      const fetchImpl = vi.fn<typeof fetch>(async () => rpcResponse('ok'));
+
+      await expect(
+        callDO<string>(
+          { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl, timeoutMs },
+          'runs',
+          'wrun_timeout_valid',
+          'getRun',
+          [],
+        ),
+      ).resolves.toBe('ok');
+      expect(fetchImpl).toHaveBeenCalledOnce();
+    },
+  );
+
   it('aborts a fleet request at its configured deadline', async () => {
     const transport = {
       fleetUrl: 'http://fleet.test',
@@ -27,17 +290,5 @@ describe('remote RPC client regressions', () => {
     ]);
 
     expect(outcome).toBeInstanceOf(FleetTransportError);
-  });
-
-  it('classifies malformed successful responses as transport failures', async () => {
-    await expect(
-      callDO(
-        { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl: malformedFetch },
-        'runs',
-        'wrun_malformed',
-        'getRun',
-        [],
-      ),
-    ).rejects.toBeInstanceOf(FleetTransportError);
   });
 });

--- a/test/stream-client.test.ts
+++ b/test/stream-client.test.ts
@@ -1,0 +1,382 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MAX_FLEET_RPC_TIMEOUT_MS } from '../src/lifecycle.js';
+import { readStreamChunks, writeStreamChunks } from '../src/remote/stream-client.js';
+import {
+  MAX_STREAM_READ_BYTES,
+  encodeStreamReadResult,
+  encodeStreamWriteResult,
+} from '../src/stream-protocol.js';
+
+const READ_REQUEST = {
+  runId: 'wrun_stream',
+  startIndex: 0,
+  maxChunks: 4,
+  maxBytes: 1024 * 1024,
+  waitMs: 0,
+};
+const OVERSIZED_WRITE_RESPONSE_BYTES = 1024;
+const OVERSIZED_READ_RESPONSE_BYTES = MAX_STREAM_READ_BYTES + 1024 * 1024;
+const OVERSIZED_ERROR_RESPONSE_BYTES = 1024 * 1024;
+
+function binaryResponse(body: Uint8Array, init?: ResponseInit): Response {
+  return new Response(body, init);
+}
+
+function writeSuccess(): Response {
+  return binaryResponse(encodeStreamWriteResult({ startIndex: 0, count: 1, tailIndex: 0 }), {
+    status: 200,
+  });
+}
+
+function readSuccess(): Response {
+  return binaryResponse(
+    encodeStreamReadResult({
+      startIndex: 0,
+      tailIndex: 0,
+      chunks: [Uint8Array.of(1, 2, 3)],
+      state: 'open',
+      timedOut: false,
+    }),
+    { status: 200 },
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('remote binary stream writes', () => {
+  it('surfaces transport failure without retrying a commit-ambiguous write', async () => {
+    const committed = new Error('response lost after commit');
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      throw committed;
+    });
+
+    const outcome = await writeStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      'wrun_stream',
+      [Uint8Array.of(1)],
+    ).catch((error) => error);
+
+    expect(outcome).toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('fleet unreachable'),
+      cause: committed,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces retryable HTTP status without blindly retrying the write', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>(async () => writeSuccess())
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { name: 'FleetUnavailableError', message: 'try later', status: 503 },
+          }),
+          { status: 503 },
+        ),
+      );
+
+    const outcome = await writeStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      'wrun_stream',
+      [Uint8Array.of(1)],
+    ).catch((error) => error);
+
+    expect(outcome).toMatchObject({
+      name: 'FleetUnavailableError',
+      message: 'try later',
+      status: 503,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces a malformed successful write response without retrying', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>(async () => writeSuccess())
+      .mockResolvedValueOnce(binaryResponse(Uint8Array.of(1, 2, 3), { status: 200 }));
+
+    await expect(
+      writeStreamChunks(
+        { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+        'stream',
+        'wrun_stream',
+        [Uint8Array.of(1)],
+      ),
+    ).rejects.toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('malformed stream response'),
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('bounds a successful write response without retrying', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>(async () => writeSuccess())
+      .mockResolvedValueOnce(
+        binaryResponse(new Uint8Array(OVERSIZED_WRITE_RESPONSE_BYTES), { status: 200 }),
+      );
+
+    await expect(
+      writeStreamChunks(
+        { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+        'stream',
+        'wrun_stream',
+        [Uint8Array.of(1)],
+      ),
+    ).rejects.toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('stream response exceeds'),
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+});
+
+describe('remote binary stream reads', () => {
+  it.each([
+    ['transport rejection', () => Promise.reject(new TypeError('connection reset'))],
+    ['HTTP 502', () => Promise.resolve(new Response('bad gateway', { status: 502 }))],
+    ['HTTP 503', () => Promise.resolve(new Response('unavailable', { status: 503 }))],
+    ['HTTP 504', () => Promise.resolve(new Response('gateway timeout', { status: 504 }))],
+    [
+      'malformed success',
+      () => Promise.resolve(binaryResponse(Uint8Array.of(1, 2, 3), { status: 200 })),
+    ],
+  ])('retries a transient %s and succeeds later', async (_name, firstAttempt) => {
+    vi.useFakeTimers();
+    const fetchImpl = vi
+      .fn<typeof fetch>(async () => readSuccess())
+      .mockImplementationOnce(firstAttempt);
+
+    const result = readStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      READ_REQUEST,
+    );
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toMatchObject({
+      chunks: [Uint8Array.of(1, 2, 3)],
+      state: 'open',
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces the final transport rejection after read exhaustion', async () => {
+    vi.useFakeTimers();
+    const failures = [new Error('first'), new Error('second'), new Error('final')];
+    let attempt = 0;
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      throw failures[attempt++];
+    });
+
+    const outcome = readStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      READ_REQUEST,
+    ).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(outcome).resolves.toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('fleet unreachable'),
+      cause: failures[2],
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('surfaces the final retryable status after read exhaustion', async () => {
+    vi.useFakeTimers();
+    const statuses = [502, 503, 504];
+    let attempt = 0;
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      const status = statuses[attempt++];
+      return new Response(
+        JSON.stringify({
+          error: { name: `Fleet${status}Error`, message: `failure ${status}`, status },
+        }),
+        { status },
+      );
+    });
+
+    const outcome = readStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      READ_REQUEST,
+    ).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(outcome).resolves.toMatchObject({
+      name: 'Fleet504Error',
+      message: 'failure 504',
+      status: 504,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('surfaces malformed success after read retry exhaustion', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      binaryResponse(Uint8Array.of(1, 2, 3), { status: 200 }),
+    );
+
+    const outcome = readStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      READ_REQUEST,
+    ).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(outcome).resolves.toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('malformed stream response'),
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('honors a caller abort while a read request is in flight', async () => {
+    const controller = new AbortController();
+    const abortReason = new DOMException('caller stopped', 'AbortError');
+    const fetchImpl = vi.fn<typeof fetch>(
+      async (_input: RequestInfo | URL, init?: RequestInit) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {
+            once: true,
+          });
+        }),
+    );
+
+    const result = readStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      READ_REQUEST,
+      controller.signal,
+    );
+    controller.abort(abortReason);
+
+    await expect(result).rejects.toBe(abortReason);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('honors a caller abort during retry backoff without another attempt', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const abortReason = new DOMException('caller stopped', 'AbortError');
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      throw new TypeError('connection reset');
+    });
+
+    const result = readStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      READ_REQUEST,
+      controller.signal,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    let immediate: unknown = 'still-backing-off';
+    const observed = result.then(
+      () => (immediate = 'resolved'),
+      (error) => (immediate = error),
+    );
+    controller.abort(abortReason);
+    for (let turn = 0; turn < 5; turn++) await Promise.resolve();
+    if (immediate === 'still-backing-off') {
+      await vi.runAllTimersAsync();
+      await observed;
+    }
+
+    expect(immediate).toBe(abortReason);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('retries an oversized transient error response and succeeds later', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi
+      .fn<typeof fetch>(async () => readSuccess())
+      .mockResolvedValueOnce(
+        binaryResponse(new Uint8Array(OVERSIZED_ERROR_RESPONSE_BYTES), { status: 503 }),
+      );
+
+    const outcome = readStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      READ_REQUEST,
+    ).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(outcome).resolves.toMatchObject({ state: 'open' });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds non-retryable error response bodies', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      binaryResponse(new Uint8Array(OVERSIZED_ERROR_RESPONSE_BYTES), { status: 400 }),
+    );
+
+    await expect(
+      readStreamChunks(
+        { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+        'stream',
+        READ_REQUEST,
+      ),
+    ).rejects.toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('stream response exceeds'),
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('bounds successful read responses across all retry attempts', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      binaryResponse(Uint8Array.of(1), {
+        status: 200,
+        headers: { 'content-length': String(OVERSIZED_READ_RESPONSE_BYTES) },
+      }),
+    );
+
+    const outcome = readStreamChunks(
+      { fleetUrl: 'http://fleet.test', secret: 'secret', fetchImpl },
+      'stream',
+      READ_REQUEST,
+    ).catch((error) => error);
+    await vi.runAllTimersAsync();
+
+    await expect(outcome).resolves.toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('stream response exceeds'),
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('remote binary stream timeout validation', () => {
+  it.each([0, MAX_FLEET_RPC_TIMEOUT_MS + 1, 1.5, Number.NaN])(
+    'rejects invalid timeout %s before a stream write or read',
+    async (timeoutMs) => {
+      const fetchImpl = vi.fn<typeof fetch>(async () => readSuccess());
+      const transport = {
+        fleetUrl: 'http://fleet.test',
+        secret: 'secret',
+        fetchImpl,
+        timeoutMs,
+      };
+
+      await expect(
+        writeStreamChunks(transport, 'stream', 'wrun_stream', [Uint8Array.of(1)]),
+      ).rejects.toThrow(
+        `world-celld: fleet RPC timeout must be between 1 and ${MAX_FLEET_RPC_TIMEOUT_MS}`,
+      );
+      await expect(readStreamChunks(transport, 'stream', READ_REQUEST)).rejects.toThrow(
+        `world-celld: fleet RPC timeout must be between 1 and ${MAX_FLEET_RPC_TIMEOUT_MS}`,
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- add deterministic RPC regressions for idempotent retry recovery and exhaustion, mutation ambiguity, error reconstruction, malformed success responses, and timeout bounds
- add direct binary stream client coverage for one-attempt writes, transient read retries, aborts during fetch and backoff, malformed responses, and bounded bodies
- fix abort-aware stream backoff, shared timeout validation, bounded transient error retries, size-error preservation, and the RunDO resolver mutation classification

## Verification

- `pnpm exec vitest run test/rpc-client.test.ts test/stream-client.test.ts` (40 tests)
- `pnpm check` (21 test files, 325 tests; formatting, lint, typecheck, build, worker bundle, and package checks)