### PR TITLE
test: enforce real celld restart recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,35 @@ jobs:
       - name: Audit production dependencies
         run: pnpm audit --prod --audit-level high
 
+  real-celld-smoke:
+    name: celld v0.3.0 restart smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      CI: true
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - name: Enable pinned pnpm
+        run: |
+          corepack enable
+          corepack install
+          pnpm --version
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Exercise real celld restart recovery
+        run: pnpm test:integration:celld-smoke
+
   actions-security:
     name: GitHub Actions security
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -293,6 +293,33 @@ CELLD_WORLD_SECRET=replace-with-a-secret \
 pnpm test:integration
 ```
 
+### Real celld restart smoke
+
+The required CI smoke owns native celld v0.3.0 and MinIO processes on loopback,
+uses fresh temporary bucket and runtime state, and kills celld with `SIGKILL`
+before deleting its local working state and starting a new process against the
+bucket-backed state. It checks that:
+
+- acknowledged run and stream state survives the process restart;
+- an accepted delayed queue message that becomes due while celld is down is
+  delivered once after the alarm is restored;
+- multi-page retention cleanup continues from a persisted nonterminal phase;
+- cancelling an in-flight HTTP long poll leaves the stream writable and
+  readable.
+
+Run the same bounded smoke locally on Linux x86-64 or macOS arm64:
+
+```sh
+pnpm test:integration:celld-smoke
+```
+
+The runner downloads celld and MinIO artifacts at pinned versions and verifies
+their SHA-256 digests before use. MinIO does not implement the conditional-write
+contract celld requires for production ownership fencing, so the smoke disables
+the storage probe and runs exactly one celld process at a time. It proves the
+single-process restart boundaries above, not multi-node ownership, handoff, or
+failover correctness.
+
 ### Local MinIO performance and loss test
 
 The opt-in performance harness starts a fresh MinIO bucket and a single celld

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "lint": "oxlint --type-aware --deny-warnings --report-unused-disable-directives .",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:integration:celld-smoke": "bash test/integration/celld-smoke/run.sh",
     "test:perf:index": "vitest run --config vitest.index-perf.config.ts",
     "test:perf:index:baseline": "node scripts/measure-index-main-baseline.mjs",
     "test:perf:minio": "bash test/perf/minio/run.sh",

--- a/test/integration/celld-smoke.test.ts
+++ b/test/integration/celld-smoke.test.ts
@@ -1,0 +1,558 @@
+import { randomUUID } from 'node:crypto';
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { RunExpiredError } from '@workflow/errors';
+import { build } from 'esbuild';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createCelldWorld } from '../../src/index.js';
+
+const execFileAsync = promisify(execFile);
+const CELLD_BIN = process.env.CELLD_SMOKE_CELLD_BIN;
+const MINIO_BIN = process.env.CELLD_SMOKE_MINIO_BIN;
+const MC_BIN = process.env.CELLD_SMOKE_MC_BIN;
+const CONFIGURED = Boolean(CELLD_BIN && MINIO_BIN && MC_BIN);
+const SECRET = 'world-celld-smoke-secret';
+const BUCKET = 'world-celld-smoke';
+const ACCESS_KEY = 'world-celld-smoke-access';
+const SECRET_KEY = 'world-celld-smoke-secret-key';
+const MAX_PROCESS_LOG_BYTES = 128 * 1024;
+
+interface CapturedDelivery {
+  body: string;
+  headers: http.IncomingHttpHeaders;
+  receivedAt: number;
+}
+
+interface ManagedProcess {
+  child: ChildProcessWithoutNullStreams;
+  logs: () => string;
+  name: string;
+}
+
+interface RestartEvidence {
+  oldPid: number;
+  newPid: number;
+  startedAt: number;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor<T>(
+  poll: () => Promise<T | null | undefined | false>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const value = await poll();
+      if (value) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(100);
+  }
+  const suffix = lastError instanceof Error ? `: ${lastError.message}` : '';
+  throw new Error(`timed out after ${timeoutMs}ms waiting for ${label}${suffix}`);
+}
+
+async function freePort(): Promise<number> {
+  const server = http.createServer();
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+function startManaged(
+  name: string,
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): ManagedProcess {
+  const child = spawn(command, args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+  let output = '';
+  const capture = (chunk: Buffer) => {
+    output += chunk.toString('utf8');
+    if (output.length > MAX_PROCESS_LOG_BYTES) output = output.slice(-MAX_PROCESS_LOG_BYTES);
+  };
+  child.stdout.on('data', capture);
+  child.stderr.on('data', capture);
+  child.on('error', (error) => capture(Buffer.from(`\nprocess error: ${String(error)}\n`)));
+  return { child, logs: () => output, name };
+}
+
+async function waitForExit(
+  process: ManagedProcess,
+  timeoutMs: number,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (process.child.exitCode !== null || process.child.signalCode !== null) {
+    return { code: process.child.exitCode, signal: process.child.signalCode };
+  }
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${process.name} did not exit within ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    process.child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+async function stopManaged(
+  process: ManagedProcess | undefined,
+  signal: NodeJS.Signals = 'SIGTERM',
+): Promise<void> {
+  if (!process || process.child.exitCode !== null || process.child.signalCode !== null) return;
+  process.child.kill(signal);
+  try {
+    await waitForExit(process, 5_000);
+  } catch {
+    process.child.kill('SIGKILL');
+    await waitForExit(process, 5_000);
+  }
+}
+
+async function prepareWorker(destination: string): Promise<void> {
+  await mkdir(destination, { recursive: true });
+  await build({
+    entryPoints: ['dist/worker.js'],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2024',
+    conditions: ['workerd', 'worker', 'browser'],
+    external: ['cloudflare:*'],
+    outfile: join(destination, 'index.js'),
+    logLevel: 'silent',
+  });
+
+  const source = await readFile('celld-worker/wrangler.jsonc', 'utf8');
+  const main = '"main": "worker.ts",';
+  if (!source.includes(main)) throw new Error('celld worker config main entry changed');
+  await writeFile(
+    join(destination, 'wrangler.jsonc'),
+    source.replace(main, '"main": "index.js",\n  "no_bundle": true,'),
+  );
+}
+
+class NativeCelldRuntime {
+  private celld: ManagedProcess | undefined;
+  private readonly baseEnv: NodeJS.ProcessEnv;
+
+  constructor(
+    private readonly binary: string,
+    private readonly endpoint: string,
+    private readonly publicPort: number,
+    private readonly internalPort: number,
+    private readonly watchDirectory: string,
+  ) {
+    this.baseEnv = {
+      ...process.env,
+      AWS_ACCESS_KEY_ID: ACCESS_KEY,
+      AWS_SECRET_ACCESS_KEY: SECRET_KEY,
+      AWS_REGION: 'us-east-1',
+      AWS_EC2_METADATA_DISABLED: 'true',
+      CELLD_DURABILITY: 'bucket',
+      CELLD_MAX_RSS_MB: '0',
+      CELLD_NODE: 'world-celld-smoke-node',
+      CELLD_OPERATION_DEADLINE_MS: '10000',
+      CELLD_STORAGE_PROBE: '0',
+      CELLD_TTL_MS: '2000',
+      CELLD_VAR_QUEUE_DELIVERY_TIMEOUT_MS: '5000',
+      CELLD_VAR_QUEUE_MAX_INFLIGHT: '1',
+      CELLD_VAR_WORLD_SECRET: SECRET,
+      CELLD_WAKER_TICK_MS: '50',
+      CELLD_WATCH: watchDirectory,
+      RUST_LOG: 'info',
+    };
+  }
+
+  get url(): string {
+    return `http://127.0.0.1:${this.publicPort}`;
+  }
+
+  private spawn(): ManagedProcess {
+    return startManaged(
+      'celld',
+      this.binary,
+      [
+        '--bucket',
+        `s3://${BUCKET}`,
+        '--endpoint',
+        this.endpoint,
+        '--region',
+        'us-east-1',
+        '--listen',
+        `127.0.0.1:${this.publicPort}`,
+        '--internal-listen',
+        `127.0.0.1:${this.internalPort}`,
+      ],
+      this.baseEnv,
+    );
+  }
+
+  async start(): Promise<void> {
+    if (this.celld && this.celld.child.exitCode === null && this.celld.child.signalCode === null) {
+      throw new Error('celld is already running');
+    }
+    this.celld = this.spawn();
+    await waitFor(
+      async () => {
+        if (this.celld?.child.exitCode !== null || this.celld?.child.signalCode !== null) {
+          throw new Error(`celld exited during startup\n${this.celld?.logs() ?? ''}`);
+        }
+        const response = await fetch(`${this.url}/v1/health`, {
+          signal: AbortSignal.timeout(1_000),
+        });
+        return response.ok ? true : null;
+      },
+      45_000,
+      'celld readiness',
+    );
+  }
+
+  async restart(downtimeMs: number, dropLocalState = false): Promise<RestartEvidence> {
+    const current = this.celld;
+    const oldPid = current?.child.pid;
+    if (!current || oldPid === undefined) throw new Error('celld is not running');
+    if (!current.child.kill('SIGKILL')) throw new Error('failed to SIGKILL celld');
+    const exit = await waitForExit(current, 5_000);
+    if (exit.signal !== 'SIGKILL') {
+      throw new Error(
+        `celld restart expected SIGKILL, got code=${exit.code} signal=${exit.signal}`,
+      );
+    }
+    if (dropLocalState) {
+      await rm(this.watchDirectory, { recursive: true, force: true });
+      await mkdir(this.watchDirectory, { recursive: true });
+    }
+    await delay(downtimeMs);
+    const startedAt = Date.now();
+    await this.start();
+    const newPid = this.celld?.child.pid;
+    if (newPid === undefined) throw new Error('restarted celld has no pid');
+    return { oldPid, newPid, startedAt };
+  }
+
+  async stop(): Promise<void> {
+    await stopManaged(this.celld);
+  }
+
+  killNow(): void {
+    if (this.celld?.child.exitCode === null && this.celld.child.signalCode === null) {
+      this.celld.child.kill('SIGKILL');
+    }
+  }
+
+  logs(): string {
+    return this.celld?.logs() ?? '';
+  }
+}
+
+describe.skipIf(!CONFIGURED)('real celld v0.3.0 restart smoke', () => {
+  const deliveries: CapturedDelivery[] = [];
+  let temporaryRoot: string;
+  let minio: ManagedProcess | undefined;
+  let runtime: NativeCelldRuntime | undefined;
+  let callbackServer: http.Server | undefined;
+  let callbackBaseUrl: string;
+  let firstRunId: string;
+
+  const emergencyStop = () => {
+    runtime?.killNow();
+    if (minio?.child.exitCode === null && minio.child.signalCode === null) {
+      minio.child.kill('SIGKILL');
+    }
+    callbackServer?.closeAllConnections();
+  };
+
+  beforeAll(async () => {
+    const requestedRoot = process.env.CELLD_SMOKE_TEMP_ROOT;
+    temporaryRoot = requestedRoot ?? (await mkdtemp(join(tmpdir(), 'world-celld-smoke-')));
+    if (requestedRoot) await mkdir(temporaryRoot, { recursive: true });
+    process.env.CELLD_QUEUE_MODE = 'cells';
+    process.once('exit', emergencyStop);
+
+    try {
+      const minioPort = await freePort();
+      const minioConsolePort = await freePort();
+      const celldPort = await freePort();
+      const celldInternalPort = await freePort();
+      const minioUrl = `http://127.0.0.1:${minioPort}`;
+      const storageEnv = {
+        ...process.env,
+        MINIO_ROOT_USER: ACCESS_KEY,
+        MINIO_ROOT_PASSWORD: SECRET_KEY,
+      };
+
+      minio = startManaged(
+        'minio',
+        MINIO_BIN!,
+        [
+          'server',
+          join(temporaryRoot, 'minio-data'),
+          '--address',
+          `127.0.0.1:${minioPort}`,
+          '--console-address',
+          `127.0.0.1:${minioConsolePort}`,
+        ],
+        storageEnv,
+      );
+      await waitFor(
+        async () => {
+          if (minio?.child.exitCode !== null || minio?.child.signalCode !== null) {
+            throw new Error(`minio exited during startup\n${minio?.logs() ?? ''}`);
+          }
+          const response = await fetch(`${minioUrl}/minio/health/live`, {
+            signal: AbortSignal.timeout(1_000),
+          });
+          return response.ok ? true : null;
+        },
+        30_000,
+        'MinIO readiness',
+      );
+
+      const mcConfig = join(temporaryRoot, 'mc-config');
+      const mcEnv = { ...process.env, MC_CONFIG_DIR: mcConfig };
+      await execFileAsync(MC_BIN!, ['alias', 'set', 'smoke', minioUrl, ACCESS_KEY, SECRET_KEY], {
+        env: mcEnv,
+      });
+      await execFileAsync(MC_BIN!, ['mb', '--ignore-existing', `smoke/${BUCKET}`], { env: mcEnv });
+
+      const workerDirectory = join(temporaryRoot, 'worker');
+      await prepareWorker(workerDirectory);
+      const storageClientEnv = {
+        ...process.env,
+        AWS_ACCESS_KEY_ID: ACCESS_KEY,
+        AWS_SECRET_ACCESS_KEY: SECRET_KEY,
+        AWS_REGION: 'us-east-1',
+        AWS_EC2_METADATA_DISABLED: 'true',
+      };
+      const version = await execFileAsync(CELLD_BIN!, ['--version'], { env: storageClientEnv });
+      if (!/\b0\.3\.0\b/.test(version.stdout)) {
+        throw new Error(`expected celld v0.3.0, got ${version.stdout.trim()}`);
+      }
+      await execFileAsync(
+        CELLD_BIN!,
+        [
+          'deploy',
+          workerDirectory,
+          '--bucket',
+          `s3://${BUCKET}`,
+          '--endpoint',
+          minioUrl,
+          '--region',
+          'us-east-1',
+        ],
+        { env: storageClientEnv, maxBuffer: 4 * 1024 * 1024 },
+      );
+
+      callbackServer = http.createServer(async (request, response) => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) chunks.push(chunk as Buffer);
+        deliveries.push({
+          body: Buffer.concat(chunks).toString('utf8'),
+          headers: request.headers,
+          receivedAt: Date.now(),
+        });
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"ok":true}');
+      });
+      await new Promise<void>((resolve) => callbackServer!.listen(0, '127.0.0.1', resolve));
+      const callbackPort = (callbackServer.address() as AddressInfo).port;
+      callbackBaseUrl = `http://127.0.0.1:${callbackPort}`;
+
+      runtime = new NativeCelldRuntime(
+        CELLD_BIN!,
+        minioUrl,
+        celldPort,
+        celldInternalPort,
+        join(temporaryRoot, 'celld-state'),
+      );
+      await runtime.start();
+    } catch (error) {
+      await runtime?.stop();
+      await stopManaged(minio);
+      await rm(temporaryRoot, { recursive: true, force: true });
+      process.off('exit', emergencyStop);
+      throw error;
+    }
+  });
+
+  afterAll(async () => {
+    delete process.env.CELLD_QUEUE_MODE;
+    await runtime?.stop();
+    if (callbackServer) {
+      await new Promise<void>((resolve, reject) => {
+        callbackServer!.close((error) => (error ? reject(error) : resolve()));
+        callbackServer!.closeAllConnections();
+      });
+    }
+    await stopManaged(minio);
+    if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true });
+    process.off('exit', emergencyStop);
+  });
+
+  function world(options: {
+    deploymentId: string;
+    runRetentionMs?: number;
+    streamLongPollMs?: number;
+  }) {
+    return createCelldWorld({
+      fleetUrl: runtime!.url,
+      secret: SECRET,
+      baseUrl: callbackBaseUrl,
+      ...options,
+    });
+  }
+
+  it('recovers durable state and one accepted alarm delivery after a process restart', async () => {
+    const deploymentId = `restart-${randomUUID()}`;
+    const w = world({ deploymentId });
+    const workflowName = `restart-${randomUUID()}`;
+    const created = await w.events.create(null, {
+      eventType: 'run_created',
+      eventData: { deploymentId, workflowName, input: ['durable-before-restart'] },
+    });
+    firstRunId = created.run.runId;
+    const streamName = `restart-stream-${randomUUID()}`;
+    await w.writeToStream(streamName, firstRunId, 'durable-stream-chunk');
+
+    const marker = randomUUID();
+    const before = deliveries.length;
+    const { messageId } = await w.queue(
+      `__wkf_workflow_restart_${marker.slice(0, 8)}`,
+      { marker },
+      { delaySeconds: 2, idempotencyKey: `restart:${marker}` },
+    );
+    expect(deliveries.slice(before).filter((delivery) => delivery.body.includes(marker))).toEqual(
+      [],
+    );
+
+    // Keep celld down past the queue deadline. Delivery therefore requires the
+    // restarted runtime to restore the durable alarm and accepted message.
+    const restart = await runtime!.restart(2_500, true);
+    expect(restart.newPid).not.toBe(restart.oldPid);
+
+    const restored = await waitFor(
+      async () => {
+        const run = await w.runs.get(firstRunId);
+        return run.workflowName === workflowName ? run : null;
+      },
+      45_000,
+      'run state after celld restart',
+    );
+    expect(restored.status).toBe('pending');
+    const stream = await w.getStreamChunks(streamName, firstRunId, {});
+    expect(new TextDecoder().decode(stream.data[0].data)).toBe('durable-stream-chunk');
+
+    const delivered = await waitFor(
+      async () => deliveries.slice(before).find((delivery) => delivery.body.includes(marker)),
+      45_000,
+      'overdue queue alarm after celld restart',
+    );
+    expect(delivered.receivedAt).toBeGreaterThanOrEqual(restart.startedAt);
+    expect(delivered.headers['x-vqs-message-id']).toBe(messageId);
+    expect(delivered.headers['x-vqs-message-attempt']).toBe('1');
+    await delay(1_500);
+    expect(
+      deliveries.slice(before).filter((delivery) => delivery.body.includes(marker)),
+    ).toHaveLength(1);
+  });
+
+  it('keeps a stream usable after cancelling an in-flight HTTP long poll', async () => {
+    const w = world({
+      deploymentId: `long-poll-${randomUUID()}`,
+      streamLongPollMs: 20_000,
+    });
+    const streamName = `abort-stream-${randomUUID()}`;
+    const readable = await w.readFromStream(streamName, firstRunId);
+    const reader = readable.getReader();
+    let settled = false;
+    const pending = reader.read();
+    void pending.then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      () => {
+        settled = true;
+        return undefined;
+      },
+    );
+
+    await delay(300);
+    expect(settled).toBe(false);
+    await reader.cancel('integration reader disconnected');
+    await expect(pending).resolves.toMatchObject({ done: true });
+
+    await w.writeToStream(streamName, firstRunId, 'usable-after-abort');
+    await w.closeStream(streamName, firstRunId);
+    const chunks = await w.getStreamChunks(streamName, firstRunId, {});
+    expect(chunks.done).toBe(true);
+    expect(chunks.data).toHaveLength(1);
+    expect(new TextDecoder().decode(chunks.data[0].data)).toBe('usable-after-abort');
+  });
+
+  it('resumes multi-page retention cleanup from durable progress after SIGKILL', async () => {
+    const deploymentId = `retention-restart-${randomUUID()}`;
+    const w = world({ deploymentId, runRetentionMs: 3_600_000 });
+    const created = await w.events.create(null, {
+      eventType: 'run_created',
+      eventData: { deploymentId, workflowName: deploymentId, input: ['retention-payload'] },
+    });
+    const runId = created.run.runId;
+    const streamName = `retention-restart-stream-${randomUUID()}`;
+    const chunks = Array.from({ length: 4_097 }, (_, index) => Uint8Array.of(index % 251));
+    await w.writeChunksToStream(streamName, runId, chunks);
+    await w.closeStream(streamName, runId);
+    await w.queue(
+      `__wkf_workflow_retention_restart_${randomUUID().slice(0, 8)}`,
+      { runId },
+      { delaySeconds: 3_600, idempotencyKey: `retention-restart:${runId}` },
+    );
+    await w.events.create(runId, {
+      eventType: 'run_completed',
+      eventData: { output: ['done'] },
+    });
+
+    const interrupted = await w.retention.cleanupNow(runId);
+    expect(interrupted).not.toBeNull();
+    expect(interrupted?.phase).not.toBe('tombstoned');
+    expect(interrupted?.generation).toBeGreaterThan(0);
+
+    // The next action is an ungraceful process kill. The 4,097 chunks require
+    // 33 bounded stream-cleanup pages, so the returned nonterminal progress
+    // cannot be collapsed into the initiating RPC.
+    const restart = await runtime!.restart(250, true);
+    expect(restart.newPid).not.toBe(restart.oldPid);
+
+    const tombstone = await waitFor(
+      async () => {
+        const status = await w.retention.getStatus(runId);
+        return status?.phase === 'tombstoned' ? status : null;
+      },
+      60_000,
+      `retention cleanup after restart\n${runtime!.logs()}`,
+    );
+    expect(tombstone.generation).toBeGreaterThan(interrupted!.generation);
+    expect(tombstone.deletedStreams).toBe(1);
+    expect(tombstone.deletedQueueMessages).toBe(1);
+    expect(tombstone.deletedPayloadKeys).toBeGreaterThan(0);
+    await expect(w.runs.get(runId)).rejects.toSatisfy((error) => RunExpiredError.is(error));
+    await expect(w.getStreamInfo(streamName, runId)).rejects.toThrow(/expired/);
+  });
+});

