### PR TITLE
test: harden StreamDO corruption handling

### DIFF
--- a/src/stream-protocol.ts
+++ b/src/stream-protocol.ts
@@ -99,8 +99,12 @@ export function validateStreamWriteChunks(chunks: readonly Uint8Array[]): number
 
 export function validateStreamReadRequest(request: StreamReadRequest): void {
   if (!request.runId) throw protocolError('runId is required');
-  if (!Number.isSafeInteger(request.startIndex) || request.startIndex < 0) {
-    throw protocolError('startIndex must be a non-negative safe integer');
+  if (
+    !Number.isSafeInteger(request.startIndex) ||
+    request.startIndex < 0 ||
+    request.startIndex > 0x7fffffff
+  ) {
+    throw protocolError('startIndex must be between 0 and 2147483647');
   }
   if (
     !Number.isSafeInteger(request.maxChunks) ||

--- a/src/testing/fake-cell.ts
+++ b/src/testing/fake-cell.ts
@@ -20,6 +20,12 @@ export interface FakeStorageMutation {
   value?: unknown;
 }
 
+export interface FakeStorageRead {
+  operation: 'get' | 'list';
+  keys?: string[];
+  options?: FakeListOptions;
+}
+
 export interface FakeStorageOperationCounts {
   get: number;
   getMany: number;
@@ -99,6 +105,10 @@ export class FakeStorage {
     predicate: (mutation: FakeStorageMutation) => boolean;
     error: Error;
   };
+  private readFailure?: {
+    predicate: (read: FakeStorageRead) => boolean;
+    error: Error;
+  };
 
   constructor(private clock: () => number = () => Date.now()) {}
 
@@ -109,12 +119,14 @@ export class FakeStorage {
       this.operationCounts.getMany += 1;
       this.getManyCalls.push([...keyOrKeys]);
       this.recordStorageCall('get', keyOrKeys, false);
+      this.maybeFailRead({ operation: 'get', keys: keyOrKeys });
       return new Map(
         keyOrKeys.filter((key) => this.data.has(key)).map((key) => [key, this.data.get(key) as T]),
       );
     }
     this.operationCounts.get += 1;
     this.recordStorageCall('get', [keyOrKeys], false);
+    this.maybeFailRead({ operation: 'get', keys: [keyOrKeys] });
     return this.data.get(keyOrKeys) as T | undefined;
   }
 
@@ -161,6 +173,7 @@ export class FakeStorage {
 
   async list<T>(options: FakeListOptions = {}): Promise<Map<string, T>> {
     this.operationCounts.list += 1;
+    this.maybeFailRead({ operation: 'list', options });
     const keys = applyListOptions(Array.from(this.data.keys()), options);
     this.recordList(options, keys.length, false);
     return new Map(keys.map((k) => [k, this.data.get(k) as T]));
@@ -239,11 +252,27 @@ export class FakeStorage {
     this.mutationFailure = { predicate, error };
   }
 
+  /** Inject one matching storage read failure, including reads inside transactions. */
+  failNextRead(
+    predicate: (read: FakeStorageRead) => boolean,
+    error = new Error('injected fake storage read failure'),
+  ): void {
+    this.readFailure = { predicate, error };
+  }
+
   /** @internal Shared with FakeTransaction so failure injection survives a transaction fix. */
   maybeFailMutation(mutation: FakeStorageMutation): void {
     if (!this.mutationFailure?.predicate(mutation)) return;
     const { error } = this.mutationFailure;
     this.mutationFailure = undefined;
+    throw error;
+  }
+
+  /** @internal Shared with FakeTransaction so read failures model transactional reads too. */
+  maybeFailRead(read: FakeStorageRead): void {
+    if (!this.readFailure?.predicate(read)) return;
+    const { error } = this.readFailure;
+    this.readFailure = undefined;
     throw error;
   }
 
@@ -267,6 +296,7 @@ class FakeTransaction {
       this.storage.recordOperation('getMany');
       this.storage.getManyCalls.push([...keyOrKeys]);
       this.storage.recordStorageCall('get', keyOrKeys, true);
+      this.storage.maybeFailRead({ operation: 'get', keys: keyOrKeys });
       const result = new Map<string, T>();
       for (const key of keyOrKeys) {
         if (this.deleted.has(key)) continue;
@@ -278,6 +308,7 @@ class FakeTransaction {
     this.storage.recordOperation('get');
     const key = keyOrKeys;
     this.storage.recordStorageCall('get', [key], true);
+    this.storage.maybeFailRead({ operation: 'get', keys: [key] });
     if (this.deleted.has(key)) return undefined;
     if (this.staged.has(key)) return this.staged.get(key) as T;
     return this.storage.data.get(key) as T | undefined;
@@ -330,6 +361,7 @@ class FakeTransaction {
 
   async list<T>(options: FakeListOptions = {}): Promise<Map<string, T>> {
     this.storage.recordOperation('list');
+    this.storage.maybeFailRead({ operation: 'list', options });
     const merged = new Map(this.storage.data);
     for (const key of this.deleted) merged.delete(key);
     for (const [key, value] of this.staged) merged.set(key, value);

--- a/src/worker/durable-objects/StreamDO.ts
+++ b/src/worker/durable-objects/StreamDO.ts
@@ -52,6 +52,7 @@ const MAX_EXPIRE_CHUNK_LIMIT = 64;
 /** Bound storage deletion work as well as item count; one oversized chunk still makes progress. */
 const DEFAULT_EXPIRE_BYTE_LIMIT = 16 * 1024 * 1024;
 const MAX_EXPIRE_BYTE_LIMIT = DEFAULT_EXPIRE_BYTE_LIMIT;
+const MAX_STREAM_INDEX = 0x7fffffff;
 
 function boundedLimit(value: number | undefined, fallback: number, maximum: number): number {
   if (value === undefined || !Number.isFinite(value)) return fallback;
@@ -62,19 +63,30 @@ function emptyMeta(): StreamMeta {
   return { count: 0, state: 'open' };
 }
 
-function validateMeta(meta: StreamMeta): StreamMeta {
+function validateMeta(meta: unknown): StreamMeta {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    throw new Error('Invalid persisted stream metadata');
+  }
+  const candidate = meta as Partial<StreamMeta>;
   if (
-    !Number.isSafeInteger(meta.count) ||
-    meta.count < 0 ||
-    meta.count > 0x7fffffff ||
-    !['open', 'closed', 'errored', 'expired'].includes(meta.state)
+    !Number.isSafeInteger(candidate.count) ||
+    candidate.count! < 0 ||
+    candidate.count! > MAX_STREAM_INDEX ||
+    !['open', 'closed', 'errored', 'expired'].includes(candidate.state as StreamTerminalState) ||
+    (candidate.ownerRunId !== undefined && typeof candidate.ownerRunId !== 'string')
   ) {
     throw new Error('Invalid persisted stream metadata');
   }
-  if (meta.state === 'errored' && !meta.error) {
+  if (
+    candidate.state === 'errored' &&
+    (!candidate.error ||
+      typeof candidate.error !== 'object' ||
+      typeof candidate.error.name !== 'string' ||
+      typeof candidate.error.message !== 'string')
+  ) {
     throw new Error('Invalid persisted stream error metadata');
   }
-  return meta;
+  return candidate as StreamMeta;
 }
 
 /** Zero-padding keeps storage.list() results in stream offset order. */
@@ -89,8 +101,27 @@ function chunkSizeKey(index: number): string {
 function indexFromChunkSizeKey(key: string): number {
   const suffix = key.slice(CHUNK_SIZE_KEY_PREFIX.length);
   const index = Number(suffix);
-  if (!/^\d{12}$/.test(suffix) || !Number.isSafeInteger(index) || index < 0) {
+  if (
+    !/^\d{12}$/.test(suffix) ||
+    !Number.isSafeInteger(index) ||
+    index < 0 ||
+    index > MAX_STREAM_INDEX
+  ) {
     throw new Error(`Invalid persisted stream chunk size key "${key}"`);
+  }
+  return index;
+}
+
+function indexFromChunkKey(key: string): number {
+  const suffix = key.slice(CHUNK_KEY_PREFIX.length);
+  const index = Number(suffix);
+  if (
+    !/^\d{12}$/.test(suffix) ||
+    !Number.isSafeInteger(index) ||
+    index < 0 ||
+    index > MAX_STREAM_INDEX
+  ) {
+    throw new Error(`Invalid persisted stream chunk key "${key}"`);
   }
   return index;
 }
@@ -134,7 +165,7 @@ export class StreamDO extends DurableObject {
   private async getMeta(): Promise<StreamMeta> {
     if (this.meta) return this.meta;
     this.metaLoad ??= this.ctx.storage.get<StreamMeta>(META_KEY).then((meta) => {
-      const loaded = meta ? validateMeta(meta) : emptyMeta();
+      const loaded = meta === undefined ? emptyMeta() : validateMeta(meta);
       this.meta = loaded;
       return loaded;
     });
@@ -274,10 +305,10 @@ export class StreamDO extends DurableObject {
     return await this.runMutation(async () => {
       const committed = await this.ctx.storage.transaction(async (txn) => {
         const stored = await txn.get<StreamMeta>(META_KEY);
-        const meta = stored ? validateMeta(stored) : emptyMeta();
+        const meta = stored === undefined ? emptyMeta() : validateMeta(stored);
         this.assertWritable(meta, runId);
         const startIndex = meta.count;
-        if (startIndex + chunks.length > 0x7fffffff) {
+        if (startIndex + chunks.length > MAX_STREAM_INDEX) {
           throw new Error('Stream offset limit exceeded');
         }
         const nextMeta: StreamMeta = {
@@ -334,7 +365,7 @@ export class StreamDO extends DurableObject {
     await this.runMutation(async () => {
       const nextMeta = await this.ctx.storage.transaction(async (txn) => {
         const stored = await txn.get<StreamMeta>(META_KEY);
-        const meta = stored ? validateMeta(stored) : emptyMeta();
+        const meta = stored === undefined ? emptyMeta() : validateMeta(stored);
         this.assertOwner(meta, runId);
         if (meta.state === 'expired') throw new Error(`Workflow run "${runId}" has expired`);
         if (meta.state !== 'open') return meta;
@@ -354,7 +385,7 @@ export class StreamDO extends DurableObject {
     await this.runMutation(async () => {
       const nextMeta = await this.ctx.storage.transaction(async (txn) => {
         const stored = await txn.get<StreamMeta>(META_KEY);
-        const meta = stored ? validateMeta(stored) : emptyMeta();
+        const meta = stored === undefined ? emptyMeta() : validateMeta(stored);
         this.assertOwner(meta, runId);
         if (meta.state === 'expired') throw new Error(`Workflow run "${runId}" has expired`);
         if (meta.state !== 'open') return meta;
@@ -463,7 +494,7 @@ export class StreamDO extends DurableObject {
     return await this.runMutation(async () => {
       const result = await this.ctx.storage.transaction(async (txn) => {
         const stored = await txn.get<StreamMeta>(META_KEY);
-        const meta = stored ? validateMeta(stored) : emptyMeta();
+        const meta = stored === undefined ? emptyMeta() : validateMeta(stored);
         this.assertOwner(meta, runId);
         const firstFence = meta.state !== 'expired';
         if (meta.state === 'expired' && meta.payloadDeleted) {
@@ -486,9 +517,35 @@ export class StreamDO extends DurableObject {
           page.push({ index, size });
           bytes += size;
         }
+
+        let payloadFallback = false;
+        if (candidates.size === 0) {
+          const payloads = await txn.list({ prefix: CHUNK_KEY_PREFIX, limit: 1 });
+          const first = payloads.entries().next().value;
+          if (first) {
+            const [key, payload] = first;
+            page.push({
+              index: indexFromChunkKey(key),
+              size: payload instanceof Uint8Array ? payload.byteLength : 0,
+            });
+            bytes = page[0].size;
+            payloadFallback = true;
+          }
+        }
+
         const keys = page.flatMap(({ index }) => [chunkKey(index), chunkSizeKey(index)]);
         if (keys.length > 0) await txn.delete(keys);
-        const done = candidates.size === page.length;
+        let done = candidates.size === page.length;
+        if (payloadFallback) {
+          const remaining = await txn.list({ prefix: CHUNK_KEY_PREFIX, limit: 1 });
+          done = remaining.size === 0;
+        } else if (done && candidates.size > 0) {
+          // A corrupt/missing size index can otherwise make cleanup report
+          // completion while leaving an orphan payload. Verify once after the
+          // final staged size-index page; healthy pages return an empty list.
+          const remaining = await txn.list({ prefix: CHUNK_KEY_PREFIX, limit: 1 });
+          done = remaining.size === 0;
+        }
         const nextMeta: StreamMeta = {
           ...meta,
           count: done ? 0 : meta.count,

--- a/src/worker/durable-objects/StreamDO.ts
+++ b/src/worker/durable-objects/StreamDO.ts
@@ -73,16 +73,19 @@ function validateMeta(meta: unknown): StreamMeta {
     candidate.count! < 0 ||
     candidate.count! > MAX_STREAM_INDEX ||
     !['open', 'closed', 'errored', 'expired'].includes(candidate.state as StreamTerminalState) ||
-    (candidate.ownerRunId !== undefined && typeof candidate.ownerRunId !== 'string')
+    (candidate.ownerRunId !== undefined && typeof candidate.ownerRunId !== 'string') ||
+    (candidate.payloadDeleted !== undefined && typeof candidate.payloadDeleted !== 'boolean')
   ) {
     throw new Error('Invalid persisted stream metadata');
   }
+  const error = candidate.error;
   if (
-    candidate.state === 'errored' &&
-    (!candidate.error ||
-      typeof candidate.error !== 'object' ||
-      typeof candidate.error.name !== 'string' ||
-      typeof candidate.error.message !== 'string')
+    (error !== undefined &&
+      (!error ||
+        typeof error !== 'object' ||
+        typeof error.name !== 'string' ||
+        typeof error.message !== 'string')) ||
+    (candidate.state === 'errored') !== (error !== undefined)
   ) {
     throw new Error('Invalid persisted stream error metadata');
   }
@@ -497,12 +500,6 @@ export class StreamDO extends DurableObject {
         const meta = stored === undefined ? emptyMeta() : validateMeta(stored);
         this.assertOwner(meta, runId);
         const firstFence = meta.state !== 'expired';
-        if (meta.state === 'expired' && meta.payloadDeleted) {
-          return {
-            meta,
-            result: { deleted: false, chunks: 0, bytes: 0, done: true },
-          };
-        }
 
         const candidates = await txn.list<number>({
           prefix: CHUNK_SIZE_KEY_PREFIX,
@@ -545,6 +542,12 @@ export class StreamDO extends DurableObject {
           // final staged size-index page; healthy pages return an empty list.
           const remaining = await txn.list({ prefix: CHUNK_KEY_PREFIX, limit: 1 });
           done = remaining.size === 0;
+        }
+        if (done && page.length === 0 && meta.state === 'expired' && meta.payloadDeleted) {
+          return {
+            meta,
+            result: { deleted: false, chunks: 0, bytes: 0, done: true },
+          };
         }
         const nextMeta: StreamMeta = {
           ...meta,

--- a/test/stream-do-cleanup.test.ts
+++ b/test/stream-do-cleanup.test.ts
@@ -75,16 +75,23 @@ describe('StreamDO paged KV cleanup', () => {
       chunks: [],
     });
 
-    expect(storage.listCalls).toHaveLength(5);
+    expect(storage.listCalls).toHaveLength(6);
     expect(
-      storage.listCalls.every(
-        (call) =>
-          call.transactional &&
-          call.options.prefix === 'chunk-size:' &&
-          call.options.limit === 65 &&
-          call.resultSize <= 65,
-      ),
+      storage.listCalls
+        .slice(0, 5)
+        .every(
+          (call) =>
+            call.transactional &&
+            call.options.prefix === 'chunk-size:' &&
+            call.options.limit === 65 &&
+            call.resultSize <= 65,
+        ),
     ).toBe(true);
+    expect(storage.listCalls[5]).toEqual({
+      options: { prefix: 'chunk:', limit: 1 },
+      resultSize: 0,
+      transactional: true,
+    });
     expect(storage.operationCounts.deleteMany).toBe(5);
   });
 

--- a/test/stream-do-failures.test.ts
+++ b/test/stream-do-failures.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_STREAM_CHUNK_BYTES,
+  MAX_STREAM_READ_BYTES,
+  type StreamReadRequest,
+} from '../src/stream-protocol.js';
+import { FakeFleet, type FakeStorage } from '../src/testing/fake-cell.js';
+import { StreamDO } from '../src/worker/durable-objects/StreamDO.js';
+
+const RUN_ID = 'wrun_stream_owner';
+const OTHER_RUN_ID = 'wrun_stream_other';
+const META_KEY = 'meta';
+const CHUNK_KEY = 'chunk:000000000000';
+const CHUNK_SIZE_KEY = 'chunk-size:000000000000';
+
+function setup(name = 'stream:failure') {
+  const fleet = new FakeFleet({ streams: StreamDO as never });
+  const get = () => fleet.namespace('streams').get({ toString: () => name }) as StreamDO;
+  const storage = fleet.cell('streams', name).storage;
+  return { fleet, get, name, storage };
+}
+
+function readRequest(overrides: Partial<StreamReadRequest> = {}): StreamReadRequest {
+  return {
+    runId: RUN_ID,
+    startIndex: 0,
+    maxChunks: 32,
+    maxBytes: MAX_STREAM_READ_BYTES,
+    waitMs: 0,
+    ...overrides,
+  };
+}
+
+function snapshot(storage: FakeStorage): Map<string, unknown> {
+  return structuredClone(storage.data);
+}
+
+describe('StreamDO persisted-state failure handling', () => {
+  it('treats absent metadata as a never-written stream without persisting partial state', async () => {
+    const { get, storage } = setup();
+
+    await expect(get().readChunks(readRequest())).resolves.toMatchObject({
+      chunks: [],
+      state: 'open',
+      tailIndex: -1,
+    });
+    expect(storage.data).toEqual(new Map());
+  });
+
+  it('rejects malformed metadata deterministically without poisoning the instance cache', async () => {
+    const invalidMetadata: Array<[string, unknown]> = [
+      ['stored null', null],
+      ['stored false', false],
+      ['stored zero', 0],
+      ['stored empty string', ''],
+      ['non-object', 'invalid'],
+      ['missing count', { state: 'open' }],
+      ['missing state', { count: 0 }],
+      ['negative count', { count: -1, state: 'open' }],
+      ['fractional count', { count: 0.5, state: 'open' }],
+      ['overflowed count', { count: 0x80000000, state: 'open' }],
+      ['invalid state', { count: 0, state: 'unknown' }],
+      ['invalid owner', { count: 0, state: 'open', ownerRunId: 42 }],
+    ];
+
+    for (const [label, invalid] of invalidMetadata) {
+      const { get, storage } = setup(`stream:invalid-meta:${label}`);
+      storage.data.set(META_KEY, invalid);
+
+      await expect(get().readChunks(readRequest())).rejects.toThrow(
+        'Invalid persisted stream metadata',
+      );
+
+      storage.data.set(META_KEY, { count: 0, state: 'open', ownerRunId: RUN_ID });
+      await expect(get().readChunks(readRequest())).resolves.toMatchObject({
+        chunks: [],
+        state: 'open',
+        tailIndex: -1,
+      });
+    }
+  });
+
+  it('rejects errored metadata with a missing or malformed error payload', async () => {
+    const invalidErrors: Array<[string, unknown]> = [
+      ['missing error', undefined],
+      ['empty error', {}],
+      ['non-string error name', { name: 42, message: 'failure' }],
+      ['non-string error message', { name: 'Error', message: null }],
+    ];
+
+    for (const [label, error] of invalidErrors) {
+      const { get, storage } = setup(`stream:invalid-error:${label}`);
+      storage.data.set(META_KEY, {
+        count: 0,
+        state: 'errored',
+        ownerRunId: RUN_ID,
+        ...(error === undefined ? {} : { error }),
+      });
+
+      await expect(get().readChunks(readRequest())).rejects.toThrow(
+        'Invalid persisted stream error metadata',
+      );
+    }
+  });
+
+  it('never treats stored falsy metadata as absent on mutating paths', async () => {
+    const operations: Array<[string, (stream: StreamDO) => Promise<unknown>]> = [
+      ['write', (stream) => stream.writeChunks(RUN_ID, [Uint8Array.of(1)])],
+      ['close', (stream) => stream.closeStream(RUN_ID)],
+      ['fail', (stream) => stream.failStream(RUN_ID, 'failure')],
+      ['expire', (stream) => stream.expireStream(RUN_ID, 123)],
+    ];
+
+    for (const [label, operation] of operations) {
+      const { get, storage } = setup(`stream:falsy-meta:${label}`);
+      storage.data.set(META_KEY, null);
+      const before = snapshot(storage);
+
+      await expect(operation(get())).rejects.toThrow('Invalid persisted stream metadata');
+      expect(storage.data).toEqual(before);
+    }
+  });
+
+  it('rejects missing and invalid chunk sizes, then retries after repair', async () => {
+    const invalidSizes: Array<[string, unknown]> = [
+      ['missing', undefined],
+      ['non-number', '3'],
+      ['negative', -1],
+      ['fractional', 1.5],
+      ['oversized', MAX_STREAM_CHUNK_BYTES + 1],
+    ];
+
+    for (const [label, invalid] of invalidSizes) {
+      const { get, storage } = setup(`stream:invalid-size:${label}`);
+      const chunk = Uint8Array.of(1, 2, 3);
+      await get().writeChunks(RUN_ID, [chunk]);
+      if (invalid === undefined) storage.data.delete(CHUNK_SIZE_KEY);
+      else storage.data.set(CHUNK_SIZE_KEY, invalid);
+
+      await expect(get().readChunks(readRequest())).rejects.toThrow(
+        'Invalid persisted stream chunk size at index 0',
+      );
+
+      storage.data.set(CHUNK_SIZE_KEY, chunk.byteLength);
+      await expect(get().readChunks(readRequest())).resolves.toMatchObject({
+        chunks: [chunk],
+        tailIndex: 0,
+      });
+    }
+  });
+
+  it('rejects missing, non-binary, and length-mismatched chunk payloads, then retries', async () => {
+    const invalidPayloads: Array<[string, unknown]> = [
+      ['missing', undefined],
+      ['non-Uint8Array', 'abc'],
+      ['length mismatch', Uint8Array.of(1, 2)],
+    ];
+
+    for (const [label, invalid] of invalidPayloads) {
+      const { get, storage } = setup(`stream:invalid-payload:${label}`);
+      const chunk = Uint8Array.of(1, 2, 3);
+      await get().writeChunks(RUN_ID, [chunk]);
+      if (invalid === undefined) storage.data.delete(CHUNK_KEY);
+      else storage.data.set(CHUNK_KEY, invalid);
+
+      await expect(get().readChunks(readRequest())).rejects.toThrow(
+        'Invalid persisted stream chunk at index 0',
+      );
+
+      storage.data.set(CHUNK_KEY, chunk);
+      await expect(get().readChunks(readRequest())).resolves.toMatchObject({
+        chunks: [chunk],
+        tailIndex: 0,
+      });
+    }
+  });
+
+  it('rolls back expiry when chunk-size keys are malformed or outside the offset range', async () => {
+    const malformedKeys = [
+      'chunk-size:00000000000x',
+      'chunk-size:0000000000000',
+      'chunk-size:002147483648',
+    ];
+
+    for (const malformedKey of malformedKeys) {
+      const { get, storage } = setup(`stream:malformed-key:${malformedKey}`);
+      await get().writeChunks(RUN_ID, [Uint8Array.of(1)]);
+      storage.data.set(malformedKey, 1);
+      const before = snapshot(storage);
+
+      await expect(get().expireStream(RUN_ID, 123)).rejects.toThrow(
+        `Invalid persisted stream chunk size key "${malformedKey}"`,
+      );
+      expect(storage.data).toEqual(before);
+
+      storage.data.delete(malformedKey);
+      await expect(get().expireStream(RUN_ID, 123)).resolves.toMatchObject({ done: true });
+      expect(Array.from(storage.data.keys())).toEqual([META_KEY]);
+    }
+  });
+
+  it('rolls back expiry on an invalid stored size and succeeds after repair', async () => {
+    const { get, storage } = setup();
+    await get().writeChunks(RUN_ID, [Uint8Array.of(1)]);
+    storage.data.set(CHUNK_SIZE_KEY, '1');
+    const before = snapshot(storage);
+
+    await expect(get().expireStream(RUN_ID, 123)).rejects.toThrow(
+      'Invalid persisted stream chunk size at index 0',
+    );
+    expect(storage.data).toEqual(before);
+
+    storage.data.set(CHUNK_SIZE_KEY, 1);
+    await expect(get().expireStream(RUN_ID, 123)).resolves.toMatchObject({ done: true });
+    expect(Array.from(storage.data.keys())).toEqual([META_KEY]);
+  });
+
+  it('cleans orphan payloads despite missing and inconsistent size keys', async () => {
+    const { get, storage } = setup();
+    await get().writeChunks(RUN_ID, [Uint8Array.of(1), Uint8Array.of(2, 3)]);
+    storage.data.delete(CHUNK_SIZE_KEY);
+    // Keep the size-key count equal to meta.count so cleanup must compare
+    // actual remaining payload keys rather than trusting matching counts.
+    storage.data.set('chunk-size:000000000002', 1);
+
+    await expect(get().expireStream(RUN_ID, 123)).resolves.toEqual({
+      deleted: true,
+      chunks: 2,
+      bytes: 3,
+      done: false,
+    });
+    expect(storage.data.has(CHUNK_KEY)).toBe(true);
+
+    await expect(get().expireStream(RUN_ID, 123)).resolves.toEqual({
+      deleted: false,
+      chunks: 1,
+      bytes: 1,
+      done: true,
+    });
+    expect(Array.from(storage.data.keys())).toEqual([META_KEY]);
+    expect(storage.data.get(META_KEY)).toMatchObject({
+      count: 0,
+      state: 'expired',
+      payloadDeleted: true,
+    });
+  });
+
+  it('rejects owner mismatches on every stream path without mutation', async () => {
+    const { get, storage } = setup();
+    await get().writeChunks(RUN_ID, [Uint8Array.of(1)]);
+    const before = snapshot(storage);
+    const operations: Array<() => Promise<unknown>> = [
+      () => get().readChunks(readRequest({ runId: OTHER_RUN_ID })),
+      () => get().writeChunks(OTHER_RUN_ID, [Uint8Array.of(2)]),
+      () => get().closeStream(OTHER_RUN_ID),
+      () => get().failStream(OTHER_RUN_ID, 'failure'),
+      () => get().expireStream(OTHER_RUN_ID, 123),
+    ];
+
+    for (const operation of operations) {
+      await expect(operation()).rejects.toThrow(`Stream is owned by workflow run "${RUN_ID}"`);
+      expect(storage.data).toEqual(before);
+    }
+  });
+
+  it('rejects registry owner mismatches across registration and expiry without mutation', async () => {
+    const { get, storage } = setup('run-streams:wrun_stream_owner');
+    await get().registerStream(RUN_ID, 'stream-a');
+    const registered = snapshot(storage);
+
+    await expect(get().registerStream(OTHER_RUN_ID, 'stream-b')).rejects.toThrow(
+      `Stream registry is owned by workflow run "${RUN_ID}"`,
+    );
+    await expect(get().expireRegistry(OTHER_RUN_ID, 123)).rejects.toThrow(
+      `Stream registry is owned by workflow run "${RUN_ID}"`,
+    );
+    expect(storage.data).toEqual(registered);
+
+    const { streams } = await get().expireRegistry(RUN_ID, 123);
+    const expired = snapshot(storage);
+    await expect(get().finalizeRegistry(OTHER_RUN_ID, streams)).rejects.toThrow(
+      `Stream registry for workflow run "${OTHER_RUN_ID}" is not expired`,
+    );
+    expect(storage.data).toEqual(expired);
+  });
+
+  it('rejects persisted offset overflow and out-of-wire-range read offsets without mutation', async () => {
+    const { get, storage } = setup();
+    storage.data.set(META_KEY, {
+      count: 0x7fffffff,
+      state: 'open',
+      ownerRunId: RUN_ID,
+    });
+    const before = snapshot(storage);
+
+    await expect(get().writeChunks(RUN_ID, [Uint8Array.of(1)])).rejects.toThrow(
+      'Stream offset limit exceeded',
+    );
+    await expect(get().readChunks(readRequest({ startIndex: 0x80000000 }))).rejects.toThrow(
+      'startIndex must be between 0 and 2147483647',
+    );
+    expect(storage.data).toEqual(before);
+  });
+
+  it('retries shared metadata loads after storage failure in the same instance and after restart', async () => {
+    const { fleet, get, name, storage } = setup();
+    storage.data.set(META_KEY, { count: 0, state: 'closed', ownerRunId: RUN_ID });
+    storage.failNextRead(
+      (read) => read.operation === 'get' && read.keys?.length === 1 && read.keys[0] === META_KEY,
+      new Error('injected meta read failure'),
+    );
+
+    const concurrent = await Promise.allSettled([
+      get().readChunks(readRequest()),
+      get().readChunks(readRequest()),
+    ]);
+    expect(concurrent).toHaveLength(2);
+    for (const result of concurrent) {
+      expect(result).toMatchObject({
+        status: 'rejected',
+        reason: expect.objectContaining({ message: 'injected meta read failure' }),
+      });
+    }
+    await expect(get().readChunks(readRequest())).resolves.toMatchObject({ state: 'closed' });
+
+    storage.failNextRead(
+      (read) => read.operation === 'get' && read.keys?.[0] === META_KEY,
+      new Error('injected restarted meta read failure'),
+    );
+    fleet.restartCell('streams', name);
+    await expect(get().readChunks(readRequest())).rejects.toThrow(
+      'injected restarted meta read failure',
+    );
+    fleet.restartCell('streams', name);
+    await expect(get().readChunks(readRequest())).resolves.toMatchObject({ state: 'closed' });
+  });
+
+  it('retries chunk index and payload reads without cache poisoning or mutation', async () => {
+    const { get, storage } = setup();
+    const chunk = Uint8Array.of(1, 2, 3);
+    await get().writeChunks(RUN_ID, [chunk]);
+    const before = snapshot(storage);
+
+    storage.failNextRead(
+      (read) => read.operation === 'get' && read.keys?.[0]?.startsWith('chunk-size:') === true,
+      new Error('injected chunk-size read failure'),
+    );
+    await expect(get().readChunks(readRequest())).rejects.toThrow(
+      'injected chunk-size read failure',
+    );
+    await expect(get().readChunks(readRequest())).resolves.toMatchObject({ chunks: [chunk] });
+
+    storage.failNextRead((read) => {
+      const key = read.keys?.[0];
+      return (
+        read.operation === 'get' &&
+        key?.startsWith('chunk:') === true &&
+        !key.startsWith('chunk-size:')
+      );
+    }, new Error('injected chunk payload read failure'));
+    await expect(get().readChunks(readRequest())).rejects.toThrow(
+      'injected chunk payload read failure',
+    );
+    await expect(get().readChunks(readRequest())).resolves.toMatchObject({ chunks: [chunk] });
+    expect(storage.data).toEqual(before);
+  });
+
+  it('rolls back failed transactional reads and writes, then retries at offset zero', async () => {
+    const readFailure = setup('stream:transaction-read-failure');
+    readFailure.storage.failNextRead(
+      (read) => read.operation === 'get' && read.keys?.[0] === META_KEY,
+      new Error('injected transaction read failure'),
+    );
+
+    await expect(readFailure.get().writeChunks(RUN_ID, [Uint8Array.of(1)])).rejects.toThrow(
+      'injected transaction read failure',
+    );
+    expect(readFailure.storage.data).toEqual(new Map());
+    await expect(readFailure.get().writeChunks(RUN_ID, [Uint8Array.of(1)])).resolves.toMatchObject({
+      startIndex: 0,
+      tailIndex: 0,
+    });
+
+    const writeFailure = setup('stream:transaction-write-failure');
+    writeFailure.storage.failNextMutation(
+      (mutation) => mutation.operation === 'put' && mutation.key === CHUNK_SIZE_KEY,
+      new Error('injected transaction write failure'),
+    );
+
+    await expect(writeFailure.get().writeChunks(RUN_ID, [Uint8Array.of(1)])).rejects.toThrow(
+      'injected transaction write failure',
+    );
+    expect(writeFailure.storage.data).toEqual(new Map());
+    await expect(writeFailure.get().writeChunks(RUN_ID, [Uint8Array.of(1)])).resolves.toMatchObject(
+      { startIndex: 0, tailIndex: 0 },
+    );
+  });
+
+  it('rolls back an expiry list failure and remains cleanly retryable', async () => {
+    const { get, storage } = setup();
+    await get().writeChunks(RUN_ID, [Uint8Array.of(1)]);
+    const before = snapshot(storage);
+    storage.failNextRead(
+      (read) => read.operation === 'list' && read.options?.prefix === 'chunk-size:',
+      new Error('injected expiry list failure'),
+    );
+
+    await expect(get().expireStream(RUN_ID, 123)).rejects.toThrow('injected expiry list failure');
+    expect(storage.data).toEqual(before);
+    await expect(get().expireStream(RUN_ID, 123)).resolves.toMatchObject({ done: true });
+    expect(Array.from(storage.data.keys())).toEqual([META_KEY]);
+  });
+});

--- a/test/stream-do-failures.test.ts
+++ b/test/stream-do-failures.test.ts
@@ -61,6 +61,7 @@ describe('StreamDO persisted-state failure handling', () => {
       ['overflowed count', { count: 0x80000000, state: 'open' }],
       ['invalid state', { count: 0, state: 'unknown' }],
       ['invalid owner', { count: 0, state: 'open', ownerRunId: 42 }],
+      ['non-boolean payloadDeleted', { count: 0, state: 'expired', payloadDeleted: 'true' }],
     ];
 
     for (const [label, invalid] of invalidMetadata) {
@@ -80,20 +81,26 @@ describe('StreamDO persisted-state failure handling', () => {
     }
   });
 
-  it('rejects errored metadata with a missing or malformed error payload', async () => {
-    const invalidErrors: Array<[string, unknown]> = [
-      ['missing error', undefined],
-      ['empty error', {}],
-      ['non-string error name', { name: 42, message: 'failure' }],
-      ['non-string error message', { name: 'Error', message: null }],
+  it('rejects missing, malformed, and state-inconsistent error payloads', async () => {
+    const invalidErrors: Array<[string, string, unknown]> = [
+      ['missing errored-state error', 'errored', undefined],
+      ['empty errored-state error', 'errored', {}],
+      ['non-string errored-state name', 'errored', { name: 42, message: 'failure' }],
+      ['non-string errored-state message', 'errored', { name: 'Error', message: null }],
+      ['non-string closed-state name', 'closed', { name: 42, message: 'failure' }],
+      ['non-string closed-state message', 'closed', { name: 'Error', message: null }],
+      ['unexpected valid closed-state error', 'closed', { name: 'Error', message: 'failure' }],
+      ['unexpected valid open-state error', 'open', { name: 'Error', message: 'failure' }],
+      ['unexpected valid expired-state error', 'expired', { name: 'Error', message: 'failure' }],
     ];
 
-    for (const [label, error] of invalidErrors) {
+    for (const [label, state, error] of invalidErrors) {
       const { get, storage } = setup(`stream:invalid-error:${label}`);
       storage.data.set(META_KEY, {
         count: 0,
-        state: 'errored',
+        state,
         ownerRunId: RUN_ID,
+        ...(state === 'expired' ? { payloadDeleted: true } : {}),
         ...(error === undefined ? {} : { error }),
       });
 
@@ -243,6 +250,59 @@ describe('StreamDO persisted-state failure handling', () => {
       state: 'expired',
       payloadDeleted: true,
     });
+  });
+
+  it('resumes historically completed cleanup when payloadDeleted still has orphan payloads', async () => {
+    const { fleet, get, name, storage } = setup('stream:historical-orphans');
+    storage.data.set(META_KEY, {
+      count: 0,
+      state: 'expired',
+      ownerRunId: RUN_ID,
+      expiredAt: 123,
+      expiredChunkCount: 2,
+      payloadDeleted: true,
+    });
+    storage.data.set(CHUNK_KEY, Uint8Array.of(1));
+    storage.data.set('chunk:000000000001', Uint8Array.of(2, 3));
+    fleet.restartCell('streams', name);
+
+    await expect(get().expireStream(RUN_ID, 123)).resolves.toEqual({
+      deleted: false,
+      chunks: 1,
+      bytes: 1,
+      done: false,
+    });
+    expect(storage.data.get(META_KEY)).toMatchObject({ payloadDeleted: false });
+    expect(Array.from(storage.data.keys()).filter((key) => key.startsWith('chunk:'))).toEqual([
+      'chunk:000000000001',
+    ]);
+
+    fleet.restartCell('streams', name);
+    await expect(get().expireStream(RUN_ID, 123)).resolves.toEqual({
+      deleted: false,
+      chunks: 1,
+      bytes: 2,
+      done: true,
+    });
+    expect(Array.from(storage.data.keys())).toEqual([META_KEY]);
+    expect(
+      storage.operationCalls
+        .filter((call) => call.operation === 'delete')
+        .map((call) => call.keys.length),
+    ).toEqual([2, 2]);
+
+    const completed = snapshot(storage);
+    storage.resetOperationCounts();
+    fleet.restartCell('streams', name);
+    await expect(get().expireStream(RUN_ID, 123)).resolves.toEqual({
+      deleted: false,
+      chunks: 0,
+      bytes: 0,
+      done: true,
+    });
+    expect(storage.data).toEqual(completed);
+    expect(storage.operationCounts).toMatchObject({ put: 0, putMany: 0, delete: 0, deleteMany: 0 });
+    expect(storage.operationCounts.list).toBe(2);
   });
 
   it('rejects owner mismatches on every stream path without mutation', async () => {


### PR DESCRIPTION
## Summary

- add deterministic persisted-state corruption coverage for StreamDO metadata, chunk indexes/payloads, ownership fences, offset bounds, and storage failures
- reject malformed persisted metadata and out-of-range persisted chunk keys instead of treating corrupt values as uninitialized state
- keep expiry retry-safe when chunk-size indexes are missing or inconsistent, including bounded orphan-payload cleanup
- add generic one-shot get/list failure injection to FakeStorage for real Durable Object storage-read failure paths

## Cases covered

- absent versus stored-invalid metadata; missing/invalid count, state, owner, and errored-state payload
- missing, invalid, inconsistent, malformed, and out-of-range chunk-size entries
- missing, non-Uint8Array, and length-mismatched chunk payloads
- run-owner mismatches for read, write, close, fail, stream expiry, registry registration, registry expiry, and registry finalization
- append offset overflow and read offsets outside the signed-32-bit wire range
- metadata, size-index, payload, transactional, and expiry-list read failures
- cache recovery in the same instance and after restart; transaction rollback and retry after read/write failure

## Production defects fixed

1. Falsy stored metadata values such as null, false, zero, and the empty string were treated as an absent meta key. Mutating paths could overwrite that corruption as a new stream. Only undefined now represents an absent key, and metadata/error shapes are validated structurally.
2. Expiry trusted chunk-size keys as the complete payload index. A missing size key could make cleanup report done and persist payloadDeleted while leaving an orphan chunk. The final size page now verifies payload exhaustion, and missing-size fallback removes one bounded orphan per retry.
3. Direct read validation accepted startIndex values that the existing signed-32-bit stream response encoding cannot represent. The validator now uses the same 0..2147483647 range as the router/wire format.

## Validation

- `pnpm exec vitest run test/stream-do.test.ts test/stream-do-failures.test.ts test/stream-do-cleanup.test.ts test/stream-protocol.test.ts` — 4 files, 36 tests passed
- `pnpm check` — formatting, strict lint, typecheck, builds, 22 files / 346 tests, worker bundle, and package check passed

## Residual limitations

- Corruption is injected directly into FakeStorage; this does not reproduce workerd process crashes or celld transport timing.
- Missing-size orphan cleanup intentionally processes one payload per retry so the corruption fallback remains bounded.
- Registry coverage targets ownership and transactional retry invariants; arbitrary malformed registry value shapes are outside this slice.