--- a/test/integration/celld-smoke/run.sh
+++ b/test/integration/celld-smoke/run.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../../.." && pwd)
+download_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/world-celld-smoke-downloads"
+runtime_root=$(mktemp -d "${TMPDIR:-/tmp}/world-celld-smoke-runtime.XXXXXX")
+
+cleanup() {
+  rm -rf "$runtime_root"
+}
+trap cleanup EXIT INT TERM
+
+download_verified() {
+  local url=$1
+  local expected_sha256=$2
+  local destination=$3
+
+  if [[ -f "$destination" ]] &&
+    [[ $(shasum -a 256 "$destination" | awk '{print $1}') == "$expected_sha256" ]]; then
+    chmod 755 "$destination"
+    return
+  fi
+
+  local temporary
+  temporary=$(mktemp "$download_root/.download.XXXXXX")
+  curl --fail --location --silent --show-error --retry 3 --retry-delay 1 \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 \
+    --output "$temporary" "$url"
+
+  local actual_sha256
+  actual_sha256=$(shasum -a 256 "$temporary" | awk '{print $1}')
+  if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+    rm -f "$temporary"
+    echo "error: checksum mismatch for $url" >&2
+    echo "expected $expected_sha256, got $actual_sha256" >&2
+    exit 1
+  fi
+
+  chmod 755 "$temporary"
+  mv "$temporary" "$destination"
+}
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    celld_asset=celld-x86_64-unknown-linux-gnu.gz
+    celld_sha256=cbfcfa5f6d7551b5316f6f4c9d7751c741a9ba2a2305dde8d5cb4d1b37fb34a6
+    minio_platform=linux-amd64
+    minio_sha256=7c5bd8512c6e966455b1d198209358b2d191c77a83ab377c4073281065fb855f
+    mc_sha256=01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891
+    ;;
+  Darwin-arm64)
+    celld_asset=celld-aarch64-apple-darwin.gz
+    celld_sha256=fc19d9fd5ed429656476190ea23f5ebdbea18538b096fdfc4a913d2e0cf551d4
+    minio_platform=darwin-arm64
+    minio_sha256=7c3b3039b76e55a1b80935848ed83998d5e8d317374f87851f46a019ff5c0aa4
+    mc_sha256=a877fd0c183409da9f20f9d6e1811987298bbbca1aa03428eebdffba79fb9445
+    ;;
+  *)
+    echo "error: the real-celld smoke supports Linux x86-64 and macOS arm64" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$download_root"
+
+celld_archive="$download_root/$celld_asset"
+minio_binary="$download_root/minio-${minio_platform}-RELEASE.2025-09-07T16-13-09Z"
+mc_binary="$download_root/mc-${minio_platform}-RELEASE.2025-08-13T08-35-41Z"
+
+download_verified \
+  "https://github.com/denoland/celld/releases/download/v0.3.0/$celld_asset" \
+  "$celld_sha256" \
+  "$celld_archive"
+download_verified \
+  "https://dl.min.io/server/minio/release/$minio_platform/archive/minio.RELEASE.2025-09-07T16-13-09Z" \
+  "$minio_sha256" \
+  "$minio_binary"
+download_verified \
+  "https://dl.min.io/client/mc/release/$minio_platform/archive/mc.RELEASE.2025-08-13T08-35-41Z" \
+  "$mc_sha256" \
+  "$mc_binary"
+
+celld_binary="$runtime_root/celld"
+gzip -dc "$celld_archive" > "$celld_binary"
+chmod 755 "$celld_binary"
+
+cd "$repo_root"
+pnpm build
+
+CELLD_SMOKE_CELLD_BIN="$celld_binary" \
+CELLD_SMOKE_MINIO_BIN="$minio_binary" \
+CELLD_SMOKE_MC_BIN="$mc_binary" \
+CELLD_SMOKE_TEMP_ROOT="$runtime_root/harness" \
+  pnpm vitest run --config vitest.celld-smoke.config.ts

--- a/vitest.celld-smoke.config.ts
+++ b/vitest.celld-smoke.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['test/integration/celld-smoke.test.ts'],
+    hookTimeout: 90_000,
+    testTimeout: 90_000,
+  },
+});


### PR DESCRIPTION
## Summary

- add a required, bounded CI smoke around native celld v0.3.0 rather than the Map-backed `FakeFleet`
- download celld, MinIO, and `mc` at pinned versions over HTTPS and verify hard-coded SHA-256 digests before execution
- bundle the production Worker, deploy it into a fresh loopback-only bucket, and run celld with bucket durability and fresh temporary state
- force two whole-process `SIGKILL` restarts, delete celld's local working state, and restore from the bucket

## What the smoke proves

1. An acknowledged workflow run and stream chunk remain readable from a new celld PID after `SIGKILL` and deletion of `CELLD_WATCH` state.
2. An accepted delayed queue message becomes due during a 2.5-second runtime outage, then the restored alarm delivers that message once after the new process is ready. The test checks the original message ID, attempt 1, and one matching callback during the bounded post-success observation.
3. Retention records a nonterminal durable generation for a stream requiring 33 cleanup pages, celld is killed immediately, local state is deleted, and the replacement process advances beyond that generation to a tombstone with the stream, delayed queue message, and payload keys removed.
4. A real HTTP stream long poll is still pending before client cancellation; after the abort completes, the same stream accepts a write, closes, and reads back the exact chunk.

The job uses ephemeral loopback ports, one runner-owned temporary root, bounded readiness and shutdown waits, an emergency process-exit kill guard, a 15-minute Actions timeout, read-only repository permission, and no secrets.

## Honest residual gap

celld v0.3.0 supports S3, GCS, and Azure storage, but the repository has no hermetic production-compatible object store. This smoke therefore uses the repository's pinned MinIO version with `CELLD_STORAGE_PROBE=0`. MinIO does not implement the conditional writes celld requires for ownership fencing.

The job runs exactly one celld process at a time. It proves bucket-backed single-process crash/restart recovery for the boundaries above; it does **not** prove multi-node ownership fencing, overlapping owners, handoff, or failover correctness. The one-delivery assertion is for the forced pre-delivery restart boundary and does not change the queue's documented at-least-once contract. No MinIO throughput or latency value is used as a correctness gate.

## Validation

- `pnpm test:integration:celld-smoke` — 3 tests passed against native celld v0.3.0, including two new PIDs and bucket-only restoration
- `pnpm check` — formatting, lint, typecheck, build, 325 tests, worker bundle, and package check passed
- `pnpm test:integration` with fleet/smoke variables unset — 1 passed, 13 skipped as intended
- `bash -n test/integration/celld-smoke/run.sh`
