### PR TITLE
test: harden configuration and malformed input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,12 @@ before changing it.
 
 Queue deadlines use fixed-width 13-digit epoch-millisecond keys. A requested
 `delaySeconds` or handler redelivery timeout is accepted only when its deadline
-is at most `9999999999999`; long test-mode waits are chunked at the host timer
-limit without changing that persisted deadline contract.
+is at most `9999999669998`, leaving 330,001 ms for a fresh alarm edge and the
+maximum delivery lease. Every derived due, retry, inflight, and GC deadline is
+checked against the absolute `9999999999999` limit. A production retry which
+cannot preserve that headroom is dead-lettered instead of clamped or rescheduled;
+the test pump terminates the equivalent in-memory message. Long test-mode waits
+are chunked at the host timer limit without changing this deadline contract.
 
 ## Workflow retention
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ variable is shown below.
 | `secret`                | `CELLD_WORLD_SECRET`     | required with `fleetUrl` |
 | `baseUrl`               | `WORKFLOW_BASE_URL`      | `http://localhost:$PORT` |
 | `deploymentId`          | `CELLD_DEPLOYMENT_ID`    | `celld-default`          |
-| `queueShards`           | —                        | `1`                      |
+| `queueShards`           | —                        | `1` (maximum `128`)      |
 | `runRetentionMs`        | `CELLD_RUN_RETENTION_MS` | `0` (disabled)           |
 | `streamLongPollMs`      | —                        | `20000`                  |
 | `streamFlushIntervalMs` | —                        | `0`                      |
@@ -180,16 +180,16 @@ variable is shown below.
 
 The deployed worker also accepts these celld variables:
 
-| Variable                          | Default  | Purpose                                                  |
-| --------------------------------- | -------- | -------------------------------------------------------- |
-| `WORLD_SECRET`                    | none     | Required bearer secret for RPC routes                    |
-| `WORKFLOW_CALLBACK_SECRET`        | none     | Sent with deliveries as `x-workflow-callback-secret`     |
-| `QUEUE_MAX_ATTEMPTS`              | `5`      | Attempts before a message is dead-lettered               |
-| `QUEUE_MAX_INFLIGHT`              | `5`      | Concurrent deliveries per queue cell (maximum `128`)     |
-| `QUEUE_DELIVERY_TIMEOUT_MS`       | `300000` | Callback timeout (maximum `300000`)                      |
-| `WORKFLOW_RETENTION_MS`           | `0`      | Maximum run age from creation; includes active runs      |
-| `WORKFLOW_RETENTION_BATCH_SIZE`   | `128`    | Runs admitted by each cron sweep (maximum `1000`)        |
-| `WORKFLOW_RETENTION_QUEUE_SHARDS` | `1`      | Queue-shard fallback for runs created before this policy |
+| Variable                          | Default  | Purpose                                              |
+| --------------------------------- | -------- | ---------------------------------------------------- |
+| `WORLD_SECRET`                    | none     | Required bearer secret for RPC routes                |
+| `WORKFLOW_CALLBACK_SECRET`        | none     | Sent with deliveries as `x-workflow-callback-secret` |
+| `QUEUE_MAX_ATTEMPTS`              | `5`      | Attempts before a message is dead-lettered           |
+| `QUEUE_MAX_INFLIGHT`              | `5`      | Concurrent deliveries per queue cell (maximum `128`) |
+| `QUEUE_DELIVERY_TIMEOUT_MS`       | `300000` | Callback timeout (maximum `300000`)                  |
+| `WORKFLOW_RETENTION_MS`           | `0`      | Maximum run age from creation; includes active runs  |
+| `WORKFLOW_RETENTION_BATCH_SIZE`   | `128`    | Runs admitted by each cron sweep (maximum `1000`)    |
+| `WORKFLOW_RETENTION_QUEUE_SHARDS` | `1`      | Queue-shard fallback for older runs (maximum `128`)  |
 
 `queueShards` is part of queue placement and is pinned when a queue cell is
 first used. Drain pending work before changing it.
@@ -218,7 +218,8 @@ does not provide the desired expiration resolution or catch-up rate.
 
 New runs persist the application's `queueShards` value for complete queue
 cleanup. `WORKFLOW_RETENTION_QUEUE_SHARDS` is the fallback for runs created
-before that metadata existed and must match the placement used by those runs.
+before that metadata existed and must match the placement used by those runs;
+both shard settings have a maximum of `128`.
 
 ### Terminal payload retention
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ variable is shown below.
 | `secret`                | `CELLD_WORLD_SECRET`     | required with `fleetUrl` |
 | `baseUrl`               | `WORKFLOW_BASE_URL`      | `http://localhost:$PORT` |
 | `deploymentId`          | `CELLD_DEPLOYMENT_ID`    | `celld-default`          |
-| `queueShards`           | —                        | `1` (maximum `128`)      |
+| `queueShards`           | —                        | `1`                      |
 | `runRetentionMs`        | `CELLD_RUN_RETENTION_MS` | `0` (disabled)           |
 | `streamLongPollMs`      | —                        | `20000`                  |
 | `streamFlushIntervalMs` | —                        | `0`                      |
@@ -189,10 +189,17 @@ The deployed worker also accepts these celld variables:
 | `QUEUE_DELIVERY_TIMEOUT_MS`       | `300000` | Callback timeout (maximum `300000`)                  |
 | `WORKFLOW_RETENTION_MS`           | `0`      | Maximum run age from creation; includes active runs  |
 | `WORKFLOW_RETENTION_BATCH_SIZE`   | `128`    | Runs admitted by each cron sweep (maximum `1000`)    |
-| `WORKFLOW_RETENTION_QUEUE_SHARDS` | `1`      | Queue-shard fallback for older runs (maximum `128`)  |
+| `WORKFLOW_RETENTION_QUEUE_SHARDS` | `1`      | Queue-shard fallback for older runs                  |
 
 `queueShards` is part of queue placement and is pinned when a queue cell is
-first used. Drain pending work before changing it.
+first used. It may be any positive safe integer; the `128` storage-operation
+batch limit does not cap the fleet's total shard count. Drain pending work
+before changing it.
+
+Queue deadlines use fixed-width 13-digit epoch-millisecond keys. A requested
+`delaySeconds` or handler redelivery timeout is accepted only when its deadline
+is at most `9999999999999`; long test-mode waits are chunked at the host timer
+limit without changing that persisted deadline contract.
 
 ## Workflow retention
 
@@ -218,8 +225,8 @@ does not provide the desired expiration resolution or catch-up rate.
 
 New runs persist the application's `queueShards` value for complete queue
 cleanup. `WORKFLOW_RETENTION_QUEUE_SHARDS` is the fallback for runs created
-before that metadata existed and must match the placement used by those runs;
-both shard settings have a maximum of `128`.
+before that metadata existed and must match the placement used by those runs.
+Both values may be any positive safe integer.
 
 ### Terminal payload retention
 

--- a/celld-worker/README.md
+++ b/celld-worker/README.md
@@ -42,9 +42,10 @@ well as terminal ones. Each cron occurrence admits at most
 state machine finishes bounded index, stream, queue, and payload cleanup.
 
 New runs persist the application's `queueShards` placement. Set
-`WORKFLOW_RETENTION_QUEUE_SHARDS` to the historical queue-shard count when
-cleaning runs created before this worker version. Edit `triggers.crons` in the
-copied config if hourly discovery is not the desired resolution.
+`WORKFLOW_RETENTION_QUEUE_SHARDS` (maximum `128`) to the historical queue-shard
+count when cleaning runs created before this worker version. Edit
+`triggers.crons` in the copied config if hourly discovery is not the desired
+resolution.
 
 Point the app at any node's public listener:
 

--- a/celld-worker/README.md
+++ b/celld-worker/README.md
@@ -42,8 +42,9 @@ well as terminal ones. Each cron occurrence admits at most
 state machine finishes bounded index, stream, queue, and payload cleanup.
 
 New runs persist the application's `queueShards` placement. Set
-`WORKFLOW_RETENTION_QUEUE_SHARDS` (maximum `128`) to the historical queue-shard
-count when cleaning runs created before this worker version. Edit
+`WORKFLOW_RETENTION_QUEUE_SHARDS` to the historical positive-safe-integer
+queue-shard count when cleaning runs created before this worker version. The
+`128` multikey storage-operation limit is not a total-shard ceiling. Edit
 `triggers.crons` in the copied config if hourly discovery is not the desired
 resolution.
 

--- a/docs/index-sharding.md
+++ b/docs/index-sharding.md
@@ -83,7 +83,8 @@ latency change.
 
 - Run create/update changed from two transactions, two fence reads, and two
   scalar writes in the singleton to one catalog-shard transaction, one local
-  expiry-fence read, and one two-key batch write. A stateless commit endpoint
+  expiry-fence read, and one three-key batch write: two public indexes plus the
+  exact internal key-pair record used by expiry. A stateless commit endpoint
   also keeps terminal fencing plus catalog publication to one public call.
 - A run list performs 16 internal catalog storage lists in parallel behind one
   authenticated stateless worker request, then the same authoritative RunDO
@@ -108,6 +109,11 @@ latency change.
   one per-run fence call and one catalog-shard expiry call. The local
   end-to-end sample was 16.70 ms before and 19.94 ms after. This is a cleanup
   safety/storage-shape tradeoff, not a portable latency claim.
+
+The public `runs.expire` operation does not accept catalog keys. It routes by
+validated `runId`; the catalog shard deletes only the exact pair retained by
+the successful catalog commit, so alternate prefixes, timestamps, encodings,
+and run IDs cannot select destructive storage keys.
 
 ### Controlled contention
 

--- a/docs/lifecycle-compaction.md
+++ b/docs/lifecycle-compaction.md
@@ -57,6 +57,7 @@ The horizons in `src/lifecycle.ts` come from enforced protocol limits:
 | idempotent fleet call     |   900,900 ms | three attempts plus the maximum two retry delays                                                |
 | run index publication     | 1,200,900 ms | one authoritative apply response plus one idempotent catalog call                               |
 | one queue delivery lease  |   330,000 ms | 300,000 ms delivery timeout plus 30,000 ms lost-claim grace                                     |
+| queue schedule headroom   |   330,001 ms | longest delivery lease plus the fresh one-millisecond alarm edge                                |
 | catalog exact-fence grace | 1,200,900 ms | maximum run-index publication lifetime                                                          |
 | queue receipt grace       |   330,000 ms | maximum of one mutation RPC and one delivery lease, starting only after durable acknowledgement |
 | hook exact-claim lease    | 2,101,800 ms | reserve retries, one authoritative apply, finalize retries, and retry delays                    |
@@ -85,7 +86,8 @@ unbounded namespace scan.
 separate from internal Durable Object/storage work.
 
 - Run create/update remains two public RPCs. Its catalog shard performs one
-  expiry-marker read, one two-key batch put, and one transaction.
+  expiry-marker read, one three-key batch put (the two public indexes plus
+  their exact internal key-pair record), and one transaction.
 - Hook create remains three public RPCs. Each ownership domain performs two
   transactions, two batch reads, three scalar writes (record, claim, claim
   deadline), and one batch delete. Finalization makes two internal lifecycle
@@ -94,8 +96,11 @@ separate from internal Durable Object/storage work.
 - Hook lookup remains one public RPC plus one internal authoritative RunDO
   lifecycle read (one RunDO transaction and one batch storage read).
 - The retention sample performs one internal catalog expiry RPC and no
-  RunFence RPC. Catalog expiry performs one marker read, two scalar writes
-  (fence and GC deadline), one two-key delete, and one transaction.
+  RunFence RPC. The caller supplies only validated run identity, hooks, and
+  expiry time. Catalog expiry reads its commit-time exact key-pair record,
+  writes the fence and GC deadline, deletes only that pair plus its internal
+  record (one two-key batch delete and one scalar delete), and does all of this
+  in one transaction. A missing pair is a mutation-free no-op.
 - A steady-state run-associated queue enqueue performs one public RPC, one
   internal RunDO lifecycle RPC, one RunDO transaction/batch read, and one queue
   transaction with two scalar reads plus four scalar writes for

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -30,11 +30,19 @@ function rpcReplacer(this: unknown, key: string, value: unknown): unknown {
 function rpcReviver(key: string, value: unknown): unknown {
   if (value && typeof value === 'object') {
     const obj = value as Record<string, unknown>;
-    if (obj.__type === 'Date' && typeof obj.iso === 'string') {
-      return new Date(obj.iso);
+    if (obj.__type === 'Date') {
+      if (typeof obj.iso !== 'string') throw new SyntaxError('Malformed Date tag');
+      const date = new Date(obj.iso);
+      if (Number.isNaN(date.getTime())) throw new SyntaxError('Malformed Date tag');
+      return date;
     }
-    if (obj.__type === 'Uint8Array' && typeof obj.data === 'string') {
-      return b64decode(obj.data);
+    if (obj.__type === 'Uint8Array') {
+      if (typeof obj.data !== 'string') throw new SyntaxError('Malformed Uint8Array tag');
+      try {
+        return b64decode(obj.data);
+      } catch {
+        throw new SyntaxError('Malformed Uint8Array tag');
+      }
     }
   }
   // Fallback shared-codec semantics for untagged ISO strings in DATE_FIELDS.

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import type { QueueCellNamespace } from './queue.js';
 import { MAX_STREAM_LONG_POLL_MS } from './stream-protocol.js';
 import type { WorkflowIndex } from './indexes.js';
 import { MAX_FLEET_RPC_TIMEOUT_MS } from './lifecycle.js';
-import { boundedIntegerOption, MAX_QUEUE_SHARDS, strictIntegerSetting } from './validation.js';
+import { boundedIntegerOption, strictIntegerSetting } from './validation.js';
 
 /** Public alias retained for custom in-process environments. */
 export type IndexNamespace = WorkflowIndex;
@@ -47,7 +47,7 @@ export interface CelldWorldConfig {
    * Default: process.env.WORKFLOW_BASE_URL || `http://localhost:${PORT ?? 3000}`
    */
   baseUrl?: string;
-  /** Number of queue cells to spread enqueues over. Default: 1; maximum: 128 */
+  /** Number of queue cells to spread enqueues over. Default: 1 */
   queueShards?: number;
   /**
    * Keep terminal run payloads for this many milliseconds before replacing
@@ -77,13 +77,7 @@ export interface ResolvedCelldConfig {
 }
 
 export function resolveConfig(config?: CelldWorldConfig): ResolvedCelldConfig {
-  const queueShards = boundedIntegerOption(
-    'world-celld: queueShards',
-    config?.queueShards,
-    1,
-    1,
-    MAX_QUEUE_SHARDS,
-  );
+  const queueShards = boundedIntegerOption('world-celld: queueShards', config?.queueShards, 1, 1);
 
   const runRetentionMs =
     config?.runRetentionMs !== undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import type { QueueCellNamespace } from './queue.js';
 import { MAX_STREAM_LONG_POLL_MS } from './stream-protocol.js';
 import type { WorkflowIndex } from './indexes.js';
 import { MAX_FLEET_RPC_TIMEOUT_MS } from './lifecycle.js';
+import { boundedIntegerOption, MAX_QUEUE_SHARDS, strictIntegerSetting } from './validation.js';
 
 /** Public alias retained for custom in-process environments. */
 export type IndexNamespace = WorkflowIndex;
@@ -46,7 +47,7 @@ export interface CelldWorldConfig {
    * Default: process.env.WORKFLOW_BASE_URL || `http://localhost:${PORT ?? 3000}`
    */
   baseUrl?: string;
-  /** Number of queue cells to spread enqueues over. Default: 1 */
+  /** Number of queue cells to spread enqueues over. Default: 1; maximum: 128 */
   queueShards?: number;
   /**
    * Keep terminal run payloads for this many milliseconds before replacing
@@ -76,17 +77,23 @@ export interface ResolvedCelldConfig {
 }
 
 export function resolveConfig(config?: CelldWorldConfig): ResolvedCelldConfig {
-  const queueShards = config?.queueShards ?? 1;
-  if (!Number.isSafeInteger(queueShards) || queueShards < 1) {
-    throw new Error('world-celld: queueShards must be a positive safe integer');
-  }
+  const queueShards = boundedIntegerOption(
+    'world-celld: queueShards',
+    config?.queueShards,
+    1,
+    1,
+    MAX_QUEUE_SHARDS,
+  );
 
-  const retentionRaw = config?.runRetentionMs ?? process.env.CELLD_RUN_RETENTION_MS ?? 0;
   const runRetentionMs =
-    typeof retentionRaw === 'number' ? retentionRaw : Number.parseInt(retentionRaw, 10);
-  if (!Number.isSafeInteger(runRetentionMs) || runRetentionMs < 0) {
-    throw new Error('world-celld: runRetentionMs must be a non-negative safe integer');
-  }
+    config?.runRetentionMs !== undefined
+      ? boundedIntegerOption('world-celld: runRetentionMs', config.runRetentionMs, 0, 0)
+      : strictIntegerSetting(
+          'world-celld: runRetentionMs',
+          process.env.CELLD_RUN_RETENTION_MS,
+          0,
+          0,
+        );
 
   const rpcTimeoutMs = config?.rpcTimeoutMs ?? 30_000;
   if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,13 @@ export interface CelldRetentionAdmin {
 
 export type CelldWorld = World & CelldStreamer & { retention: CelldRetentionAdmin };
 
+const REQUIRED_ENV_BINDINGS = [
+  'WORKFLOW_DB',
+  'WORKFLOW_INDEX',
+  'WORKFLOW_QUEUE',
+  'WORKFLOW_STREAMS',
+] as const satisfies readonly (keyof CelldWorldEnv)[];
+
 export function createCelldWorld(config?: CelldWorldConfig): CelldWorld {
   const resolved = resolveConfig(config);
 
@@ -81,6 +88,12 @@ export function createCelldWorld(config?: CelldWorldConfig): CelldWorld {
         '(or CELLD_FLEET_URL / CELLD_WORLD_SECRET), or pass config.env with ' +
         'WORKFLOW_DB, WORKFLOW_INDEX, WORKFLOW_QUEUE, WORKFLOW_STREAMS',
     );
+  }
+
+  for (const binding of REQUIRED_ENV_BINDINGS) {
+    if (!env[binding]) {
+      throw new Error(`world-celld: config.env is missing required binding ${binding}`);
+    }
   }
 
   const storage = createStorage({

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -24,7 +24,8 @@ export interface IndexListOptions {
 }
 
 export interface IndexListPage {
-  keys: Array<{ name: string; value: string }>;
+  /** sourceShard is populated by the merged fleet index for exact follow-up mutation. */
+  keys: Array<{ name: string; value: string; sourceShard?: string }>;
   list_complete: boolean;
   cursor?: string;
 }
@@ -259,15 +260,19 @@ export function createWorkflowIndex(bindings: WorkflowIndexBindings): WorkflowIn
           ? Math.floor(suppliedLimit)
           : 1000;
       const limit = Math.min(1000, Math.max(1, requestedLimit));
+      const shardNames = allRunCatalogShardNames();
       const pages = await Promise.all(
-        allRunCatalogShardNames().map((name) =>
+        shardNames.map((name) =>
           stub(bindings.runCatalog, name).list({ ...options, limit: limit + 1 }),
         ),
       );
       const encoder = new TextEncoder();
       const candidates = pages
-        .flatMap((shardPage) =>
-          shardPage.keys.map((entry) => ({ entry, encodedName: encoder.encode(entry.name) })),
+        .flatMap((shardPage, shardIndex) =>
+          shardPage.keys.map((entry) => ({
+            entry: { ...entry, sourceShard: shardNames[shardIndex] },
+            encodedName: encoder.encode(entry.name),
+          })),
         )
         .toSorted((left, right) => {
           const compared = compareBytes(left.encodedName, right.encodedName);

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -43,7 +43,7 @@ export interface RunCatalogShardStub {
     key: string,
     expectedValue: string,
   ): Promise<{ deleted: boolean }>;
-  expireRun(runId: string, keys: string[], expiredAt: number): Promise<ExpireRunIndexesResult>;
+  expireRun(runId: string, expiredAt: number): Promise<ExpireRunIndexesResult>;
 }
 
 export type HookClaimResult =
@@ -377,7 +377,6 @@ export function createWorkflowIndex(bindings: WorkflowIndexBindings): WorkflowIn
       const [catalog, hookDeletes] = await Promise.all([
         stub(bindings.runCatalog, runCatalogShardName(request.runId)).expireRun(
           request.runId,
-          request.keys,
           request.expiredAt,
         ),
         releaseHooks({ runId: request.runId, hooks: request.hooks }),

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,3 +1,5 @@
+import { MAX_QUEUE_TIMESTAMP_MS } from './validation.js';
+
 /**
  * Hard protocol bounds used by lifecycle leases and derivative-fence cleanup.
  *
@@ -21,6 +23,13 @@ export const MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS =
 export const MAX_QUEUE_DELIVERY_TIMEOUT_MS = 5 * 60 * 1000;
 export const QUEUE_INFLIGHT_GRACE_MS = 30 * 1000;
 export const MAX_QUEUE_INFLIGHT_LEASE_MS = MAX_QUEUE_DELIVERY_TIMEOUT_MS + QUEUE_INFLIGHT_GRACE_MS;
+/** A fresh alarm edge may advance an immediately-due message by one millisecond. */
+export const QUEUE_ALARM_EDGE_MS = 1;
+export const MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS =
+  MAX_QUEUE_INFLIGHT_LEASE_MS + QUEUE_ALARM_EDGE_MS;
+/** Latest admissible due time with room for the alarm edge and longest delivery lease. */
+export const MAX_QUEUE_SCHEDULE_TIMESTAMP_MS =
+  MAX_QUEUE_TIMESTAMP_MS - MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS;
 
 export const CATALOG_FENCE_GRACE_MS = MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS;
 export const QUEUE_FENCE_GRACE_MS = Math.max(MAX_FLEET_RPC_TIMEOUT_MS, MAX_QUEUE_INFLIGHT_LEASE_MS);

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -29,10 +29,13 @@ import {
 import { parse, stringify } from './vendor/shared/index.js';
 import { monotonicFactory } from 'ulid';
 import { debug } from './util.js';
-import { MAX_QUEUE_DELIVERY_TIMEOUT_MS } from './lifecycle.js';
+import {
+  MAX_QUEUE_DELIVERY_TIMEOUT_MS,
+  MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+} from './lifecycle.js';
 import {
   boundedIntegerOption,
-  isValidQueueDelaySeconds,
+  checkedQueueTimestampAdd,
   queueDelayDeadline,
   strictIntegerSetting,
 } from './validation.js';
@@ -287,9 +290,16 @@ function createTestPump(config: CelldQueueConfig) {
         parsed = null;
       }
       const timeoutSeconds = (parsed as { timeoutSeconds?: number } | null)?.timeoutSeconds;
-      if (isValidQueueDelaySeconds(timeoutSeconds, 1)) {
+      const now = Date.now();
+      const redeliveryAt = queueDelayDeadline(
+        now,
+        timeoutSeconds,
+        1,
+        MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+      );
+      if (redeliveryAt !== null) {
         // Same message re-delivered later: the idempotency key stays claimed.
-        void delayFor(timeoutSeconds * 1000).then(() => enqueue(pathname, envelope));
+        void delayFor(redeliveryAt - now).then(() => enqueue(pathname, envelope));
         return;
       }
     }
@@ -308,6 +318,16 @@ function createTestPump(config: CelldQueueConfig) {
         MAX_TEST_PUMP_BACKOFF_MS,
         baseBackoffMs * 2 ** Math.min(next.attempt - 1, 30),
       );
+      if (
+        checkedQueueTimestampAdd(Date.now(), backoff, MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS) ===
+        null
+      ) {
+        release(envelope);
+        console.error(
+          `[world-celld test pump] dropping ${envelope.messageId}: retry deadline exceeds the queue timestamp horizon`,
+        );
+        return;
+      }
       void delayFor(backoff).then(() => enqueue(pathname, next));
     } else {
       release(envelope);
@@ -337,6 +357,16 @@ function createTestPump(config: CelldQueueConfig) {
       return idempotencyKey ? inflightMessages.get(idempotencyKey) : undefined;
     },
     push(pathname: Pathname, envelope: PumpEnvelope, delaySeconds?: number) {
+      if (
+        queueDelayDeadline(
+          Date.now(),
+          delaySeconds ?? 0,
+          0,
+          MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+        ) === null
+      ) {
+        throw new Error('world-celld queue delaySeconds lacks required delivery headroom');
+      }
       if (envelope.idempotencyKey) {
         inflightMessages.set(envelope.idempotencyKey, MessageId.parse(envelope.messageId));
       }
@@ -380,8 +410,15 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
       if (!parsedMessage.success) {
         throw new WorkflowWorldError('world-celld queue payload is invalid', { status: 422 });
       }
-      if (queueDelayDeadline(Date.now(), opts?.delaySeconds ?? 0) === null) {
-        throw new Error('world-celld queue delaySeconds is out of range');
+      if (
+        queueDelayDeadline(
+          Date.now(),
+          opts?.delaySeconds ?? 0,
+          0,
+          MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+        ) === null
+      ) {
+        throw new Error('world-celld queue delaySeconds lacks required delivery headroom');
       }
       const runId =
         'runId' in parsedMessage.data && typeof parsedMessage.data.runId === 'string'
@@ -492,7 +529,14 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
             messageId: reqMessageId,
           });
           if (result && typeof result.timeoutSeconds === 'number') {
-            if (queueDelayDeadline(Date.now(), result.timeoutSeconds, 1) === null) {
+            if (
+              queueDelayDeadline(
+                Date.now(),
+                result.timeoutSeconds,
+                1,
+                MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+              ) === null
+            ) {
               throw new Error('Queue handler timeoutSeconds is out of range');
             }
             return Response.json(

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -16,12 +16,12 @@
  *   HTTP statuses. QueueDO deliveries and the in-process test pump hit the
  *   exact same handler path.
  */
-import { setTimeout as delay } from 'node:timers/promises';
 import { WorkflowWorldError } from '@workflow/errors';
 import { RunExpiredError } from '@workflow/errors';
 import {
   MessageId,
   parseQueueName,
+  QueuePayloadSchema,
   type Queue,
   type QueuePayload,
   type ValidQueueName,
@@ -33,12 +33,16 @@ import { MAX_QUEUE_DELIVERY_TIMEOUT_MS } from './lifecycle.js';
 import {
   boundedIntegerOption,
   isValidQueueDelaySeconds,
-  MAX_QUEUE_SHARDS,
+  queueDelayDeadline,
   strictIntegerSetting,
 } from './validation.js';
 
 const MAX_TIMER_DELAY_MS = 0x7fffffff;
 const MAX_TEST_PUMP_BACKOFF_MS = 60_000;
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
 
 async function delayFor(milliseconds: number): Promise<void> {
   let remaining = milliseconds;
@@ -147,7 +151,7 @@ export interface CelldQueueConfig {
    * Default: process.env.WORKFLOW_BASE_URL || `http://localhost:${process.env.PORT ?? 3000}`
    */
   baseUrl?: string;
-  /** Number of `q:<shard>` cells to spread enqueues over. Default: 1; maximum: 128 */
+  /** Number of `q:<shard>` cells to spread enqueues over. Default: 1 */
   queueShards?: number;
   /** Per-job HTTP request timeout (ms) for the test pump. Default/max: 300_000 */
   httpTimeoutMs?: number;
@@ -177,8 +181,8 @@ function resolveBaseUrl(config: CelldQueueConfig): string {
  * land on the same cell so dedup stays strictly consistent.
  */
 export function shardFor(key: string, shards: number): number {
-  if (!Number.isSafeInteger(shards) || shards < 1 || shards > MAX_QUEUE_SHARDS) {
-    throw new Error(`world-celld queueShards must be between 1 and ${MAX_QUEUE_SHARDS}`);
+  if (!Number.isSafeInteger(shards) || shards < 1) {
+    throw new Error('world-celld queueShards must be a positive safe integer');
   }
   if (shards <= 1) return 0;
   let hash = 0x811c9dc5;
@@ -359,13 +363,7 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
   if (!env?.WORKFLOW_QUEUE) {
     throw new Error('world-celld queue missing WORKFLOW_QUEUE binding');
   }
-  const queueShards = boundedIntegerOption(
-    'world-celld queueShards',
-    config.queueShards,
-    1,
-    1,
-    MAX_QUEUE_SHARDS,
-  );
+  const queueShards = boundedIntegerOption('world-celld queueShards', config.queueShards, 1, 1);
 
   const generateMessageId = monotonicFactory();
   const testPump = createTestPump(config);
@@ -378,11 +376,17 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
   return {
     async queue(queueName, message, opts) {
       parseQueueName(queueName);
-      if (opts?.delaySeconds !== undefined && !isValidQueueDelaySeconds(opts.delaySeconds)) {
+      const parsedMessage = QueuePayloadSchema.safeParse(message);
+      if (!parsedMessage.success) {
+        throw new WorkflowWorldError('world-celld queue payload is invalid', { status: 422 });
+      }
+      if (queueDelayDeadline(Date.now(), opts?.delaySeconds ?? 0) === null) {
         throw new Error('world-celld queue delaySeconds is out of range');
       }
       const runId =
-        'runId' in message && typeof message.runId === 'string' ? message.runId : undefined;
+        'runId' in parsedMessage.data && typeof parsedMessage.data.runId === 'string'
+          ? parsedMessage.data.runId
+          : undefined;
 
       if (isTestMode()) {
         // Dedup on idempotencyKey while a message with the same key is in
@@ -399,7 +403,7 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
             messageId,
             queueName,
             attempt: 1,
-            message,
+            message: parsedMessage.data,
             idempotencyKey: opts?.idempotencyKey,
           },
           opts?.delaySeconds,
@@ -416,7 +420,7 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
         messageId,
         queueName,
         pathname: QUEUE_PATHNAME,
-        body: stringify(message),
+        body: stringify(parsedMessage.data),
         runId,
         idempotencyKey: opts?.idempotencyKey,
         delaySeconds: opts?.delaySeconds,
@@ -475,19 +479,20 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
           let body: unknown;
           try {
             body = parse<unknown>(await req.text());
-            if (!body || typeof body !== 'object' || Array.isArray(body)) {
-              throw new SyntaxError('payload is not an object');
-            }
           } catch {
             return Response.json({ error: 'Malformed tagged JSON body' }, { status: 422 });
           }
-          const result = await handler(body, {
+          const parsedBody = QueuePayloadSchema.safeParse(body);
+          if (!parsedBody.success) {
+            return Response.json({ error: 'Invalid queue payload' }, { status: 422 });
+          }
+          const result = await handler(parsedBody.data, {
             attempt,
             queueName: reqQueueName,
             messageId: reqMessageId,
           });
           if (result && typeof result.timeoutSeconds === 'number') {
-            if (!isValidQueueDelaySeconds(result.timeoutSeconds, 1)) {
+            if (queueDelayDeadline(Date.now(), result.timeoutSeconds, 1) === null) {
               throw new Error('Queue handler timeoutSeconds is out of range');
             }
             return Response.json(

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -29,6 +29,25 @@ import {
 import { parse, stringify } from './vendor/shared/index.js';
 import { monotonicFactory } from 'ulid';
 import { debug } from './util.js';
+import { MAX_QUEUE_DELIVERY_TIMEOUT_MS } from './lifecycle.js';
+import {
+  boundedIntegerOption,
+  isValidQueueDelaySeconds,
+  MAX_QUEUE_SHARDS,
+  strictIntegerSetting,
+} from './validation.js';
+
+const MAX_TIMER_DELAY_MS = 0x7fffffff;
+const MAX_TEST_PUMP_BACKOFF_MS = 60_000;
+
+async function delayFor(milliseconds: number): Promise<void> {
+  let remaining = milliseconds;
+  while (remaining > MAX_TIMER_DELAY_MS) {
+    await delay(MAX_TIMER_DELAY_MS);
+    remaining -= MAX_TIMER_DELAY_MS;
+  }
+  await delay(remaining);
+}
 
 /**
  * HTTP status codes that indicate permanent (non-retryable) failures.
@@ -128,13 +147,13 @@ export interface CelldQueueConfig {
    * Default: process.env.WORKFLOW_BASE_URL || `http://localhost:${process.env.PORT ?? 3000}`
    */
   baseUrl?: string;
-  /** Number of `q:<shard>` cells to spread enqueues over. Default: 1 */
+  /** Number of `q:<shard>` cells to spread enqueues over. Default: 1; maximum: 128 */
   queueShards?: number;
-  /** Per-job HTTP request timeout (ms) for the test pump. Default: 300_000 */
+  /** Per-job HTTP request timeout (ms) for the test pump. Default/max: 300_000 */
   httpTimeoutMs?: number;
   /** Maximum retry attempts in the test pump before dropping a job. Default: 5 */
   maxAttempts?: number;
-  /** Base backoff delay (ms) for test pump retries. Default: 1000 */
+  /** Base backoff delay (ms) for test pump retries. Default: 1000; maximum: 60_000 */
   backoffDelayMs?: number;
 }
 
@@ -158,6 +177,9 @@ function resolveBaseUrl(config: CelldQueueConfig): string {
  * land on the same cell so dedup stays strictly consistent.
  */
 export function shardFor(key: string, shards: number): number {
+  if (!Number.isSafeInteger(shards) || shards < 1 || shards > MAX_QUEUE_SHARDS) {
+    throw new Error(`world-celld queueShards must be between 1 and ${MAX_QUEUE_SHARDS}`);
+  }
   if (shards <= 1) return 0;
   let hash = 0x811c9dc5;
   for (let i = 0; i < key.length; i++) {
@@ -180,9 +202,26 @@ export function shardFor(key: string, shards: number): number {
  * matching QueueDO's production semantics.
  */
 function createTestPump(config: CelldQueueConfig) {
-  const httpTimeoutMs = config.httpTimeoutMs ?? 300_000;
-  const maxAttempts = config.maxAttempts ?? 5;
-  const baseBackoffMs = config.backoffDelayMs ?? 1000;
+  const httpTimeoutMs = boundedIntegerOption(
+    'world-celld test pump httpTimeoutMs',
+    config.httpTimeoutMs,
+    300_000,
+    1,
+    MAX_QUEUE_DELIVERY_TIMEOUT_MS,
+  );
+  const maxAttempts = boundedIntegerOption(
+    'world-celld test pump maxAttempts',
+    config.maxAttempts,
+    5,
+    1,
+  );
+  const baseBackoffMs = boundedIntegerOption(
+    'world-celld test pump backoffDelayMs',
+    config.backoffDelayMs,
+    1000,
+    0,
+    MAX_TEST_PUMP_BACKOFF_MS,
+  );
 
   const queues: Record<Pathname, PumpEnvelope[]> = { flow: [] };
   const wakers: Record<Pathname, Array<() => void>> = { flow: [] };
@@ -244,9 +283,9 @@ function createTestPump(config: CelldQueueConfig) {
         parsed = null;
       }
       const timeoutSeconds = (parsed as { timeoutSeconds?: number } | null)?.timeoutSeconds;
-      if (typeof timeoutSeconds === 'number') {
+      if (isValidQueueDelaySeconds(timeoutSeconds, 1)) {
         // Same message re-delivered later: the idempotency key stays claimed.
-        void delay(timeoutSeconds * 1000).then(() => enqueue(pathname, envelope));
+        void delayFor(timeoutSeconds * 1000).then(() => enqueue(pathname, envelope));
         return;
       }
     }
@@ -261,8 +300,11 @@ function createTestPump(config: CelldQueueConfig) {
 
     if (envelope.attempt < maxAttempts) {
       const next: PumpEnvelope = { ...envelope, attempt: envelope.attempt + 1 };
-      const backoff = baseBackoffMs * 2 ** (next.attempt - 1);
-      void delay(backoff).then(() => enqueue(pathname, next));
+      const backoff = Math.min(
+        MAX_TEST_PUMP_BACKOFF_MS,
+        baseBackoffMs * 2 ** Math.min(next.attempt - 1, 30),
+      );
+      void delayFor(backoff).then(() => enqueue(pathname, next));
     } else {
       release(envelope);
       console.error(
@@ -295,7 +337,7 @@ function createTestPump(config: CelldQueueConfig) {
         inflightMessages.set(envelope.idempotencyKey, MessageId.parse(envelope.messageId));
       }
       if (delaySeconds && delaySeconds > 0) {
-        void delay(delaySeconds * 1000).then(() => enqueue(pathname, envelope));
+        void delayFor(delaySeconds * 1000).then(() => enqueue(pathname, envelope));
       } else {
         enqueue(pathname, envelope);
       }
@@ -314,7 +356,16 @@ function createTestPump(config: CelldQueueConfig) {
 
 export function createQueue(config: CelldQueueConfig): Queue & { start(): Promise<void> } {
   const { env, deploymentId } = config;
-  const queueShards = config.queueShards ?? 1;
+  if (!env?.WORKFLOW_QUEUE) {
+    throw new Error('world-celld queue missing WORKFLOW_QUEUE binding');
+  }
+  const queueShards = boundedIntegerOption(
+    'world-celld queueShards',
+    config.queueShards,
+    1,
+    1,
+    MAX_QUEUE_SHARDS,
+  );
 
   const generateMessageId = monotonicFactory();
   const testPump = createTestPump(config);
@@ -327,6 +378,9 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
   return {
     async queue(queueName, message, opts) {
       parseQueueName(queueName);
+      if (opts?.delaySeconds !== undefined && !isValidQueueDelaySeconds(opts.delaySeconds)) {
+        throw new Error('world-celld queue delaySeconds is out of range');
+      }
       const runId =
         'runId' in message && typeof message.runId === 'string' ? message.runId : undefined;
 
@@ -391,6 +445,15 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
       // - 404/409/410/422         -> permanent, drop without retrying
       // - other non-2xx           -> retry with capped backoff
       return async (req: Request) => {
+        if (req.method !== 'POST') {
+          return Response.json({ error: 'Expected POST' }, { status: 405 });
+        }
+        if (
+          req.headers.get('content-type')?.split(';', 1)[0].trim().toLowerCase() !==
+          'application/json'
+        ) {
+          return Response.json({ error: 'Expected application/json' }, { status: 415 });
+        }
         const reqQueueName = req.headers.get('x-vqs-queue-name');
         const reqMessageId = req.headers.get('x-vqs-message-id') as MessageId | null;
         const attemptStr = req.headers.get('x-vqs-message-attempt');
@@ -401,16 +464,32 @@ export function createQueue(config: CelldQueueConfig): Queue & { start(): Promis
         if (!reqQueueName.startsWith(queueNamePrefix)) {
           return Response.json({ error: 'Unhandled queue' }, { status: 400 });
         }
-        const attempt = Number.parseInt(attemptStr, 10);
+        let attempt: number;
+        try {
+          attempt = strictIntegerSetting('x-vqs-message-attempt', attemptStr, 1, 1);
+        } catch {
+          return Response.json({ error: 'Invalid x-vqs-message-attempt header' }, { status: 400 });
+        }
         try {
           // Tagged-JSON codec: revives Uint8Array payloads (runInput.input).
-          const body = parse<unknown>(await req.text());
+          let body: unknown;
+          try {
+            body = parse<unknown>(await req.text());
+            if (!body || typeof body !== 'object' || Array.isArray(body)) {
+              throw new SyntaxError('payload is not an object');
+            }
+          } catch {
+            return Response.json({ error: 'Malformed tagged JSON body' }, { status: 422 });
+          }
           const result = await handler(body, {
             attempt,
             queueName: reqQueueName,
             messageId: reqMessageId,
           });
           if (result && typeof result.timeoutSeconds === 'number') {
+            if (!isValidQueueDelaySeconds(result.timeoutSeconds, 1)) {
+              throw new Error('Queue handler timeoutSeconds is out of range');
+            }
             return Response.json(
               { timeoutSeconds: result.timeoutSeconds },
               { status: 503, headers: { 'Retry-After': String(result.timeoutSeconds) } },

--- a/src/retention.ts
+++ b/src/retention.ts
@@ -78,7 +78,6 @@ export interface ReleaseHookIndexesResult {
 
 export interface ExpireRunIndexesRequest {
   runId: string;
-  keys: string[];
   hooks: HookIndexReference[];
   expiredAt: number;
 }

--- a/src/test-mocks.ts
+++ b/src/test-mocks.ts
@@ -303,6 +303,10 @@ class MockWorkflowIndex {
     }
     kvData.set(workflowRunIndexKey(run), serializedMetadata);
     kvData.set(globalRunIndexKey(run), serializedMetadata);
+    kvData.set(
+      `catalog-keys:${run.runId}`,
+      JSON.stringify([workflowRunIndexKey(run), globalRunIndexKey(run)]),
+    );
     return { stored: true };
   }
 
@@ -316,7 +320,7 @@ class MockWorkflowIndex {
     list_complete: boolean;
     cursor?: string;
   }> {
-    const prefix = options?.prefix || '';
+    const prefix = options?.prefix || 'run';
     const limit = options?.limit || 1000;
 
     let matchingKeys = Array.from(kvData.keys())
@@ -359,12 +363,15 @@ class MockWorkflowIndex {
   }
 
   async expireRun(request: ExpireRunIndexesRequest): Promise<{ deleted: number }> {
+    const storedKeys = kvData.get(`catalog-keys:${request.runId}`);
+    if (storedKeys === undefined) return { deleted: 0 };
     kvData.set(`expired:${request.runId}`, String(request.expiredAt));
     let deleted = 0;
     if (kvData.delete(`terminal:${request.runId}`)) deleted++;
-    for (const key of request.keys) {
+    for (const key of JSON.parse(storedKeys) as string[]) {
       if (kvData.delete(key)) deleted++;
     }
+    kvData.delete(`catalog-keys:${request.runId}`);
     for (const hook of request.hooks) {
       for (const key of [
         `hook:${hook.token}`,

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -59,10 +59,35 @@ export function queueDelayDeadline(
   now: number,
   delaySeconds: unknown,
   minimum: 0 | 1 = 0,
+  requiredHeadroomMs = 0,
 ): number | null {
   if (!isNonNegativeSafeInteger(now) || !isValidQueueDelaySeconds(delaySeconds, minimum)) {
     return null;
   }
-  const deadline = now + delaySeconds * 1000;
-  return Number.isSafeInteger(deadline) && deadline <= MAX_QUEUE_TIMESTAMP_MS ? deadline : null;
+  return checkedQueueTimestampAdd(now, delaySeconds * 1000, requiredHeadroomMs);
+}
+
+/**
+ * Add an offset to a queue timestamp while preserving its 13-digit key order.
+ * Optional headroom reserves space for a later persisted derivative deadline.
+ */
+export function checkedQueueTimestampAdd(
+  timestampMs: unknown,
+  offsetMs: unknown,
+  requiredHeadroomMs = 0,
+): number | null {
+  if (
+    !isNonNegativeSafeInteger(timestampMs) ||
+    !isNonNegativeSafeInteger(offsetMs) ||
+    !isNonNegativeSafeInteger(requiredHeadroomMs)
+  ) {
+    return null;
+  }
+  const timestamp = timestampMs;
+  const offset = offsetMs;
+  if (timestamp > MAX_QUEUE_TIMESTAMP_MS || offset > MAX_QUEUE_TIMESTAMP_MS - timestamp) {
+    return null;
+  }
+  const result = timestamp + offset;
+  return requiredHeadroomMs <= MAX_QUEUE_TIMESTAMP_MS - result ? result : null;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,70 @@
+/** Largest queue deadline representable by JavaScript's Date and alarm APIs. */
+export const MAX_QUEUE_TIMESTAMP_MS = 8_640_000_000_000_000;
+export const MAX_QUEUE_DELAY_SECONDS = Math.floor(MAX_QUEUE_TIMESTAMP_MS / 1000);
+/** Bounds queue-cell fanout and the per-run retention cleanup state machine. */
+export const MAX_QUEUE_SHARDS = 128;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isNonNegativeSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+export function isPositiveSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+export function boundedIntegerOption(
+  name: string,
+  value: unknown,
+  fallback: number,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isSafeInteger(value) || (value as number) < minimum || (value as number) > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value as number;
+}
+
+/**
+ * Parse a deployment/runtime integer setting without accepting whitespace,
+ * exponents, fractions, or numeric prefixes such as `5junk`.
+ */
+export function strictIntegerSetting(
+  name: string,
+  raw: string | number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER,
+): number {
+  if (raw === undefined) return fallback;
+  const value = typeof raw === 'number' ? raw : /^\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value;
+}
+
+export function isValidQueueDelaySeconds(value: unknown, minimum: 0 | 1 = 0): value is number {
+  return (
+    Number.isSafeInteger(value) &&
+    (value as number) >= minimum &&
+    (value as number) <= MAX_QUEUE_DELAY_SECONDS
+  );
+}
+
+export function queueDelayDeadline(
+  now: number,
+  delaySeconds: unknown,
+  minimum: 0 | 1 = 0,
+): number | null {
+  if (!isNonNegativeSafeInteger(now) || !isValidQueueDelaySeconds(delaySeconds, minimum)) {
+    return null;
+  }
+  const deadline = now + delaySeconds * 1000;
+  return Number.isSafeInteger(deadline) && deadline <= MAX_QUEUE_TIMESTAMP_MS ? deadline : null;
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,8 +1,6 @@
-/** Largest queue deadline representable by JavaScript's Date and alarm APIs. */
-export const MAX_QUEUE_TIMESTAMP_MS = 8_640_000_000_000_000;
+/** Largest epoch-ms deadline that fits the queue's fixed-width 13-digit keys. */
+export const MAX_QUEUE_TIMESTAMP_MS = 9_999_999_999_999;
 export const MAX_QUEUE_DELAY_SECONDS = Math.floor(MAX_QUEUE_TIMESTAMP_MS / 1000);
-/** Bounds queue-cell fanout and the per-run retention cleanup state machine. */
-export const MAX_QUEUE_SHARDS = 128;
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);

--- a/src/vendor/shared/serialization.ts
+++ b/src/vendor/shared/serialization.ts
@@ -68,12 +68,23 @@ export function uint8ArrayReviver(key: string, value: unknown): unknown {
   if (value && typeof value === 'object') {
     const obj = value as Record<string, unknown>;
     // New format: base64-encoded
-    if (obj.__type === 'Uint8Array' && typeof obj.data === 'string') {
-      return b64decode(obj.data);
+    if (obj.__type === 'Uint8Array') {
+      if (typeof obj.data !== 'string') throw new SyntaxError('Malformed Uint8Array tag');
+      try {
+        return b64decode(obj.data);
+      } catch {
+        throw new SyntaxError('Malformed Uint8Array tag');
+      }
     }
     // Legacy format: number array (backwards compat with NATS JetStream data)
-    if (obj.__uint8array === true && Array.isArray(obj.data)) {
-      return new Uint8Array(obj.data as number[]);
+    if (obj.__uint8array === true) {
+      if (
+        !Array.isArray(obj.data) ||
+        !obj.data.every((byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255)
+      ) {
+        throw new SyntaxError('Malformed legacy Uint8Array tag');
+      }
+      return new Uint8Array(obj.data);
     }
   }
   return dateReviver(key, value);

--- a/src/worker/durable-objects/QueueDO.ts
+++ b/src/worker/durable-objects/QueueDO.ts
@@ -1,3 +1,5 @@
+import { WorkflowWorldError } from '@workflow/errors';
+import { QueuePayloadSchema } from '@workflow/world';
 import { DurableObject } from '../do-base.js';
 import type { EnqueueOutcome, EnqueueRequest } from '../../queue.js';
 import type {
@@ -13,7 +15,7 @@ import {
   isPositiveSafeInteger,
   isRecord,
   isValidQueueDelaySeconds,
-  MAX_QUEUE_SHARDS,
+  MAX_QUEUE_TIMESTAMP_MS,
   queueDelayDeadline,
   strictIntegerSetting,
 } from '../../validation.js';
@@ -153,6 +155,10 @@ function deadlineFromInflightKey(key: string): number {
   );
 }
 
+function inclusiveTimestampEnd(prefix: string, now: number): string {
+  return now >= MAX_QUEUE_TIMESTAMP_MS ? `${prefix.slice(0, -1)};` : `${prefix}${pad(now + 1)}`;
+}
+
 function runReferenceKey(runId: string, messageId: string): string {
   return `run:${runId}:${messageId}`;
 }
@@ -182,13 +188,8 @@ function validateEnqueueRequest(request: unknown): asserts request is EnqueueReq
   ) {
     throw new Error('world-celld queue enqueue config is invalid');
   }
-  if (
-    !isPositiveSafeInteger(request.config.queueShards) ||
-    request.config.queueShards > MAX_QUEUE_SHARDS
-  ) {
-    throw new Error(
-      `world-celld queue enqueue queueShards must be between 1 and ${MAX_QUEUE_SHARDS}`,
-    );
+  if (!isPositiveSafeInteger(request.config.queueShards)) {
+    throw new Error('world-celld queue enqueue queueShards must be a positive safe integer');
   }
   if (request.delaySeconds !== undefined && !isValidQueueDelaySeconds(request.delaySeconds)) {
     throw new Error('world-celld queue enqueue delaySeconds is out of range');
@@ -205,10 +206,28 @@ function validateEnqueueRequest(request: unknown): asserts request is EnqueueReq
   ) {
     throw new Error('world-celld queue enqueue idempotencyKey must be a non-empty string');
   }
+  let body: unknown;
   try {
-    if (!isRecord(parse(request.body as string))) throw new SyntaxError('payload is not an object');
+    body = parse(request.body as string);
   } catch {
-    throw new Error('world-celld queue enqueue body must be valid tagged JSON');
+    throw new WorkflowWorldError('world-celld queue enqueue body must be valid tagged JSON', {
+      status: 422,
+    });
+  }
+  const payload = QueuePayloadSchema.safeParse(body);
+  if (!payload.success) {
+    throw new WorkflowWorldError('world-celld queue enqueue body is an invalid queue payload', {
+      status: 422,
+    });
+  }
+  const payloadRunId =
+    'runId' in payload.data && typeof payload.data.runId === 'string'
+      ? payload.data.runId
+      : undefined;
+  if (request.runId !== payloadRunId) {
+    throw new WorkflowWorldError('world-celld queue enqueue runId does not match body', {
+      status: 422,
+    });
   }
 }
 
@@ -477,7 +496,7 @@ export class QueueDO extends DurableObject {
       // (node crash, deploy restart) — back to due for redelivery.
       const expiredPage = await txn.list<string>({
         prefix: INFLIGHT_DEADLINE_PREFIX,
-        end: `${INFLIGHT_DEADLINE_PREFIX}${pad(now + 1)}`,
+        end: inclusiveTimestampEnd(INFLIGHT_DEADLINE_PREFIX, now),
         limit: EXPIRED_INFLIGHT_BATCH + 1,
       });
       const expired = Array.from(expiredPage.entries()).slice(0, EXPIRED_INFLIGHT_BATCH);
@@ -526,7 +545,7 @@ export class QueueDO extends DurableObject {
       if (inflightCount < maxInflight) {
         const due = await txn.list<string>({
           prefix: 'due:',
-          end: `due:${pad(now + 1)}`,
+          end: inclusiveTimestampEnd('due:', now),
           limit: maxInflight - inflightCount,
         });
         const timeoutMs = this.#deliveryTimeoutMs();

--- a/src/worker/durable-objects/QueueDO.ts
+++ b/src/worker/durable-objects/QueueDO.ts
@@ -11,6 +11,7 @@ import type { RunLifecycleStatus } from '../../retention.js';
 import { parse } from '../../vendor/shared/index.js';
 import {
   boundedIntegerOption,
+  checkedQueueTimestampAdd,
   isNonNegativeSafeInteger,
   isPositiveSafeInteger,
   isRecord,
@@ -23,6 +24,7 @@ import {
   LIFECYCLE_COMPACTION_BATCH,
   LIFECYCLE_COMPACTION_RETRY_MS,
   MAX_QUEUE_DELIVERY_TIMEOUT_MS,
+  MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
   QUEUE_FENCE_GRACE_MS,
   QUEUE_INFLIGHT_GRACE_MS,
 } from '../../lifecycle.js';
@@ -137,7 +139,10 @@ const EXPIRED_RUN_GC_PREFIX = 'expired-run-gc:';
 type AlarmStorage = Pick<DurableObjectStorage, 'list' | 'getAlarm' | 'setAlarm' | 'deleteAlarm'>;
 
 function pad(ms: number): string {
-  return String(Math.max(0, Math.floor(ms))).padStart(13, '0');
+  if (!isNonNegativeSafeInteger(ms) || ms > MAX_QUEUE_TIMESTAMP_MS) {
+    throw new Error('queue timestamp must be a non-negative 13-digit integer');
+  }
+  return String(ms).padStart(13, '0');
 }
 
 function dueKey(atMs: number, messageId: string): string {
@@ -366,9 +371,14 @@ export class QueueDO extends DurableObject {
     validateEnqueueRequest(request);
     const storage = this.ctx.storage;
     const now = this.#now();
-    const dueAt = queueDelayDeadline(now, request.delaySeconds ?? 0);
+    const dueAt = queueDelayDeadline(
+      now,
+      request.delaySeconds ?? 0,
+      0,
+      MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+    );
     if (dueAt === null) {
-      throw new Error('world-celld queue enqueue delaySeconds produces an invalid deadline');
+      throw new Error('world-celld queue enqueue delaySeconds lacks required delivery headroom');
     }
 
     const persist = async (txn: DurableObjectTransaction): Promise<EnqueueOutcome> => {
@@ -466,7 +476,9 @@ export class QueueDO extends DurableObject {
       await attempt();
     }
     if (failure !== null) {
-      await this.ctx.storage.setAlarm(this.#now() + LIFECYCLE_COMPACTION_RETRY_MS);
+      const retryAt = checkedQueueTimestampAdd(this.#now(), LIFECYCLE_COMPACTION_RETRY_MS);
+      if (retryAt === null) await this.ctx.storage.deleteAlarm();
+      else await this.ctx.storage.setAlarm(retryAt);
       throw failure;
     }
 
@@ -488,7 +500,9 @@ export class QueueDO extends DurableObject {
       // Queue operations always consult the authoritative RunDO tombstone, so
       // deleting the receipt cannot reopen the run.
       if (await this.#compactExpiredRunFences(txn, now)) {
-        await txn.setAlarm(now + MIN_ALARM_DELAY_MS);
+        const nextAt = checkedQueueTimestampAdd(now, MIN_ALARM_DELAY_MS);
+        if (nextAt === null) await txn.deleteAlarm();
+        else await txn.setAlarm(nextAt);
         return [];
       }
 
@@ -512,7 +526,22 @@ export class QueueDO extends DurableObject {
       for (const [, messageId] of expired) {
         const row = expiredRows.get(`msg:${messageId}`);
         if (row) {
-          const scheduleKey = dueKey(now, messageId);
+          const recoveryAt = checkedQueueTimestampAdd(
+            now,
+            0,
+            MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+          );
+          if (recoveryAt === null) {
+            await this.#deadLetter(
+              txn,
+              row,
+              row.attempt,
+              'inflight recovery exceeded the queue timestamp horizon',
+              now,
+            );
+            continue;
+          }
+          const scheduleKey = dueKey(recoveryAt, messageId);
           recoveryWrites.push([scheduleKey, messageId]);
           if (row.runId) {
             recoveryWrites.push([
@@ -528,7 +557,9 @@ export class QueueDO extends DurableObject {
       }
       await putMany(txn, recoveryWrites);
       if (expiredPage.size > EXPIRED_INFLIGHT_BATCH) {
-        await txn.setAlarm(now + MIN_ALARM_DELAY_MS);
+        const nextAt = checkedQueueTimestampAdd(now, MIN_ALARM_DELAY_MS);
+        if (nextAt === null) await txn.deleteAlarm();
+        else await txn.setAlarm(nextAt);
         return [];
       }
 
@@ -558,7 +589,18 @@ export class QueueDO extends DurableObject {
         for (const [, messageId] of due) {
           const row = dueRows.get(`msg:${messageId}`);
           if (!row) continue; // orphaned schedule entry
-          const claimKey = inflightKey(now + timeoutMs + QUEUE_INFLIGHT_GRACE_MS, messageId);
+          const claimDeadline = checkedQueueTimestampAdd(now, timeoutMs + QUEUE_INFLIGHT_GRACE_MS);
+          if (claimDeadline === null) {
+            await this.#deadLetter(
+              txn,
+              row,
+              row.attempt,
+              'delivery lease exceeded the queue timestamp horizon',
+              now,
+            );
+            continue;
+          }
+          const claimKey = inflightKey(claimDeadline, messageId);
           claimWrites.push([claimKey, messageId]);
           if (row.runId) {
             claimWrites.push([
@@ -630,7 +672,12 @@ export class QueueDO extends DurableObject {
       } catch {
         timeoutSeconds = undefined;
       }
-      const redeliveryAt = queueDelayDeadline(now, timeoutSeconds, 1);
+      const redeliveryAt = queueDelayDeadline(
+        now,
+        timeoutSeconds,
+        1,
+        MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+      );
       if (redeliveryAt !== null) {
         const reschedule = async (txn: DurableObjectTransaction) => {
           // Deleting the exact deadline key doubles as a lease-token check. A
@@ -712,34 +759,29 @@ export class QueueDO extends DurableObject {
     const now = this.#now();
     const maxAttempts = this.#maxAttempts();
     const attempt = row.attempt + 1;
+    const retryAt = checkedQueueTimestampAdd(
+      now,
+      backoffSeconds(attempt) * 1000,
+      MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+    );
 
     const persistRetry = async (txn: DurableObjectTransaction) => {
       if (!(await txn.delete(claimKey))) return;
 
-      if (attempt >= maxAttempts) {
-        const dead: DeadLetterRow = { ...row, attempt, lastError: reason, failedAt: now };
-        const deadKey = `dlq:${pad(now)}:${row.messageId}`;
-        await txn.put(deadKey, dead);
-        await txn.delete(`msg:${row.messageId}`);
-        if (row.idempotencyKey) {
-          const holder = await txn.get<string>(`key:${row.idempotencyKey}`);
-          if (holder === row.messageId) {
-            await txn.delete(`key:${row.idempotencyKey}`);
-          }
-        }
-        if (row.runId) {
-          await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
-            messageId: row.messageId,
-            dlqKey: deadKey,
-            idempotencyKey: row.idempotencyKey,
-          });
-        }
+      if (attempt >= maxAttempts || retryAt === null) {
+        await this.#deadLetter(
+          txn,
+          row,
+          attempt,
+          retryAt === null ? `${reason}; retry exceeded the queue timestamp horizon` : reason,
+          now,
+        );
         await this.#scheduleNextAlarm(txn, now);
         return;
       }
 
       const updated: MessageRow = { ...row, attempt, lastError: reason };
-      const scheduleKey = dueKey(now + backoffSeconds(attempt) * 1000, row.messageId);
+      const scheduleKey = dueKey(retryAt, row.messageId);
       await txn.put(`msg:${row.messageId}`, updated);
       await txn.put(scheduleKey, row.messageId);
       if (row.runId) {
@@ -762,11 +804,40 @@ export class QueueDO extends DurableObject {
     }
   }
 
+  async #deadLetter(
+    txn: DurableObjectTransaction,
+    row: MessageRow,
+    attempt: number,
+    reason: string,
+    now: number,
+  ): Promise<void> {
+    const failedAt = checkedQueueTimestampAdd(now, 0);
+    await txn.delete(`msg:${row.messageId}`);
+    if (row.idempotencyKey) {
+      const holder = await txn.get<string>(`key:${row.idempotencyKey}`);
+      if (holder === row.messageId) await txn.delete(`key:${row.idempotencyKey}`);
+    }
+    if (failedAt === null) {
+      if (row.runId) await txn.delete(runReferenceKey(row.runId, row.messageId));
+      return;
+    }
+    const dead: DeadLetterRow = { ...row, attempt, lastError: reason, failedAt };
+    const deadKey = `dlq:${pad(failedAt)}:${row.messageId}`;
+    await txn.put(deadKey, dead);
+    if (row.runId) {
+      await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
+        messageId: row.messageId,
+        dlqKey: deadKey,
+        idempotencyKey: row.idempotencyKey,
+      });
+    }
+  }
+
   /** Return true when another due compaction page must run immediately. */
   async #compactExpiredRunFences(txn: DurableObjectTransaction, now: number): Promise<boolean> {
     const due = await txn.list<ExpiredRunGc>({
       prefix: EXPIRED_RUN_GC_PREFIX,
-      end: `${EXPIRED_RUN_GC_PREFIX}${pad(now + 1)}`,
+      end: inclusiveTimestampEnd(EXPIRED_RUN_GC_PREFIX, now),
       limit: LIFECYCLE_COMPACTION_BATCH + 1,
     });
     const page = Array.from(due).slice(0, LIFECYCLE_COMPACTION_BATCH);
@@ -790,12 +861,18 @@ export class QueueDO extends DurableObject {
   /** Arm the alarm no later than `atMs` (durable backoff never throws). */
   async #armAlarmAtMost(storage: AlarmStorage, atMs: number, now: number): Promise<void> {
     const current = await storage.getAlarm();
+    const immediate = checkedQueueTimestampAdd(now, MIN_ALARM_DELAY_MS);
     if (current !== null && current <= now) {
-      await storage.setAlarm(now + MIN_ALARM_DELAY_MS);
+      if (immediate === null) await storage.deleteAlarm();
+      else await storage.setAlarm(immediate);
       return;
     }
 
-    const target = atMs <= now ? now + MIN_ALARM_DELAY_MS : atMs;
+    const target = atMs <= now ? immediate : atMs;
+    if (target === null) {
+      await storage.deleteAlarm();
+      return;
+    }
     if (current === null || target < current) {
       await storage.setAlarm(target);
     }
@@ -827,7 +904,9 @@ export class QueueDO extends DurableObject {
     }
 
     if (next !== null) {
-      await storage.setAlarm(next <= now ? now + MIN_ALARM_DELAY_MS : next);
+      const target = next <= now ? checkedQueueTimestampAdd(now, MIN_ALARM_DELAY_MS) : next;
+      if (target === null) await storage.deleteAlarm();
+      else await storage.setAlarm(target);
     } else {
       await storage.deleteAlarm();
     }
@@ -890,6 +969,9 @@ export class QueueDO extends DurableObject {
     }
     const storage = this.ctx.storage;
     const now = this.#now();
+    if (checkedQueueTimestampAdd(now, 0, MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS) === null) {
+      return { ok: false };
+    }
     const found = Array.from(await storage.list<DeadLetterRow>({ prefix: 'dlq:' })).find(
       ([, dead]) => dead.messageId === messageId,
     );
@@ -1058,9 +1140,11 @@ export class QueueDO extends DurableObject {
         return { acknowledged: false };
       }
       if (marker.compactAt === null) {
-        const compactAt = this.#now() + QUEUE_FENCE_GRACE_MS;
-        await txn.put<ExpiredRunFence>(key, { ...marker, compactAt });
-        await txn.put<ExpiredRunGc>(expiredRunGcKey(runId, compactAt), { runId, compactAt });
+        const compactAt = checkedQueueTimestampAdd(this.#now(), QUEUE_FENCE_GRACE_MS);
+        if (compactAt !== null) {
+          await txn.put<ExpiredRunFence>(key, { ...marker, compactAt });
+          await txn.put<ExpiredRunGc>(expiredRunGcKey(runId, compactAt), { runId, compactAt });
+        }
       }
       await this.#scheduleNextAlarm(txn, this.#now());
       return { acknowledged: true };

--- a/src/worker/durable-objects/QueueDO.ts
+++ b/src/worker/durable-objects/QueueDO.ts
@@ -6,6 +6,17 @@ import type {
   QueueExpiryReceipt,
 } from '../../retention.js';
 import type { RunLifecycleStatus } from '../../retention.js';
+import { parse } from '../../vendor/shared/index.js';
+import {
+  boundedIntegerOption,
+  isNonNegativeSafeInteger,
+  isPositiveSafeInteger,
+  isRecord,
+  isValidQueueDelaySeconds,
+  MAX_QUEUE_SHARDS,
+  queueDelayDeadline,
+  strictIntegerSetting,
+} from '../../validation.js';
 import {
   LIFECYCLE_COMPACTION_BATCH,
   LIFECYCLE_COMPACTION_RETRY_MS,
@@ -116,6 +127,7 @@ const EXPIRED_INFLIGHT_BATCH = 128;
 const STORAGE_BATCH_SIZE = 128;
 const EXPIRE_RUN_REFERENCE_BATCH = 64;
 const PURGE_DEAD_LETTER_BATCH = 128;
+const MAX_DEAD_LETTER_LIST_SIZE = 1000;
 
 const INFLIGHT_DEADLINE_PREFIX = 'inflight-deadline:';
 const EXPIRED_RUN_GC_PREFIX = 'expired-run-gc:';
@@ -153,9 +165,51 @@ function expiredRunGcKey(runId: string, compactAt: number): string {
   return `${EXPIRED_RUN_GC_PREFIX}${pad(compactAt)}:${encodeURIComponent(runId)}`;
 }
 
-function boundedLimit(value: number | undefined, fallback: number, maximum: number): number {
-  if (value === undefined || !Number.isFinite(value)) return fallback;
-  return Math.max(1, Math.min(maximum, Math.floor(value)));
+function validateEnqueueRequest(request: unknown): asserts request is EnqueueRequest {
+  if (!isRecord(request)) throw new Error('world-celld queue enqueue request must be an object');
+  for (const field of ['messageId', 'queueName', 'body'] as const) {
+    if (typeof request[field] !== 'string' || request[field].length === 0) {
+      throw new Error(`world-celld queue enqueue ${field} must be a non-empty string`);
+    }
+  }
+  if (request.pathname !== 'flow') {
+    throw new Error('world-celld queue enqueue pathname must be flow');
+  }
+  if (
+    !isRecord(request.config) ||
+    typeof request.config.targetBaseUrl !== 'string' ||
+    request.config.targetBaseUrl.length === 0
+  ) {
+    throw new Error('world-celld queue enqueue config is invalid');
+  }
+  if (
+    !isPositiveSafeInteger(request.config.queueShards) ||
+    request.config.queueShards > MAX_QUEUE_SHARDS
+  ) {
+    throw new Error(
+      `world-celld queue enqueue queueShards must be between 1 and ${MAX_QUEUE_SHARDS}`,
+    );
+  }
+  if (request.delaySeconds !== undefined && !isValidQueueDelaySeconds(request.delaySeconds)) {
+    throw new Error('world-celld queue enqueue delaySeconds is out of range');
+  }
+  if (
+    request.runId !== undefined &&
+    (typeof request.runId !== 'string' || request.runId.length === 0)
+  ) {
+    throw new Error('world-celld queue enqueue runId must be a non-empty string');
+  }
+  if (
+    request.idempotencyKey !== undefined &&
+    (typeof request.idempotencyKey !== 'string' || request.idempotencyKey.length === 0)
+  ) {
+    throw new Error('world-celld queue enqueue idempotencyKey must be a non-empty string');
+  }
+  try {
+    if (!isRecord(parse(request.body as string))) throw new SyntaxError('payload is not an object');
+  } catch {
+    throw new Error('world-celld queue enqueue body must be valid tagged JSON');
+  }
 }
 
 async function getMany<T>(
@@ -234,8 +288,11 @@ export class QueueDO extends DurableObject {
     fallback: number,
   ): number {
     const raw = (this.env as QueueCellEnv)?.[name];
-    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+    return strictIntegerSetting(name, raw, fallback, 1);
+  }
+
+  #maxAttempts(): number {
+    return this.#intVar('QUEUE_MAX_ATTEMPTS', DEFAULT_MAX_ATTEMPTS);
   }
 
   #maxInflight(): number {
@@ -252,6 +309,12 @@ export class QueueDO extends DurableObject {
       throw new Error(`QUEUE_DELIVERY_TIMEOUT_MS must be at most ${MAX_QUEUE_DELIVERY_TIMEOUT_MS}`);
     }
     return configured;
+  }
+
+  #validateRuntimeConfig(): void {
+    this.#maxAttempts();
+    this.#maxInflight();
+    this.#deliveryTimeoutMs();
   }
 
   async #authoritativeRunExpired(runId: string): Promise<boolean> {
@@ -280,10 +343,14 @@ export class QueueDO extends DurableObject {
   }
 
   async enqueue(request: EnqueueRequest): Promise<EnqueueOutcome> {
-    this.#maxInflight();
-    this.#deliveryTimeoutMs();
+    this.#validateRuntimeConfig();
+    validateEnqueueRequest(request);
     const storage = this.ctx.storage;
     const now = this.#now();
+    const dueAt = queueDelayDeadline(now, request.delaySeconds ?? 0);
+    if (dueAt === null) {
+      throw new Error('world-celld queue enqueue delaySeconds produces an invalid deadline');
+    }
 
     const persist = async (txn: DurableObjectTransaction): Promise<EnqueueOutcome> => {
       // Pin the shard count from the first enqueue and reject drift loudly:
@@ -330,7 +397,6 @@ export class QueueDO extends DurableObject {
         attempt: 0,
         enqueuedAt: now,
       };
-      const dueAt = now + Math.max(0, request.delaySeconds ?? 0) * 1000;
       const scheduleKey = dueKey(dueAt, row.messageId);
       await txn.put(`msg:${row.messageId}`, row);
       await txn.put(scheduleKey, row.messageId);
@@ -362,6 +428,7 @@ export class QueueDO extends DurableObject {
   }
 
   async alarm(): Promise<void> {
+    this.#validateRuntimeConfig();
     // celld#144: alarm handlers can overlap while awaiting. The storage-only
     // claim phase runs under the input gate; a failure is carried out and
     // rethrown outside so a failed critical section cannot reset the cell.
@@ -544,12 +611,13 @@ export class QueueDO extends DurableObject {
       } catch {
         timeoutSeconds = undefined;
       }
-      if (typeof timeoutSeconds === 'number') {
+      const redeliveryAt = queueDelayDeadline(now, timeoutSeconds, 1);
+      if (redeliveryAt !== null) {
         const reschedule = async (txn: DurableObjectTransaction) => {
           // Deleting the exact deadline key doubles as a lease-token check. A
           // late response from an expired claim must not mutate a newer claim.
           if (!(await txn.delete(claimKey))) return;
-          const scheduleKey = dueKey(now + timeoutSeconds * 1000, row.messageId);
+          const scheduleKey = dueKey(redeliveryAt, row.messageId);
           await txn.put(scheduleKey, row.messageId);
           if (row.runId) {
             await txn.put<QueueRunReference>(runReferenceKey(row.runId, row.messageId), {
@@ -623,7 +691,7 @@ export class QueueDO extends DurableObject {
   async #retry(row: MessageRow, claimKey: string, reason: string): Promise<void> {
     const storage = this.ctx.storage;
     const now = this.#now();
-    const maxAttempts = this.#intVar('QUEUE_MAX_ATTEMPTS', DEFAULT_MAX_ATTEMPTS);
+    const maxAttempts = this.#maxAttempts();
     const attempt = row.attempt + 1;
 
     const persistRetry = async (txn: DurableObjectTransaction) => {
@@ -768,7 +836,19 @@ export class QueueDO extends DurableObject {
     limit?: number;
     cursor?: string;
   }): Promise<{ data: DeadLetterRow[]; cursor: string | null; hasMore: boolean }> {
-    const limit = params?.limit ?? 100;
+    if (params !== undefined && !isRecord(params)) {
+      throw new Error('world-celld queue dead-letter list options must be an object');
+    }
+    const limit = boundedIntegerOption(
+      'world-celld queue dead-letter limit',
+      params?.limit,
+      100,
+      1,
+      MAX_DEAD_LETTER_LIST_SIZE,
+    );
+    if (params?.cursor !== undefined && typeof params.cursor !== 'string') {
+      throw new Error('world-celld queue dead-letter cursor must be a string');
+    }
     const entries = await this.ctx.storage.list<DeadLetterRow>({
       prefix: 'dlq:',
       startAfter: params?.cursor,
@@ -786,6 +866,9 @@ export class QueueDO extends DurableObject {
 
   /** Move a dead letter back to the live queue (attempt count reset). */
   async redriveDeadLetter(messageId: string): Promise<{ ok: boolean }> {
+    if (typeof messageId !== 'string' || messageId.length === 0) {
+      throw new Error('world-celld queue redrive messageId must be a non-empty string');
+    }
     const storage = this.ctx.storage;
     const now = this.#now();
     const found = Array.from(await storage.list<DeadLetterRow>({ prefix: 'dlq:' })).find(
@@ -872,10 +955,21 @@ export class QueueDO extends DurableObject {
     expiredAt: number,
     options?: { limit?: number },
   ): Promise<ExpireQueueRunResult> {
+    if (typeof runId !== 'string' || runId.length === 0) {
+      throw new Error('world-celld queue expiry runId must be a non-empty string');
+    }
+    if (!isNonNegativeSafeInteger(expiredAt)) {
+      throw new Error('world-celld queue expiry expiredAt must be a non-negative safe integer');
+    }
+    if (options !== undefined && !isRecord(options)) {
+      throw new Error('world-celld queue expiry options must be an object');
+    }
     const storage = this.ctx.storage;
-    const limit = boundedLimit(
+    const limit = boundedIntegerOption(
+      'world-celld queue expiry limit',
       options?.limit,
       EXPIRE_RUN_REFERENCE_BATCH,
+      1,
       EXPIRE_RUN_REFERENCE_BATCH,
     );
     return await storage.transaction(async (txn) => {
@@ -924,6 +1018,16 @@ export class QueueDO extends DurableObject {
     runId: string,
     receipt: QueueExpiryReceipt,
   ): Promise<AcknowledgeQueueExpiryResult> {
+    if (typeof runId !== 'string' || runId.length === 0) {
+      throw new Error('world-celld queue expiry runId must be a non-empty string');
+    }
+    if (
+      !isRecord(receipt) ||
+      !isNonNegativeSafeInteger(receipt.expiredAt) ||
+      !isNonNegativeSafeInteger(receipt.deleted)
+    ) {
+      throw new Error('world-celld queue expiry receipt is invalid');
+    }
     return await this.ctx.storage.transaction(async (txn) => {
       const key = expiredRunKey(runId);
       const marker = await txn.get<ExpiredRunFence>(key);

--- a/src/worker/durable-objects/RunCatalogDO.ts
+++ b/src/worker/durable-objects/RunCatalogDO.ts
@@ -98,10 +98,6 @@ export class RunCatalogDO extends DurableObject {
     if (!key.startsWith('runall:') || !key.endsWith(`:${runId}`)) {
       throw new Error('Stale run catalog deletion requires the exact global run key');
     }
-    const metadata = JSON.parse(expectedValue) as { runId?: unknown };
-    if (metadata.runId !== runId) {
-      throw new Error('Stale run catalog deletion requires matching run metadata');
-    }
     return await this.ctx.storage.transaction(async (txn) => {
       if ((await txn.get<string>(key)) !== expectedValue) return { deleted: false };
       return { deleted: await txn.delete(key) };

--- a/src/worker/durable-objects/RunCatalogDO.ts
+++ b/src/worker/durable-objects/RunCatalogDO.ts
@@ -10,6 +10,7 @@ import {
 
 const MAX_INDEX_LIST_SIZE = 1001;
 const EXPIRY_GC_PREFIX = 'expiry-gc:';
+const CATALOG_KEYS_PREFIX = 'catalog-keys:';
 
 interface RunCatalogEnv {
   clock?: () => number;
@@ -25,12 +26,37 @@ interface CatalogExpiryGc {
   compactAt: number;
 }
 
+interface CatalogKeys {
+  keys: [string, string];
+}
+
 function pad(ms: number): string {
   return String(Math.max(0, Math.floor(ms))).padStart(13, '0');
 }
 
 function expiredKey(runId: string): string {
   return `expired:${runId}`;
+}
+
+function catalogKeysKey(runId: string): string {
+  return `${CATALOG_KEYS_PREFIX}${encodeURIComponent(runId)}`;
+}
+
+function canonicalCatalogKeys(runId: string, keys: unknown): [string, string] {
+  if (!Array.isArray(keys) || keys.length !== 2 || keys.some((key) => typeof key !== 'string')) {
+    throw new Error('Run catalog commit requires exactly two string keys');
+  }
+  const suffix = `:${runId}`;
+  const workflowMatch = /^run:(.+):(\d{13}):/.exec(keys[0]);
+  if (
+    workflowMatch === null ||
+    !keys[0].endsWith(suffix) ||
+    keys[0] !== `run:${workflowMatch[1]}:${workflowMatch[2]}${suffix}` ||
+    keys[1] !== `runall:${workflowMatch[2]}${suffix}`
+  ) {
+    throw new Error('Run catalog commit requires the canonical run key pair');
+  }
+  return [keys[0], keys[1]];
 }
 
 function expiryGcKey(runId: string, compactAt: number): string {
@@ -50,7 +76,7 @@ export class RunCatalogDO extends DurableObject {
     serializedMetadata: string,
     publicationExpiresAt: number,
   ): Promise<{ stored: boolean }> {
-    if (keys.length !== 2) throw new Error('Run catalog commit requires exactly two keys');
+    const canonicalKeys = canonicalCatalogKeys(runId, keys);
     return await this.ctx.storage.transaction(async (txn) => {
       if ((await txn.get(expiredKey(runId))) !== undefined) return { stored: false };
       const now = this.now();
@@ -61,7 +87,11 @@ export class RunCatalogDO extends DurableObject {
       ) {
         return { stored: false };
       }
-      await txn.put(Object.fromEntries(keys.map((key) => [key, serializedMetadata])));
+      await txn.put({
+        [canonicalKeys[0]]: serializedMetadata,
+        [canonicalKeys[1]]: serializedMetadata,
+        [catalogKeysKey(runId)]: { keys: canonicalKeys } satisfies CatalogKeys,
+      });
       return { stored: true };
     });
   }
@@ -74,7 +104,9 @@ export class RunCatalogDO extends DurableObject {
         : MAX_INDEX_LIST_SIZE;
     const limit = Math.min(MAX_INDEX_LIST_SIZE, Math.max(1, requestedLimit));
     const entries = await this.ctx.storage.list<string>({
-      prefix: options.prefix ?? '',
+      // The shard also owns internal expiry metadata. An unprefixed catalog
+      // read means all public run/runall entries, never internal records.
+      prefix: options.prefix || 'run',
       ...(options.reverse
         ? { reverse: true, end: options.cursor ?? options.end }
         : { startAfter: options.cursor, end: options.end }),
@@ -104,20 +136,21 @@ export class RunCatalogDO extends DurableObject {
     });
   }
 
-  async expireRun(
-    runId: string,
-    keys: string[],
-    expiredAt: number,
-  ): Promise<ExpireRunIndexesResult> {
-    if (keys.length !== 2) throw new Error('Run catalog expiry requires exactly two keys');
+  async expireRun(runId: string, expiredAt: number): Promise<ExpireRunIndexesResult> {
     return await this.ctx.storage.transaction(async (txn) => {
+      const storedKeysKey = catalogKeysKey(runId);
+      const storedKeys = await txn.get<CatalogKeys>(storedKeysKey);
+      if (storedKeys === undefined) return { deleted: 0 };
+      const canonicalKeys = canonicalCatalogKeys(runId, storedKeys.keys);
       const marker = expiredKey(runId);
       const existing = await txn.get<CatalogExpiryFence>(marker);
       const compactAt = existing?.compactAt ?? this.now() + CATALOG_FENCE_GRACE_MS;
       await txn.put<CatalogExpiryFence>(marker, { expiredAt, compactAt });
       await txn.put<CatalogExpiryGc>(expiryGcKey(runId, compactAt), { runId, compactAt });
       await this.armAtMost(txn, compactAt);
-      return { deleted: await txn.delete(keys) };
+      const deleted = await txn.delete(canonicalKeys);
+      await txn.delete(storedKeysKey);
+      return { deleted };
     });
   }
 

--- a/src/worker/durable-objects/WorkflowRunDO.ts
+++ b/src/worker/durable-objects/WorkflowRunDO.ts
@@ -52,6 +52,12 @@ import {
   workflowRunIndexKey,
 } from '../../retention.js';
 import { MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS } from '../../lifecycle.js';
+import {
+  isNonNegativeSafeInteger,
+  isPositiveSafeInteger,
+  isRecord,
+  MAX_QUEUE_SHARDS,
+} from '../../validation.js';
 
 interface CellId {
   toString(): string;
@@ -110,7 +116,34 @@ const QUEUE_REFERENCES_PER_CLEANUP_PAGE = 64;
 const CLEANUP_RETRY_MAX_MS = 60 * 60 * 1000;
 const CLEANUP_PROGRESS_KEY = 'retention:progress';
 const RUN_QUEUE_SHARDS_KEY = 'retention:queue-shards';
+const MAX_DATE_MS = 8_640_000_000_000_000;
 type TerminalRun = Extract<WorkflowRun, { status: 'completed' | 'failed' | 'cancelled' }>;
+
+function validateCleanupRequest(request: unknown, allowDisabled: boolean): ScheduleCleanupRequest {
+  if (!isRecord(request)) {
+    throw new Error('world-celld retention request must be an object');
+  }
+  const validRetention = allowDisabled
+    ? isNonNegativeSafeInteger(request.retentionMs)
+    : isPositiveSafeInteger(request.retentionMs);
+  if (!validRetention) {
+    throw new Error(
+      `world-celld retentionMs must be a ${allowDisabled ? 'non-negative' : 'positive'} safe integer`,
+    );
+  }
+  if (!isPositiveSafeInteger(request.queueShards) || request.queueShards > MAX_QUEUE_SHARDS) {
+    throw new Error(`world-celld retention queueShards must be between 1 and ${MAX_QUEUE_SHARDS}`);
+  }
+  return request as unknown as ScheduleCleanupRequest;
+}
+
+function retentionDeadline(baseMs: number, retentionMs: number, runId: string): number {
+  const dueAtMs = baseMs + retentionMs;
+  if (!Number.isSafeInteger(dueAtMs) || dueAtMs > MAX_DATE_MS) {
+    throw new Error(`world-celld retention deadline is out of range for ${runId}`);
+  }
+  return dueAtMs;
+}
 
 function cleanupRecord(
   run: WorkflowRun,
@@ -250,6 +283,7 @@ export class WorkflowRunDO extends DurableObject {
 
   /** Apply an event and capture all retention metadata in the same transaction. */
   async applyEvent(request: ApplyEventRequest): Promise<ApplyEventOutcome> {
+    if (request.cleanup !== undefined) validateCleanupRequest(request.cleanup, true);
     return await this.ctx.storage.transaction(async (txn) => {
       const now = new Date(this.now());
       const retention = await this.retentionState(txn, now.getTime());
@@ -297,7 +331,9 @@ export class WorkflowRunDO extends DurableObject {
         !retention.cleanup
       ) {
         const terminalRun = outcome.run as TerminalRun;
-        const dueAt = new Date(terminalRun.completedAt.getTime() + retentionMs);
+        const dueAt = new Date(
+          retentionDeadline(terminalRun.completedAt.getTime(), retentionMs, terminalRun.runId),
+        );
         const run = WorkflowRunSchema.parse({ ...terminalRun, expiredAt: dueAt }) as TerminalRun;
         const cleanup = cleanupRecord(
           run,
@@ -446,7 +482,7 @@ export class WorkflowRunDO extends DurableObject {
 
   /** Explicitly schedule an existing terminal run, used for opt-in backfills. */
   async scheduleCleanup(request: ScheduleCleanupRequest): Promise<CleanupRecord | null> {
-    if (request.retentionMs <= 0) return this.getCleanupStatus();
+    request = validateCleanupRequest(request, false);
     return await this.ctx.storage.transaction(async (txn) => {
       const values = await txn.get<
         CleanupRecord | RunTombstone | TerminalCleanupRecord | WorkflowRun
@@ -457,7 +493,13 @@ export class WorkflowRunDO extends DurableObject {
       const current = values.get('run') as WorkflowRun | undefined;
       if (!current || !isTerminalWorkflowRunStatus(current.status)) return null;
       const terminalRun = current as TerminalRun;
-      const dueAt = new Date(terminalRun.completedAt.getTime() + request.retentionMs);
+      const dueAt = new Date(
+        retentionDeadline(
+          terminalRun.completedAt.getTime(),
+          request.retentionMs,
+          terminalRun.runId,
+        ),
+      );
       const run = WorkflowRunSchema.parse({ ...terminalRun, expiredAt: dueAt }) as TerminalRun;
       const cleanup = cleanupRecord(run, dueAt, request.queueShards, 'manual');
       await txn.put('run', run);
@@ -477,12 +519,7 @@ export class WorkflowRunDO extends DurableObject {
    * becomes an authoritative write/read fence, including for active runs.
    */
   async enforceRetention(request: EnforceRetentionRequest): Promise<EnforceRetentionResult> {
-    if (!Number.isSafeInteger(request.retentionMs) || request.retentionMs <= 0) {
-      throw new Error('world-celld retentionMs must be a positive safe integer');
-    }
-    if (!Number.isSafeInteger(request.queueShards) || request.queueShards <= 0) {
-      throw new Error('world-celld retention queueShards must be a positive safe integer');
-    }
+    validateCleanupRequest(request, false);
     if (!Number.isSafeInteger(request.scheduledTime) || request.scheduledTime < 0) {
       throw new Error('world-celld retention scheduledTime must be a non-negative safe integer');
     }
@@ -504,10 +541,7 @@ export class WorkflowRunDO extends DurableObject {
 
       const run = values.get('run') as WorkflowRun | undefined;
       if (!run) return { state: 'missing', cleanup: null } satisfies EnforceRetentionResult;
-      const dueAtMs = run.createdAt.getTime() + request.retentionMs;
-      if (!Number.isSafeInteger(dueAtMs) || dueAtMs > 8_640_000_000_000_000) {
-        throw new Error(`world-celld retention deadline is out of range for ${run.runId}`);
-      }
+      const dueAtMs = retentionDeadline(run.createdAt.getTime(), request.retentionMs, run.runId);
       if (dueAtMs > request.scheduledTime) {
         return { state: 'not-due', cleanup: null } satisfies EnforceRetentionResult;
       }
@@ -562,8 +596,9 @@ export class WorkflowRunDO extends DurableObject {
   }
 
   async cleanupNow(request: ScheduleCleanupRequest): Promise<CleanupRecord | null> {
+    request = validateCleanupRequest(request, false);
     if (!(await this.ctx.storage.get<CleanupRecord>(CLEANUP_RECORD_KEY))) {
-      await this.scheduleCleanup({ ...request, retentionMs: Math.max(1, request.retentionMs) });
+      await this.scheduleCleanup(request);
     }
     await this.ctx.storage.transaction(async (txn) => {
       const cleanup = await txn.get<CleanupRecord>(CLEANUP_RECORD_KEY);

--- a/src/worker/durable-objects/WorkflowRunDO.ts
+++ b/src/worker/durable-objects/WorkflowRunDO.ts
@@ -52,12 +52,7 @@ import {
   workflowRunIndexKey,
 } from '../../retention.js';
 import { MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS } from '../../lifecycle.js';
-import {
-  isNonNegativeSafeInteger,
-  isPositiveSafeInteger,
-  isRecord,
-  MAX_QUEUE_SHARDS,
-} from '../../validation.js';
+import { isNonNegativeSafeInteger, isPositiveSafeInteger, isRecord } from '../../validation.js';
 
 interface CellId {
   toString(): string;
@@ -131,8 +126,8 @@ function validateCleanupRequest(request: unknown, allowDisabled: boolean): Sched
       `world-celld retentionMs must be a ${allowDisabled ? 'non-negative' : 'positive'} safe integer`,
     );
   }
-  if (!isPositiveSafeInteger(request.queueShards) || request.queueShards > MAX_QUEUE_SHARDS) {
-    throw new Error(`world-celld retention queueShards must be between 1 and ${MAX_QUEUE_SHARDS}`);
+  if (!isPositiveSafeInteger(request.queueShards)) {
+    throw new Error('world-celld retention queueShards must be a positive safe integer');
   }
   return request as unknown as ScheduleCleanupRequest;
 }

--- a/src/worker/durable-objects/WorkflowRunDO.ts
+++ b/src/worker/durable-objects/WorkflowRunDO.ts
@@ -37,7 +37,6 @@ import {
   type ExpireStreamResult,
   type FinalizeRunStreamsResult,
   expiredRead,
-  globalRunIndexKey,
   HOOK_MARKER_PREFIX,
   type HookIndexReference,
   hookMarkerKey,
@@ -49,7 +48,6 @@ import {
   TERMINAL_CLEANUP_KEY,
   type TerminalCleanupRecord,
   TOMBSTONE_KEY,
-  workflowRunIndexKey,
 } from '../../retention.js';
 import { MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS } from '../../lifecycle.js';
 import { isNonNegativeSafeInteger, isPositiveSafeInteger, isRecord } from '../../validation.js';
@@ -871,7 +869,6 @@ export class WorkflowRunDO extends DurableObject {
     const hookMarkers = Array.from(hookEntries).slice(0, HOOK_MARKER_PAGE_SIZE);
     await this.workflowIndex().expireRun({
       runId: cleanup.runId,
-      keys: [workflowRunIndexKey(cleanup), globalRunIndexKey(cleanup)],
       hooks: hookMarkers.map(([, value]) => value),
       expiredAt: cleanup.dueAt.getTime(),
     });

--- a/src/worker/index-validation.ts
+++ b/src/worker/index-validation.ts
@@ -96,6 +96,11 @@ function hooks(value: unknown): Array<{ hookId: string; token: string }> {
   });
 }
 
+function exactProperties(value: Record<string, unknown>, allowed: string[], name: string): void {
+  const unexpected = Object.keys(value).find((key) => !allowed.includes(key));
+  if (unexpected !== undefined) invalid(`${name}.${unexpected} is not allowed`);
+}
+
 function releaseRequest(value: unknown): ReleaseHookIndexesRequest {
   if (!isRecord(value)) invalid('release request must be an object');
   return {
@@ -106,17 +111,9 @@ function releaseRequest(value: unknown): ReleaseHookIndexesRequest {
 
 function expireRequest(value: unknown): ExpireRunIndexesRequest {
   if (!isRecord(value)) invalid('expiry request must be an object');
-  if (!Array.isArray(value.keys) || value.keys.length !== 2) {
-    invalid('request.keys must contain exactly two keys');
-  }
-  const runId = nonEmptyString(value.runId, 'request.runId');
-  const keys = value.keys.map((key, index) => nonEmptyString(key, `request.keys[${index}]`));
-  if (!keys.every((key) => key.endsWith(`:${runId}`))) {
-    invalid('request.keys must belong to request.runId');
-  }
+  exactProperties(value, ['runId', 'hooks', 'expiredAt'], 'request');
   return {
-    runId,
-    keys,
+    runId: nonEmptyString(value.runId, 'request.runId'),
     hooks: hooks(value.hooks),
     expiredAt: nonNegativeSafeInteger(value.expiredAt, 'request.expiredAt'),
   };

--- a/src/worker/index-validation.ts
+++ b/src/worker/index-validation.ts
@@ -1,0 +1,249 @@
+import { HookSchema, WorkflowRunSchema, type WorkflowRun } from '@workflow/world';
+import type { HookTokenOwner } from '../config.js';
+import type { HookReservation, IndexListOptions } from '../indexes.js';
+import type { ExpireRunIndexesRequest, ReleaseHookIndexesRequest } from '../retention.js';
+import { isRecord } from '../validation.js';
+import { parse } from '../vendor/shared/index.js';
+
+export type IndexOperation =
+  | 'runs.list'
+  | 'runs.commit'
+  | 'runs.expire'
+  | 'hooks.reserve'
+  | 'hooks.finalize'
+  | 'hooks.release-reservation'
+  | 'hooks.release';
+
+export type ValidatedIndexRequest =
+  | { operation: 'runs.list'; args: [IndexListOptions | undefined] }
+  | { operation: 'runs.commit'; args: [WorkflowRun, string, number] }
+  | { operation: 'runs.expire'; args: [ExpireRunIndexesRequest] }
+  | { operation: 'hooks.reserve'; args: [string, HookTokenOwner] }
+  | {
+      operation: 'hooks.finalize';
+      args: [string, string, string, HookTokenOwner, HookReservation | undefined];
+    }
+  | {
+      operation: 'hooks.release-reservation';
+      args: [string, HookTokenOwner, HookReservation];
+    }
+  | { operation: 'hooks.release'; args: [ReleaseHookIndexesRequest] };
+
+function invalid(message: string): never {
+  const error = new Error(`invalid index RPC arguments: ${message}`);
+  error.name = 'RequestValidationError';
+  throw error;
+}
+
+function exactArgs(args: unknown[], count: number): void {
+  if (args.length !== count) invalid(`expected ${count} argument(s)`);
+}
+
+function nonEmptyString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value.length === 0)
+    invalid(`${name} must be a non-empty string`);
+  return value;
+}
+
+function stringValue(value: unknown, name: string): string {
+  if (typeof value !== 'string') invalid(`${name} must be a string`);
+  return value;
+}
+
+function nonNegativeSafeInteger(value: unknown, name: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    invalid(`${name} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function positiveSafeInteger(value: unknown, name: string): number {
+  const parsed = nonNegativeSafeInteger(value, name);
+  if (parsed === 0) invalid(`${name} must be a positive safe integer`);
+  return parsed;
+}
+
+function owner(value: unknown, name = 'owner'): HookTokenOwner {
+  if (!isRecord(value)) invalid(`${name} must be an object`);
+  return {
+    runId: nonEmptyString(value.runId, `${name}.runId`),
+    hookId: nonEmptyString(value.hookId, `${name}.hookId`),
+  };
+}
+
+function reservation(value: unknown): HookReservation {
+  if (!isRecord(value)) invalid('reservation must be an object');
+  const parsed: HookReservation = {
+    claimId: nonEmptyString(value.claimId, 'reservation.claimId'),
+  };
+  if (value.tokenClaimId !== undefined) {
+    parsed.tokenClaimId = nonEmptyString(value.tokenClaimId, 'reservation.tokenClaimId');
+  }
+  if (value.hookIdClaimId !== undefined) {
+    parsed.hookIdClaimId = nonEmptyString(value.hookIdClaimId, 'reservation.hookIdClaimId');
+  }
+  return parsed;
+}
+
+function hooks(value: unknown): Array<{ hookId: string; token: string }> {
+  if (!Array.isArray(value)) invalid('hooks must be an array');
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) invalid(`hooks[${index}] must be an object`);
+    return {
+      hookId: nonEmptyString(entry.hookId, `hooks[${index}].hookId`),
+      token: nonEmptyString(entry.token, `hooks[${index}].token`),
+    };
+  });
+}
+
+function releaseRequest(value: unknown): ReleaseHookIndexesRequest {
+  if (!isRecord(value)) invalid('release request must be an object');
+  return {
+    runId: nonEmptyString(value.runId, 'request.runId'),
+    hooks: hooks(value.hooks),
+  };
+}
+
+function expireRequest(value: unknown): ExpireRunIndexesRequest {
+  if (!isRecord(value)) invalid('expiry request must be an object');
+  if (!Array.isArray(value.keys) || value.keys.length !== 2) {
+    invalid('request.keys must contain exactly two keys');
+  }
+  const runId = nonEmptyString(value.runId, 'request.runId');
+  const keys = value.keys.map((key, index) => nonEmptyString(key, `request.keys[${index}]`));
+  if (!keys.every((key) => key.endsWith(`:${runId}`))) {
+    invalid('request.keys must belong to request.runId');
+  }
+  return {
+    runId,
+    keys,
+    hooks: hooks(value.hooks),
+    expiredAt: nonNegativeSafeInteger(value.expiredAt, 'request.expiredAt'),
+  };
+}
+
+function listOptions(value: unknown): IndexListOptions | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) invalid('list options must be an object');
+  const parsed: IndexListOptions = {};
+  for (const name of ['prefix', 'cursor', 'end'] as const) {
+    if (value[name] !== undefined) parsed[name] = stringValue(value[name], `options.${name}`);
+  }
+  if (value.limit !== undefined) {
+    const limit = value.limit;
+    if (!Number.isSafeInteger(limit) || (limit as number) < 1 || (limit as number) > 1000) {
+      invalid('options.limit must be an integer between 1 and 1000');
+    }
+    parsed.limit = limit as number;
+  }
+  if (value.reverse !== undefined) {
+    if (typeof value.reverse !== 'boolean') invalid('options.reverse must be a boolean');
+    parsed.reverse = value.reverse;
+  }
+  return parsed;
+}
+
+function runCommit(args: unknown[]): ValidatedIndexRequest {
+  exactArgs(args, 3);
+  const parsedRun = WorkflowRunSchema.safeParse(args[0]);
+  if (!parsedRun.success) invalid('run does not match WorkflowRunSchema');
+  const run = parsedRun.data;
+  nonEmptyString(run.runId, 'run.runId');
+  nonEmptyString(run.workflowName, 'run.workflowName');
+  nonEmptyString(run.deploymentId, 'run.deploymentId');
+  const serializedMetadata = nonEmptyString(args[1], 'serializedMetadata');
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(serializedMetadata);
+  } catch {
+    invalid('serializedMetadata must be valid JSON');
+  }
+  if (
+    !isRecord(metadata) ||
+    metadata.runId !== run.runId ||
+    metadata.status !== run.status ||
+    metadata.createdAt !== run.createdAt.toISOString()
+  ) {
+    invalid('serializedMetadata must match the committed run');
+  }
+  const publicationExpiresAt = positiveSafeInteger(args[2], 'publicationExpiresAt');
+  return { operation: 'runs.commit', args: [run, serializedMetadata, publicationExpiresAt] };
+}
+
+function hookFinalize(args: unknown[]): ValidatedIndexRequest {
+  if (args.length !== 4 && args.length !== 5) invalid('expected 4 or 5 arguments');
+  const token = nonEmptyString(args[0], 'token');
+  const hookId = nonEmptyString(args[1], 'hookId');
+  const serializedHook = nonEmptyString(args[2], 'serializedHook');
+  const hookOwner = owner(args[3]);
+  if (hookOwner.hookId !== hookId) invalid('owner.hookId must match hookId');
+  let decodedHook: unknown;
+  try {
+    decodedHook = parse<unknown>(serializedHook);
+  } catch {
+    invalid('serializedHook must be valid tagged JSON');
+  }
+  const parsedHook = HookSchema.safeParse(decodedHook);
+  if (!parsedHook.success) invalid('serializedHook does not match HookSchema');
+  if (
+    parsedHook.data.runId !== hookOwner.runId ||
+    parsedHook.data.hookId !== hookId ||
+    parsedHook.data.token !== token ||
+    !parsedHook.data.runId ||
+    !parsedHook.data.hookId ||
+    !parsedHook.data.token
+  ) {
+    invalid('serializedHook must match token, hookId, and owner');
+  }
+  const hookReservation =
+    args[4] === undefined || args[4] === null ? undefined : reservation(args[4]);
+  return {
+    operation: 'hooks.finalize',
+    args: [token, hookId, serializedHook, hookOwner, hookReservation],
+  };
+}
+
+export function validateIndexRequest(
+  operation: IndexOperation,
+  args: unknown[],
+): ValidatedIndexRequest {
+  switch (operation) {
+    case 'runs.list':
+      if (args.length > 1) invalid('expected at most 1 argument');
+      return { operation, args: [listOptions(args[0])] };
+    case 'runs.commit':
+      return runCommit(args);
+    case 'runs.expire':
+      exactArgs(args, 1);
+      return { operation, args: [expireRequest(args[0])] };
+    case 'hooks.reserve':
+      exactArgs(args, 2);
+      return {
+        operation,
+        args: [nonEmptyString(args[0], 'token'), owner(args[1])],
+      };
+    case 'hooks.finalize':
+      return hookFinalize(args);
+    case 'hooks.release-reservation':
+      exactArgs(args, 3);
+      return {
+        operation,
+        args: [nonEmptyString(args[0], 'token'), owner(args[1]), reservation(args[2])],
+      };
+    case 'hooks.release':
+      exactArgs(args, 1);
+      return { operation, args: [releaseRequest(args[0])] };
+    default:
+      return invalid('unknown operation');
+  }
+}
+
+export const INDEX_OPERATIONS = new Set<IndexOperation>([
+  'runs.list',
+  'runs.commit',
+  'runs.expire',
+  'hooks.reserve',
+  'hooks.finalize',
+  'hooks.release-reservation',
+  'hooks.release',
+]);

--- a/src/worker/retention-sweep.ts
+++ b/src/worker/retention-sweep.ts
@@ -3,7 +3,6 @@ import {
   type CellNamespaceLike,
   type HookIdShardStub,
   type HookTokenShardStub,
-  runCatalogShardName,
   type RunCatalogShardStub,
 } from '../indexes.js';
 import {
@@ -11,7 +10,7 @@ import {
   type EnforceRetentionRequest,
   type EnforceRetentionResult,
 } from '../retention.js';
-import { isRecord, MAX_QUEUE_SHARDS, strictIntegerSetting } from '../validation.js';
+import { isRecord, strictIntegerSetting } from '../validation.js';
 
 export const DEFAULT_RETENTION_SWEEP_BATCH_SIZE = 128;
 export const MAX_RETENTION_SWEEP_BATCH_SIZE = 1000;
@@ -45,6 +44,8 @@ export interface RetentionSweepResult {
   missing: number;
   notDue: number;
   invalid: number;
+  /** Candidates preserved because their exact catalog value changed during the sweep. */
+  preserved: number;
 }
 
 function requireNamespace<T>(
@@ -105,6 +106,7 @@ export async function runRetentionSweep(
       missing: 0,
       notDue: 0,
       invalid: 0,
+      preserved: 0,
     };
   }
   const batchSize = strictIntegerSetting(
@@ -119,7 +121,6 @@ export async function runRetentionSweep(
     env.WORKFLOW_RETENTION_QUEUE_SHARDS,
     1,
     1,
-    MAX_QUEUE_SHARDS,
   );
   const cutoff = scheduledTime - retentionMs;
   const runNamespace = requireNamespace('WORKFLOW_DB', env.WORKFLOW_DB);
@@ -144,6 +145,7 @@ export async function runRetentionSweep(
     missing: 0,
     notDue: 0,
     invalid: 0,
+    preserved: 0,
   };
   const failures: unknown[] = [];
   for (let offset = 0; offset < page.keys.length; offset += RETENTION_SWEEP_CONCURRENCY) {
@@ -151,19 +153,21 @@ export async function runRetentionSweep(
     const settled = await Promise.allSettled(
       candidates.map(async (entry) => {
         const { runId, invalid } = catalogCandidate(entry.name, entry.value);
-        const catalog = catalogNamespace.get(
-          catalogNamespace.idFromName(runCatalogShardName(runId)),
-        );
+        if (!entry.sourceShard) {
+          throw new Error('world-celld: merged run catalog entry omitted its source shard');
+        }
+        const catalog = catalogNamespace.get(catalogNamespace.idFromName(entry.sourceShard));
         if (invalid) {
-          await catalog.deleteStaleGlobalRun(runId, entry.name, entry.value);
-          return { state: 'invalid' } as const;
+          const deleted = await catalog.deleteStaleGlobalRun(runId, entry.name, entry.value);
+          return { state: 'invalid', preserved: !deleted.deleted } as const;
         }
         const run = runNamespace.get(runNamespace.idFromName(runId));
         const outcome = await run.enforceRetention({ retentionMs, queueShards, scheduledTime });
         if (outcome.state === 'missing' || outcome.state === 'not-due') {
-          await catalog.deleteStaleGlobalRun(runId, entry.name, entry.value);
+          const deleted = await catalog.deleteStaleGlobalRun(runId, entry.name, entry.value);
+          return { state: outcome.state, preserved: !deleted.deleted };
         }
-        return outcome;
+        return { state: outcome.state, preserved: false };
       }),
     );
     for (const outcome of settled) {
@@ -171,6 +175,7 @@ export async function runRetentionSweep(
         failures.push(outcome.reason);
       } else {
         result[outcome.value.state === 'not-due' ? 'notDue' : outcome.value.state]++;
+        if (outcome.value.preserved) result.preserved++;
       }
     }
   }

--- a/src/worker/retention-sweep.ts
+++ b/src/worker/retention-sweep.ts
@@ -11,6 +11,7 @@ import {
   type EnforceRetentionRequest,
   type EnforceRetentionResult,
 } from '../retention.js';
+import { isRecord, MAX_QUEUE_SHARDS, strictIntegerSetting } from '../validation.js';
 
 export const DEFAULT_RETENTION_SWEEP_BATCH_SIZE = 128;
 export const MAX_RETENTION_SWEEP_BATCH_SIZE = 1000;
@@ -43,28 +44,38 @@ export interface RetentionSweepResult {
   expired: number;
   missing: number;
   notDue: number;
+  invalid: number;
 }
 
-function integerSetting(
-  name: string,
-  raw: string | number | undefined,
-  fallback: number,
-  minimum: number,
-  maximum = Number.MAX_SAFE_INTEGER,
-): number {
-  const value = raw === undefined || raw === '' ? fallback : Number(raw);
-  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
-    throw new Error(`world-celld: ${name} must be an integer between ${minimum} and ${maximum}`);
+function requireNamespace<T>(
+  name: keyof Pick<
+    RetentionSweepEnv,
+    'WORKFLOW_DB' | 'WORKFLOW_RUN_CATALOG' | 'WORKFLOW_HOOK_TOKENS' | 'WORKFLOW_HOOK_IDS'
+  >,
+  namespace: RetentionNamespace<T> | undefined,
+): RetentionNamespace<T> {
+  if (
+    !namespace ||
+    typeof namespace.idFromName !== 'function' ||
+    typeof namespace.get !== 'function'
+  ) {
+    throw new Error(`world-celld retention sweep missing binding ${name}`);
   }
-  return value;
+  return namespace;
 }
 
-function runIdFromCatalogValue(value: string): string {
-  const parsed = JSON.parse(value) as { runId?: unknown };
-  if (typeof parsed.runId !== 'string' || parsed.runId.length === 0) {
-    throw new Error('world-celld: run catalog entry has no runId');
+function catalogCandidate(name: string, value: string): { runId: string; invalid: boolean } {
+  const keyMatch = /^runall:\d{13}:(.+)$/.exec(name);
+  if (!keyMatch?.[1]) {
+    throw new Error('world-celld: run catalog entry has an invalid global key');
   }
-  return parsed.runId;
+  const runId = keyMatch[1];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return { runId, invalid: !isRecord(parsed) || parsed.runId !== runId };
+  } catch {
+    return { runId, invalid: true };
+  }
 }
 
 /**
@@ -78,7 +89,12 @@ export async function runRetentionSweep(
   if (!Number.isSafeInteger(scheduledTime) || scheduledTime < 0) {
     throw new Error('world-celld: scheduledTime must be a non-negative safe integer');
   }
-  const retentionMs = integerSetting('WORKFLOW_RETENTION_MS', env.WORKFLOW_RETENTION_MS, 0, 0);
+  const retentionMs = strictIntegerSetting(
+    'world-celld: WORKFLOW_RETENTION_MS',
+    env.WORKFLOW_RETENTION_MS,
+    0,
+    0,
+  );
   if (retentionMs === 0 || scheduledTime < retentionMs) {
     return {
       disabled: retentionMs === 0,
@@ -88,26 +104,30 @@ export async function runRetentionSweep(
       expired: 0,
       missing: 0,
       notDue: 0,
+      invalid: 0,
     };
   }
-  const batchSize = integerSetting(
-    'WORKFLOW_RETENTION_BATCH_SIZE',
+  const batchSize = strictIntegerSetting(
+    'world-celld: WORKFLOW_RETENTION_BATCH_SIZE',
     env.WORKFLOW_RETENTION_BATCH_SIZE,
     DEFAULT_RETENTION_SWEEP_BATCH_SIZE,
     1,
     MAX_RETENTION_SWEEP_BATCH_SIZE,
   );
-  const queueShards = integerSetting(
-    'WORKFLOW_RETENTION_QUEUE_SHARDS',
+  const queueShards = strictIntegerSetting(
+    'world-celld: WORKFLOW_RETENTION_QUEUE_SHARDS',
     env.WORKFLOW_RETENTION_QUEUE_SHARDS,
     1,
     1,
+    MAX_QUEUE_SHARDS,
   );
   const cutoff = scheduledTime - retentionMs;
+  const runNamespace = requireNamespace('WORKFLOW_DB', env.WORKFLOW_DB);
+  const catalogNamespace = requireNamespace('WORKFLOW_RUN_CATALOG', env.WORKFLOW_RUN_CATALOG);
   const index = createWorkflowIndex({
-    runCatalog: env.WORKFLOW_RUN_CATALOG,
-    hookTokens: env.WORKFLOW_HOOK_TOKENS,
-    hookIds: env.WORKFLOW_HOOK_IDS,
+    runCatalog: catalogNamespace,
+    hookTokens: requireNamespace('WORKFLOW_HOOK_TOKENS', env.WORKFLOW_HOOK_TOKENS),
+    hookIds: requireNamespace('WORKFLOW_HOOK_IDS', env.WORKFLOW_HOOK_IDS),
   });
   const page = await index.listRuns({
     prefix: 'runall:',
@@ -123,19 +143,24 @@ export async function runRetentionSweep(
     expired: 0,
     missing: 0,
     notDue: 0,
+    invalid: 0,
   };
   const failures: unknown[] = [];
   for (let offset = 0; offset < page.keys.length; offset += RETENTION_SWEEP_CONCURRENCY) {
     const candidates = page.keys.slice(offset, offset + RETENTION_SWEEP_CONCURRENCY);
     const settled = await Promise.allSettled(
       candidates.map(async (entry) => {
-        const runId = runIdFromCatalogValue(entry.value);
-        const run = env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName(runId));
+        const { runId, invalid } = catalogCandidate(entry.name, entry.value);
+        const catalog = catalogNamespace.get(
+          catalogNamespace.idFromName(runCatalogShardName(runId)),
+        );
+        if (invalid) {
+          await catalog.deleteStaleGlobalRun(runId, entry.name, entry.value);
+          return { state: 'invalid' } as const;
+        }
+        const run = runNamespace.get(runNamespace.idFromName(runId));
         const outcome = await run.enforceRetention({ retentionMs, queueShards, scheduledTime });
         if (outcome.state === 'missing' || outcome.state === 'not-due') {
-          const catalog = env.WORKFLOW_RUN_CATALOG.get(
-            env.WORKFLOW_RUN_CATALOG.idFromName(runCatalogShardName(runId)),
-          );
           await catalog.deleteStaleGlobalRun(runId, entry.name, entry.value);
         }
         return outcome;

--- a/src/worker/router.ts
+++ b/src/worker/router.ts
@@ -132,6 +132,40 @@ function errorResponse(status: number, name: string, message: string): Response 
   return Response.json({ error: { name, message } }, { status });
 }
 
+function hasContentType(request: Request, expected: string): boolean {
+  return (
+    request.headers.get('content-type')?.split(';', 1)[0].trim().toLowerCase() ===
+    expected.toLowerCase()
+  );
+}
+
+function declaredContentLength(request: Request): number | null {
+  const raw = request.headers.get('content-length');
+  if (raw === null) return null;
+  if (!/^\d+$/.test(raw)) {
+    const error = new Error('content-length must be a non-negative integer');
+    error.name = 'RequestValidationError';
+    throw error;
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    const error = new Error('content-length is out of range');
+    error.name = 'RequestValidationError';
+    throw error;
+  }
+  return value;
+}
+
+function decodePathComponent(value: string, name: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    const error = new Error(`${name} has malformed percent encoding`);
+    error.name = 'RequestValidationError';
+    throw error;
+  }
+}
+
 async function readBoundedBody(request: Request): Promise<string | null> {
   if (!request.body) return '';
   const reader = request.body.getReader();
@@ -185,7 +219,7 @@ async function readBoundedBytes(request: Request, maxBytes: number): Promise<Uin
 
 function parseBoundedInteger(url: URL, name: string, minimum: number, maximum: number): number {
   const raw = url.searchParams.get(name);
-  const value = raw === null ? Number.NaN : Number(raw);
+  const value = raw !== null && /^\d+$/.test(raw) ? Number(raw) : Number.NaN;
   if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
     const error = new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
     error.name = 'StreamProtocolError';
@@ -211,6 +245,9 @@ export function createRouter(env: WorkerEnv) {
     }
 
     if (parts[1] === 'health' && parts.length === 2) {
+      if (request.method !== 'GET') {
+        return errorResponse(405, 'MethodNotAllowed', 'expected GET');
+      }
       return Response.json({
         ok: true,
         name: WORLD_NAME,
@@ -228,8 +265,25 @@ export function createRouter(env: WorkerEnv) {
       if (request.method !== 'POST') {
         return errorResponse(405, 'MethodNotAllowed', 'expected POST');
       }
-      const contentLength = Number(request.headers.get('content-length') ?? '0');
-      if (contentLength > MAX_BODY_BYTES) {
+      if (!hasContentType(request, 'application/json')) {
+        return errorResponse(415, 'UnsupportedMediaType', 'expected application/json');
+      }
+      for (const required of [
+        'WORKFLOW_RUN_CATALOG',
+        'WORKFLOW_HOOK_TOKENS',
+        'WORKFLOW_HOOK_IDS',
+      ] as const) {
+        if (!env[required]) {
+          return errorResponse(500, 'WorldMisconfigured', `missing binding: ${required}`);
+        }
+      }
+      let contentLength: number | null;
+      try {
+        contentLength = declaredContentLength(request);
+      } catch (error) {
+        return errorResponse(400, 'BadRequest', (error as Error).message);
+      }
+      if (contentLength !== null && contentLength > MAX_BODY_BYTES) {
         return errorResponse(413, 'PayloadTooLarge', `body exceeds ${MAX_BODY_BYTES} bytes`);
       }
       let args: unknown[];
@@ -301,25 +355,22 @@ export function createRouter(env: WorkerEnv) {
     }
 
     if (parts[1] === 'streams' && parts.length === 4 && parts[3] === 'chunks') {
-      const namespace = env.WORKFLOW_STREAMS;
-      if (!namespace) {
-        return errorResponse(500, 'WorldMisconfigured', 'missing binding: WORKFLOW_STREAMS');
-      }
-      const name = decodeURIComponent(parts[2]);
       const runId = url.searchParams.get('runId');
       if (!runId) return errorResponse(400, 'BadRequest', 'runId is required');
-      const stub = namespace.get(namespace.idFromName(name)) as {
-        writeChunks(runId: string, chunks: Uint8Array[]): Promise<StreamWriteResult>;
-        readChunks(request: StreamReadRequest, signal?: AbortSignal): Promise<StreamReadResult>;
-      };
+      let name: string;
+      try {
+        name = decodePathComponent(parts[2], 'stream name');
+      } catch (error) {
+        return errorResponse(400, 'BadRequest', (error as Error).message);
+      }
 
       try {
         if (request.method === 'POST') {
-          if (!request.headers.get('content-type')?.startsWith(STREAM_BATCH_CONTENT_TYPE)) {
+          if (!hasContentType(request, STREAM_BATCH_CONTENT_TYPE)) {
             return errorResponse(415, 'UnsupportedMediaType', STREAM_BATCH_CONTENT_TYPE);
           }
-          const contentLength = Number(request.headers.get('content-length') ?? '0');
-          if (contentLength > MAX_STREAM_WRITE_BODY_BYTES) {
+          const contentLength = declaredContentLength(request);
+          if (contentLength !== null && contentLength > MAX_STREAM_WRITE_BODY_BYTES) {
             return errorResponse(
               413,
               'PayloadTooLarge',
@@ -334,26 +385,39 @@ export function createRouter(env: WorkerEnv) {
               `body exceeds ${MAX_STREAM_WRITE_BODY_BYTES} bytes`,
             );
           }
-          const result = await stub.writeChunks(runId, decodeStreamWriteBatch(body));
+          const chunks = decodeStreamWriteBatch(body);
+          const namespace = env.WORKFLOW_STREAMS;
+          if (!namespace) {
+            return errorResponse(500, 'WorldMisconfigured', 'missing binding: WORKFLOW_STREAMS');
+          }
+          const stub = namespace.get(namespace.idFromName(name)) as {
+            writeChunks(runId: string, chunks: Uint8Array[]): Promise<StreamWriteResult>;
+          };
+          const result = await stub.writeChunks(runId, chunks);
           return streamResponse(encodeStreamWriteResult(result));
         }
 
         if (request.method === 'GET') {
-          const result = await stub.readChunks(
-            {
-              runId,
-              startIndex: parseBoundedInteger(url, 'startIndex', 0, 0x7fffffff),
-              maxChunks: parseBoundedInteger(url, 'maxChunks', 0, MAX_STREAM_READ_CHUNKS),
-              maxBytes: parseBoundedInteger(
-                url,
-                'maxBytes',
-                MAX_STREAM_CHUNK_BYTES,
-                MAX_STREAM_READ_BYTES,
-              ),
-              waitMs: parseBoundedInteger(url, 'waitMs', 0, MAX_STREAM_LONG_POLL_MS),
-            },
-            request.signal,
-          );
+          const readRequest = {
+            runId,
+            startIndex: parseBoundedInteger(url, 'startIndex', 0, 0x7fffffff),
+            maxChunks: parseBoundedInteger(url, 'maxChunks', 0, MAX_STREAM_READ_CHUNKS),
+            maxBytes: parseBoundedInteger(
+              url,
+              'maxBytes',
+              MAX_STREAM_CHUNK_BYTES,
+              MAX_STREAM_READ_BYTES,
+            ),
+            waitMs: parseBoundedInteger(url, 'waitMs', 0, MAX_STREAM_LONG_POLL_MS),
+          } satisfies StreamReadRequest;
+          const namespace = env.WORKFLOW_STREAMS;
+          if (!namespace) {
+            return errorResponse(500, 'WorldMisconfigured', 'missing binding: WORKFLOW_STREAMS');
+          }
+          const stub = namespace.get(namespace.idFromName(name)) as {
+            readChunks(request: StreamReadRequest, signal?: AbortSignal): Promise<StreamReadResult>;
+          };
+          const result = await stub.readChunks(readRequest, request.signal);
           return streamResponse(encodeStreamReadResult(result));
         }
 
@@ -368,7 +432,12 @@ export function createRouter(env: WorkerEnv) {
               status: typeof err?.status === 'number' ? err.status : undefined,
             },
           },
-          { status: err?.name === 'StreamProtocolError' ? 400 : 500 },
+          {
+            status:
+              err?.name === 'StreamProtocolError' || err?.name === 'RequestValidationError'
+                ? 400
+                : 500,
+          },
         );
       }
     }
@@ -377,8 +446,11 @@ export function createRouter(env: WorkerEnv) {
       return errorResponse(404, 'NotFound', `unknown path: ${url.pathname}`);
     }
 
-    if (request.method !== 'POST' || parts.length !== 5) {
+    if (parts.length !== 5) {
       return errorResponse(404, 'NotFound', 'expected POST /v1/rpc/{binding}/{name}/{method}');
+    }
+    if (request.method !== 'POST') {
+      return errorResponse(405, 'MethodNotAllowed', 'expected POST');
     }
 
     const [, , bindingKey, encodedName, method] = parts;
@@ -390,8 +462,26 @@ export function createRouter(env: WorkerEnv) {
       return errorResponse(404, 'NotFound', `unknown method: ${bindingKey}.${method}`);
     }
 
-    const contentLength = Number(request.headers.get('content-length') ?? '0');
-    if (contentLength > MAX_BODY_BYTES) {
+    if (!hasContentType(request, 'application/json')) {
+      return errorResponse(415, 'UnsupportedMediaType', 'expected application/json');
+    }
+    let name: string;
+    try {
+      name = decodePathComponent(encodedName, 'Durable Object name');
+    } catch (error) {
+      return errorResponse(400, 'BadRequest', (error as Error).message);
+    }
+    const namespace = env[binding.env] as DONamespaceLike | undefined;
+    if (!namespace) {
+      return errorResponse(500, 'WorldMisconfigured', `missing binding: ${binding.env}`);
+    }
+    let contentLength: number | null;
+    try {
+      contentLength = declaredContentLength(request);
+    } catch (error) {
+      return errorResponse(400, 'BadRequest', (error as Error).message);
+    }
+    if (contentLength !== null && contentLength > MAX_BODY_BYTES) {
       return errorResponse(413, 'PayloadTooLarge', `body exceeds ${MAX_BODY_BYTES} bytes`);
     }
 
@@ -408,12 +498,6 @@ export function createRouter(env: WorkerEnv) {
       args = parsed;
     } catch {
       return errorResponse(400, 'BadRequest', 'malformed rpc body');
-    }
-
-    const name = decodeURIComponent(encodedName);
-    const namespace = env[binding.env] as DONamespaceLike | undefined;
-    if (!namespace) {
-      return errorResponse(500, 'WorldMisconfigured', `missing binding: ${binding.env}`);
     }
 
     try {

--- a/src/worker/router.ts
+++ b/src/worker/router.ts
@@ -11,19 +11,15 @@
  * Generic RPC bodies use the tagged JSON codec. Stream chunk bodies use the
  * compact binary stream protocol. Only whitelisted routes/methods dispatch.
  */
-import { SPEC_VERSION_CURRENT, type WorkflowRun } from '@workflow/world';
+import { SPEC_VERSION_CURRENT } from '@workflow/world';
 import { rpcParse, rpcStringify } from '../codec.js';
-import type { HookTokenOwner } from '../config.js';
 import {
   createWorkflowIndex,
   type CellNamespaceLike,
-  type HookReservation,
   type HookIdShardStub,
   type HookTokenShardStub,
-  type IndexListOptions,
   type RunCatalogShardStub,
 } from '../indexes.js';
-import type { ExpireRunIndexesRequest, ReleaseHookIndexesRequest } from '../retention.js';
 import {
   MAX_STREAM_BATCH_BYTES,
   MAX_STREAM_CHUNK_BYTES,
@@ -39,6 +35,7 @@ import {
   type StreamWriteResult,
 } from '../stream-protocol.js';
 import { authenticate } from './auth.js';
+import { INDEX_OPERATIONS, type IndexOperation, validateIndexRequest } from './index-validation.js';
 
 export const WORLD_NAME = 'world-celld';
 export const WORLD_VERSION = '0.1.0';
@@ -300,40 +297,41 @@ export function createRouter(env: WorkerEnv) {
       } catch {
         return errorResponse(400, 'BadRequest', 'malformed rpc body');
       }
+      const operation = `${parts[2]}.${parts[3]}`;
+      if (!INDEX_OPERATIONS.has(operation as IndexOperation)) {
+        return errorResponse(404, 'NotFound', `unknown index operation: ${operation}`);
+      }
+      let validated;
+      try {
+        validated = validateIndexRequest(operation as IndexOperation, args);
+      } catch (error) {
+        return errorResponse(400, 'BadRequest', (error as Error).message);
+      }
       try {
         const index = workflowIndex(env);
         let result: unknown;
-        const operation = `${parts[2]}.${parts[3]}`;
-        if (operation === 'runs.list') {
-          result = await index.listRuns(args[0] as IndexListOptions | undefined);
-        } else if (operation === 'runs.commit') {
-          result = await index.commitRun(
-            args[0] as WorkflowRun,
-            args[1] as string,
-            args[2] as number,
-          );
-        } else if (operation === 'runs.expire') {
-          result = await index.expireRun(args[0] as ExpireRunIndexesRequest);
-        } else if (operation === 'hooks.reserve') {
-          result = await index.reserveHook(args[0] as string, args[1] as HookTokenOwner);
-        } else if (operation === 'hooks.finalize') {
-          result = await index.finalizeHookIndexes(
-            args[0] as string,
-            args[1] as string,
-            args[2] as string,
-            args[3] as HookTokenOwner,
-            args[4] as HookReservation | undefined,
-          );
-        } else if (operation === 'hooks.release-reservation') {
-          result = await index.releaseHookReservation(
-            args[0] as string,
-            args[1] as HookTokenOwner,
-            args[2] as HookReservation,
-          );
-        } else if (operation === 'hooks.release') {
-          result = await index.releaseHookIndexes(args[0] as ReleaseHookIndexesRequest);
-        } else {
-          return errorResponse(404, 'NotFound', `unknown index operation: ${operation}`);
+        switch (validated.operation) {
+          case 'runs.list':
+            result = await index.listRuns(...validated.args);
+            break;
+          case 'runs.commit':
+            result = await index.commitRun(...validated.args);
+            break;
+          case 'runs.expire':
+            result = await index.expireRun(...validated.args);
+            break;
+          case 'hooks.reserve':
+            result = await index.reserveHook(...validated.args);
+            break;
+          case 'hooks.finalize':
+            result = await index.finalizeHookIndexes(...validated.args);
+            break;
+          case 'hooks.release-reservation':
+            result = await index.releaseHookReservation(...validated.args);
+            break;
+          case 'hooks.release':
+            result = await index.releaseHookIndexes(...validated.args);
+            break;
         }
         return new Response(rpcStringify(result ?? null), {
           status: 200,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -4,7 +4,6 @@ import { createCelldWorld } from '../src/index.js';
 import { MAX_FLEET_RPC_TIMEOUT_MS } from '../src/lifecycle.js';
 import { MAX_STREAM_LONG_POLL_MS } from '../src/stream-protocol.js';
 import { createMockEnv } from '../src/test-mocks.js';
-import { MAX_QUEUE_SHARDS } from '../src/validation.js';
 
 describe('runtime configuration validation', () => {
   const originalGlobalEnv = (globalThis as { CELLD_ENV?: CelldWorldEnv }).CELLD_ENV;
@@ -36,16 +35,15 @@ describe('runtime configuration validation', () => {
     });
   });
 
-  it.each([
-    0,
-    -1,
-    1.5,
-    Number.NaN,
-    Number.POSITIVE_INFINITY,
-    MAX_QUEUE_SHARDS + 1,
-    Number.MAX_SAFE_INTEGER + 1,
-  ])('rejects invalid queueShards %s', (queueShards) => {
-    expect(() => resolveConfig({ queueShards })).toThrow(/queueShards/);
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid queueShards %s',
+    (queueShards) => {
+      expect(() => resolveConfig({ queueShards })).toThrow(/queueShards/);
+    },
+  );
+
+  it.each([129, Number.MAX_SAFE_INTEGER])('accepts positive safe queueShards %s', (queueShards) => {
+    expect(resolveConfig({ queueShards }).queueShards).toBe(queueShards);
   });
 
   it('does not coerce numeric strings in typed configuration options', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveConfig, type CelldWorldEnv } from '../src/config.js';
+import { createCelldWorld } from '../src/index.js';
+import { MAX_FLEET_RPC_TIMEOUT_MS } from '../src/lifecycle.js';
+import { MAX_STREAM_LONG_POLL_MS } from '../src/stream-protocol.js';
+import { createMockEnv } from '../src/test-mocks.js';
+import { MAX_QUEUE_SHARDS } from '../src/validation.js';
+
+describe('runtime configuration validation', () => {
+  const originalGlobalEnv = (globalThis as { CELLD_ENV?: CelldWorldEnv }).CELLD_ENV;
+
+  beforeEach(() => {
+    delete process.env.CELLD_RUN_RETENTION_MS;
+    delete process.env.CELLD_FLEET_URL;
+    delete process.env.CELLD_WORLD_SECRET;
+    delete (globalThis as { CELLD_ENV?: CelldWorldEnv }).CELLD_ENV;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    if (originalGlobalEnv) {
+      (globalThis as { CELLD_ENV?: CelldWorldEnv }).CELLD_ENV = originalGlobalEnv;
+    } else {
+      delete (globalThis as { CELLD_ENV?: CelldWorldEnv }).CELLD_ENV;
+    }
+  });
+
+  it('resolves intentional defaults explicitly', () => {
+    expect(resolveConfig()).toMatchObject({
+      deploymentId: 'celld-default',
+      queueShards: 1,
+      runRetentionMs: 0,
+      rpcTimeoutMs: 30_000,
+      streamLongPollMs: MAX_STREAM_LONG_POLL_MS,
+      streamFlushIntervalMs: 0,
+    });
+  });
+
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    MAX_QUEUE_SHARDS + 1,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects invalid queueShards %s', (queueShards) => {
+    expect(() => resolveConfig({ queueShards })).toThrow(/queueShards/);
+  });
+
+  it('does not coerce numeric strings in typed configuration options', () => {
+    expect(() => resolveConfig({ queueShards: '5' as unknown as number })).toThrow(/queueShards/);
+    expect(() => resolveConfig({ runRetentionMs: '5' as unknown as number })).toThrow(
+      /runRetentionMs/,
+    );
+  });
+
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid runRetentionMs %s',
+    (runRetentionMs) => {
+      expect(() => resolveConfig({ runRetentionMs })).toThrow(/runRetentionMs/);
+    },
+  );
+
+  it.each(['', ' ', '5junk', '1.5', '1e3', 'NaN', 'Infinity', '-1', '9007199254740992'])(
+    'rejects malformed CELLD_RUN_RETENTION_MS %j instead of falling back',
+    (value) => {
+      vi.stubEnv('CELLD_RUN_RETENTION_MS', value);
+      expect(() => resolveConfig()).toThrow(/runRetentionMs/);
+    },
+  );
+
+  it('accepts a complete decimal retention environment value, including zero', () => {
+    vi.stubEnv('CELLD_RUN_RETENTION_MS', '0005');
+    expect(resolveConfig().runRetentionMs).toBe(5);
+    vi.stubEnv('CELLD_RUN_RETENTION_MS', '0');
+    expect(resolveConfig().runRetentionMs).toBe(0);
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, MAX_FLEET_RPC_TIMEOUT_MS + 1])(
+    'rejects out-of-range rpcTimeoutMs %s',
+    (rpcTimeoutMs) => {
+      expect(() => resolveConfig({ rpcTimeoutMs })).toThrow(/rpcTimeoutMs/);
+    },
+  );
+
+  it('enforces stream long-poll bounds and the RPC deadline relationship', () => {
+    expect(() => resolveConfig({ streamLongPollMs: 0 })).toThrow(/streamLongPollMs/);
+    expect(() => resolveConfig({ streamLongPollMs: MAX_STREAM_LONG_POLL_MS + 1 })).toThrow(
+      /streamLongPollMs/,
+    );
+    expect(() => resolveConfig({ rpcTimeoutMs: 100, streamLongPollMs: 100 })).toThrow(
+      /less than rpcTimeoutMs/,
+    );
+    expect(resolveConfig({ rpcTimeoutMs: 100, streamLongPollMs: 99 }).streamLongPollMs).toBe(99);
+  });
+
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid streamFlushIntervalMs %s',
+    (streamFlushIntervalMs) => {
+      expect(() => resolveConfig({ streamFlushIntervalMs })).toThrow(/streamFlushIntervalMs/);
+    },
+  );
+
+  it('fails early when a required in-process binding is missing', () => {
+    const env = createMockEnv();
+    const partial = { ...env, WORKFLOW_DB: undefined } as unknown as CelldWorldEnv;
+    expect(() => createCelldWorld({ env: partial })).toThrow(
+      /missing required binding WORKFLOW_DB/,
+    );
+  });
+
+  it('requires a secret whenever fleetUrl is configured', () => {
+    expect(() => createCelldWorld({ fleetUrl: 'http://fleet.test' })).toThrow(
+      /secret.*required with fleetUrl/,
+    );
+  });
+});

--- a/test/index-do.test.ts
+++ b/test/index-do.test.ts
@@ -73,6 +73,22 @@ function run(sequence: number, workflowName = 'routing-workflow'): WorkflowRun {
   };
 }
 
+function paddedTimestamp(value: number): string {
+  return String(value).padStart(13, '0');
+}
+
+async function seedCatalogRun(catalog: RunCatalogDO, runId: string, now: number): Promise<void> {
+  const timestamp = paddedTimestamp(now);
+  await expect(
+    catalog.upsertRun(
+      runId,
+      [`run:catalog-compaction:${timestamp}:${runId}`, `runall:${timestamp}:${runId}`],
+      JSON.stringify({ runId }),
+      now + MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS,
+    ),
+  ).resolves.toEqual({ stored: true });
+}
+
 function hook(runId: string, hookId: string, token: string): Hook {
   return {
     runId,
@@ -450,7 +466,6 @@ describe('sharded workflow indexes', () => {
     expect(
       await indexes.expireRun({
         runId: value.runId,
-        keys: [workflowRunIndexKey(value), globalRunIndexKey(value)],
         hooks: [],
         expiredAt: 123,
       }),
@@ -494,6 +509,56 @@ describe('sharded workflow indexes', () => {
     expect(await indexes.commitRun(value, currentMetadata, publicationExpiresAt)).toEqual({
       stored: true,
     });
+  });
+
+  it('rejects noncanonical internal catalog commits and makes missing-run expiry mutation-free', async () => {
+    const shardName = 'run-catalog:v1:canonical-keys-test';
+    const catalog = fleet.namespace('run-catalog').get({
+      toString: () => shardName,
+    }) as RunCatalogDO;
+    const runId = 'wrun_canonical_keys';
+    const timestamp = paddedTimestamp(fleet.now);
+    const canonical = [
+      `run:canonical-workflow:${timestamp}:${runId}`,
+      `runall:${timestamp}:${runId}`,
+    ];
+    const malformedPairs = [
+      [`arbitrary:canonical-workflow:${timestamp}:${runId}`, canonical[1]],
+      [canonical[1], canonical[0]],
+      [canonical[0], canonical[0]],
+      [canonical[0], `runall:${paddedTimestamp(fleet.now + 1)}:${runId}`],
+      [`expired:${runId}`, `expiry-gc:${timestamp}:${runId}`],
+      [`run%3Acanonical-workflow%3A${timestamp}%3A${runId}`, canonical[1]],
+      [canonical[0], `runall:${timestamp}:wrun_wrong`],
+    ];
+    const storage = fleet.cell('run-catalog', shardName).storage;
+
+    for (const keys of malformedPairs) {
+      const before = new Map(storage.data);
+      await expect(
+        catalog.upsertRun(
+          runId,
+          keys,
+          JSON.stringify({ runId }),
+          fleet.now + MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS,
+        ),
+      ).rejects.toThrow(/canonical run key pair/);
+      expect(storage.data).toEqual(before);
+      expect(storage.alarmAt).toBeNull();
+    }
+
+    const before = new Map(storage.data);
+    await expect(catalog.expireRun(runId, fleet.now)).resolves.toEqual({ deleted: 0 });
+    expect(storage.data).toEqual(before);
+    expect(storage.alarmAt).toBeNull();
+
+    storage.data.set(`catalog-keys:${runId}`, {
+      keys: [`expired:${runId}`, `expiry-gc:${timestamp}:${runId}`],
+    });
+    const corruptBefore = new Map(storage.data);
+    await expect(catalog.expireRun(runId, fleet.now)).rejects.toThrow(/canonical run key pair/);
+    expect(storage.data).toEqual(corruptBefore);
+    expect(storage.alarmAt).toBeNull();
   });
 
   it('compacts abandoned exact claims after the protocol lease and survives restart', async () => {
@@ -739,7 +804,8 @@ describe('sharded workflow indexes', () => {
     }) as RunCatalogDO;
     const runIds = Array.from({ length: 300 }, (_, index) => `wrun_catalog_compaction_${index}`);
     for (const runId of runIds) {
-      await catalog.expireRun(runId, [`run:${runId}`, `runall:${runId}`], fleet.now);
+      await seedCatalogRun(catalog, runId, fleet.now);
+      await catalog.expireRun(runId, fleet.now);
     }
 
     const catalogStorage = fleet.cell('run-catalog', shardName).storage;
@@ -794,7 +860,8 @@ describe('sharded workflow indexes', () => {
       toString: () => shardName,
     }) as RunCatalogDO;
     const runId = 'wrun_reused_catalog_generation';
-    await catalog.expireRun(runId, [`run:${runId}`, `runall:${runId}`], fleet.now);
+    await seedCatalogRun(catalog, runId, fleet.now);
+    await catalog.expireRun(runId, fleet.now);
 
     const catalogStorage = fleet.cell('run-catalog', shardName).storage;
     const markerKey = `expired:${runId}`;
@@ -805,7 +872,8 @@ describe('sharded workflow indexes', () => {
     const oldGc = catalogStorage.data.get(oldGcKey);
     catalogStorage.data.delete(markerKey);
     fleet.advance(1);
-    await catalog.expireRun(runId, [`run:${runId}`, `runall:${runId}`], fleet.now);
+    await seedCatalogRun(catalog, runId, fleet.now);
+    await catalog.expireRun(runId, fleet.now);
     catalogStorage.data.set(oldGcKey, oldGc);
 
     const currentFence = catalogStorage.data.get(markerKey) as { compactAt: number };

--- a/test/integration/celld-smoke.test.ts
+++ b/test/integration/celld-smoke.test.ts
@@ -435,7 +435,7 @@ describe.skipIf(!CONFIGURED)('real celld v0.3.0 restart smoke', () => {
     const before = deliveries.length;
     const { messageId } = await w.queue(
       `__wkf_workflow_restart_${marker.slice(0, 8)}`,
-      { marker },
+      { __healthCheck: true, correlationId: marker },
       { delaySeconds: 2, idempotencyKey: `restart:${marker}` },
     );
     expect(deliveries.slice(before).filter((delivery) => delivery.body.includes(marker))).toEqual(

--- a/test/integration/fleet.test.ts
+++ b/test/integration/fleet.test.ts
@@ -224,7 +224,10 @@ describe.skipIf(!FLEET_URL || !SECRET)('celld fleet integration', () => {
     const marker = randomUUID();
     const before = deliveries.length;
 
-    await w.queue(`__wkf_workflow_it_${marker.slice(0, 8)}`, { marker });
+    await w.queue(`__wkf_workflow_it_${marker.slice(0, 8)}`, {
+      __healthCheck: true,
+      correlationId: marker,
+    });
 
     const delivered = await waitFor(
       async () => deliveries.slice(before).find((d) => d.body.includes(marker)),
@@ -243,7 +246,7 @@ describe.skipIf(!FLEET_URL || !SECRET)('celld fleet integration', () => {
 
     await w.queue(
       `__wkf_workflow_delay_${marker.slice(0, 8)}`,
-      { marker },
+      { __healthCheck: true, correlationId: marker },
       {
         delaySeconds: 3,
       },
@@ -264,7 +267,10 @@ describe.skipIf(!FLEET_URL || !SECRET)('celld fleet integration', () => {
     const before = deliveries.length;
     responseQueue.push({ status: 503, body: { timeoutSeconds: 2 } });
 
-    await w.queue(`__wkf_workflow_retry_${marker.slice(0, 8)}`, { marker });
+    await w.queue(`__wkf_workflow_retry_${marker.slice(0, 8)}`, {
+      __healthCheck: true,
+      correlationId: marker,
+    });
 
     await waitFor(
       async () => deliveries.slice(before).filter((d) => d.body.includes(marker)).length >= 2,
@@ -283,7 +289,8 @@ describe.skipIf(!FLEET_URL || !SECRET)('celld fleet integration', () => {
     for (let i = 0; i < 5; i++) responseQueue.push({ status: 500, body: { error: 'down' } });
 
     const { messageId } = await w.queue(`__wkf_workflow_dlq_${marker.slice(0, 8)}`, {
-      marker,
+      __healthCheck: true,
+      correlationId: marker,
     });
 
     const stats = await waitFor(

--- a/test/perf/index-scalability.test.ts
+++ b/test/perf/index-scalability.test.ts
@@ -696,8 +696,9 @@ describe('sharded index scalability evidence', () => {
     expect(internalCatalogExpireCalls).toBe(1);
     expect(report.indexStorage.runCatalog).toEqual({
       ...emptyCounts(),
-      get: 1,
+      get: 2,
       put: 2,
+      delete: 1,
       deleteMany: 1,
       transaction: 1,
     });

--- a/test/perf/index-scalability.test.ts
+++ b/test/perf/index-scalability.test.ts
@@ -24,7 +24,7 @@ function queueRequest(messageId: string, runId: string): EnqueueRequest {
     runId,
     queueName: '__wkf_workflow_lifecycle_evidence',
     pathname: 'flow',
-    body: '{}',
+    body: JSON.stringify({ runId }),
     delaySeconds: 3_600,
     config: { targetBaseUrl: 'http://app.invalid', queueShards: 1 },
   };

--- a/test/perf/minio.test.ts
+++ b/test/perf/minio.test.ts
@@ -92,9 +92,8 @@ async function waitUntil(predicate: () => Promise<boolean> | boolean, timeoutMs:
 }
 
 interface PerfPayload {
-  perfRunId: string;
-  sequence: number;
-  padding: string;
+  __healthCheck: boolean;
+  correlationId: string;
 }
 
 interface Delivery {
@@ -199,18 +198,19 @@ describe('MinIO single-node queue performance and loss', () => {
         return;
       }
 
+      const [payloadRunId, sequenceText] = payload.correlationId.split('|', 2);
+      const sequence = /^\d+$/.test(sequenceText ?? '') ? Number(sequenceText) : Number.NaN;
       if (
-        payload.perfRunId !== runId ||
-        !Number.isSafeInteger(payload.sequence) ||
-        payload.sequence < 0 ||
-        payload.sequence >= messageCount
+        !payload['__healthCheck'] ||
+        payloadRunId !== runId ||
+        !Number.isSafeInteger(sequence) ||
+        sequence >= messageCount
       ) {
         invalidCallbacks.push(`unexpected payload: ${JSON.stringify(payload)}`);
         response.writeHead(400).end();
         return;
       }
 
-      const sequence = payload.sequence;
       const attemptCount = (callbackAttempts.get(sequence) ?? 0) + 1;
       callbackAttempts.set(sequence, attemptCount);
 
@@ -271,7 +271,10 @@ describe('MinIO single-node queue performance and loss', () => {
       const enqueueStart = performance.now();
       startedAt.set(sequence, enqueueStart);
       try {
-        const outcome = await world.queue(queueName, { perfRunId: runId, sequence, padding });
+        const outcome = await world.queue(queueName, {
+          __healthCheck: true,
+          correlationId: `${runId}|${sequence}|${padding}`,
+        });
         accepted.set(sequence, String(outcome.messageId));
         enqueueLatencies.push(performance.now() - enqueueStart);
       } catch (error) {

--- a/test/queue-do.test.ts
+++ b/test/queue-do.test.ts
@@ -8,6 +8,7 @@ import { QueueDO, type MessageRow } from '../src/worker/durable-objects/QueueDO.
 import { FakeFleet } from '../src/testing/fake-cell.js';
 import { LIFECYCLE_COMPACTION_RETRY_MS, QUEUE_FENCE_GRACE_MS } from '../src/lifecycle.js';
 import type { RunLifecycleStatus } from '../src/retention.js';
+import { MAX_QUEUE_DELAY_SECONDS } from '../src/validation.js';
 
 class TestRunLifecycleDO {
   constructor(private ctx: { storage: DurableObjectStorage }) {}
@@ -123,6 +124,69 @@ describe('QueueDO', () => {
     await expect(invalidQueue.enqueue(enqueueReq())).rejects.toThrow(
       'QUEUE_MAX_INFLIGHT must be at most 128',
     );
+  });
+
+  it.each([
+    ['QUEUE_MAX_ATTEMPTS', '5junk'],
+    ['QUEUE_MAX_ATTEMPTS', '0'],
+    ['QUEUE_MAX_ATTEMPTS', '1.5'],
+    ['QUEUE_MAX_ATTEMPTS', ''],
+    ['QUEUE_MAX_INFLIGHT', '5junk'],
+    ['QUEUE_MAX_INFLIGHT', '0'],
+    ['QUEUE_DELIVERY_TIMEOUT_MS', '5junk'],
+    ['QUEUE_DELIVERY_TIMEOUT_MS', '0'],
+    ['QUEUE_DELIVERY_TIMEOUT_MS', '300001'],
+  ] as const)(
+    'rejects malformed runtime setting %s=%j before queue mutation',
+    async (name, value) => {
+      const invalidFleet = new FakeFleet(
+        { queue: QueueDO },
+        { [name]: value, clock: () => invalidFleet.now, fetch: fetchStub },
+      );
+      const invalidQueue = invalidFleet
+        .namespace('queue')
+        .get({ toString: () => 'q:0' }) as QueueDO;
+
+      await expect(invalidQueue.enqueue(enqueueReq())).rejects.toThrow(name);
+      const invalidStorage = invalidFleet.cell('queue', 'q:0').storage;
+      expect(invalidStorage.data.size).toBe(0);
+      expect(invalidStorage.alarmAt).toBeNull();
+      expect(fetchStub).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { config: { targetBaseUrl: 'http://app.test:3000', queueShards: 0 } },
+    { config: { targetBaseUrl: 'http://app.test:3000', queueShards: 1.5 } },
+    { config: { targetBaseUrl: 'http://app.test:3000', queueShards: 129 } },
+    { delaySeconds: -1 },
+    { delaySeconds: MAX_QUEUE_DELAY_SECONDS },
+    { delaySeconds: Number.MAX_SAFE_INTEGER },
+    { body: 'null' },
+    { body: '{"payload":{"__type":"Uint8Array"}}' },
+  ])('rejects malformed enqueue envelope before queue mutation: %j', async (over) => {
+    await expect(queue.enqueue(enqueueReq(over as Partial<EnqueueRequest>))).rejects.toThrow(
+      /world-celld queue enqueue/,
+    );
+    expect(storage().size).toBe(0);
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBeNull();
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it('rejects a run-owned enqueue when WORKFLOW_DB is missing without persisting it', async () => {
+    const missingBindingFleet = new FakeFleet(
+      { queue: QueueDO },
+      { clock: () => missingBindingFleet.now, fetch: fetchStub },
+    );
+    const missingBindingQueue = missingBindingFleet.namespace('queue').get({
+      toString: () => 'q:0',
+    }) as QueueDO;
+
+    await expect(
+      missingBindingQueue.enqueue(enqueueReq({ runId: 'wrun_missing_binding' })),
+    ).rejects.toThrow(/missing WORKFLOW_DB/);
+    expect(missingBindingFleet.cell('queue', 'q:0').storage.data.size).toBe(0);
+    expect(fetchStub).not.toHaveBeenCalled();
   });
 
   it('dedups on idempotencyKey while active and releases after ack', async () => {
@@ -292,6 +356,22 @@ describe('QueueDO', () => {
     // Same message, attempt header unchanged (503-redeliver is not a retry).
     expect(fetchStub.mock.calls[1][1].headers['x-vqs-message-attempt']).toBe('1');
   });
+
+  it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER])(
+    'treats invalid 503 timeoutSeconds %s as a normal retry rather than ack or immediate redelivery',
+    async (timeoutSeconds) => {
+      fetchStub.mockResolvedValue(jsonResponse(503, { timeoutSeconds }));
+      await queue.enqueue(enqueueReq({ messageId: 'msg_invalid_timeout' }));
+
+      await tick();
+
+      expect(fetchStub).toHaveBeenCalledOnce();
+      expect(storage().get('msg:msg_invalid_timeout')).toMatchObject({ attempt: 1 });
+      const dueKeys = Array.from(storage().keys()).filter((key) => key.startsWith('due:'));
+      expect(dueKeys).toEqual([`due:${padded(fleet.now + 2_000)}:msg_invalid_timeout`]);
+      expect(Array.from(storage().keys()).some((key) => key.startsWith('dlq:'))).toBe(false);
+    },
+  );
 
   it('drops permanently on 404/409/410/422 without retrying', async () => {
     fetchStub.mockResolvedValue(jsonResponse(410, { error: 'gone', permanent: true }));
@@ -627,6 +707,27 @@ describe('QueueDO', () => {
     }
     expect((await queue.purgeDeadLetters()).purged).toBe(1);
     expect((await queue.stats()).deadLetters).toBe(0);
+  });
+
+  it('rejects malformed queue admin input before storage mutation', async () => {
+    const queueStorage = fleet.cell('queue', 'q:0').storage;
+    queueStorage.resetOperationCounts();
+    await expect(queue.listDeadLetters({ limit: 0 })).rejects.toThrow(/dead-letter limit/);
+    await expect(queue.listDeadLetters({ limit: '5' as unknown as number })).rejects.toThrow(
+      /dead-letter limit/,
+    );
+    await expect(queue.redriveDeadLetter('')).rejects.toThrow(/messageId/);
+    await expect(queue.expireRun('', fleet.now)).rejects.toThrow(/runId/);
+    await expect(queue.expireRun('wrun_admin', -1)).rejects.toThrow(/expiredAt/);
+    await expect(queue.expireRun('wrun_admin', fleet.now, { limit: 65 })).rejects.toThrow(/limit/);
+    await expect(
+      queue.expireRun('wrun_admin', fleet.now, { limit: '5' as unknown as number }),
+    ).rejects.toThrow(/limit/);
+    await expect(
+      queue.acknowledgeExpireRun('wrun_admin', { expiredAt: -1, deleted: 0 }),
+    ).rejects.toThrow(/receipt/);
+    expect(queueStorage.operationCounts.transaction).toBe(0);
+    expect(queueStorage.data.size).toBe(0);
   });
 
   it('purges every message state for an expired run and fences late enqueue', async () => {

--- a/test/queue-do.test.ts
+++ b/test/queue-do.test.ts
@@ -4,11 +4,12 @@
  */
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import type { EnqueueRequest } from '../src/queue.js';
+import { stringify } from '../src/vendor/shared/index.js';
 import { QueueDO, type MessageRow } from '../src/worker/durable-objects/QueueDO.js';
 import { FakeFleet } from '../src/testing/fake-cell.js';
 import { LIFECYCLE_COMPACTION_RETRY_MS, QUEUE_FENCE_GRACE_MS } from '../src/lifecycle.js';
 import type { RunLifecycleStatus } from '../src/retention.js';
-import { MAX_QUEUE_DELAY_SECONDS } from '../src/validation.js';
+import { MAX_QUEUE_DELAY_SECONDS, MAX_QUEUE_TIMESTAMP_MS } from '../src/validation.js';
 
 class TestRunLifecycleDO {
   constructor(private ctx: { storage: DurableObjectStorage }) {}
@@ -24,14 +25,19 @@ function jsonResponse(status: number, body?: unknown, headers?: Record<string, s
   return new Response(body === undefined ? null : JSON.stringify(body), { status, headers });
 }
 
-const enqueueReq = (over: Partial<EnqueueRequest> = {}): EnqueueRequest => ({
-  messageId: over.messageId ?? `msg_${Math.random().toString(36).slice(2)}`,
-  queueName: '__wkf_workflow_test',
-  pathname: 'flow',
-  body: '{"data":"payload"}',
-  config: { targetBaseUrl: 'http://app.test:3000', queueShards: 1 },
-  ...over,
-});
+const enqueueReq = (over: Partial<EnqueueRequest> = {}): EnqueueRequest => {
+  const payload = over.runId
+    ? { runId: over.runId }
+    : { __healthCheck: true as const, correlationId: 'queue-do-test' };
+  return {
+    messageId: over.messageId ?? `msg_${Math.random().toString(36).slice(2)}`,
+    queueName: '__wkf_workflow_test',
+    pathname: 'flow',
+    body: JSON.stringify(payload),
+    config: { targetBaseUrl: 'http://app.test:3000', queueShards: 1 },
+    ...over,
+  };
+};
 
 const MIN_TEST_ALARM_DELAY_MS = 1;
 const INFLIGHT_DEADLINE_PREFIX = 'inflight-deadline:';
@@ -45,7 +51,7 @@ function storedMessage(messageId: string, now: number): MessageRow {
     messageId,
     queueName: '__wkf_workflow_test',
     pathname: 'flow',
-    body: '{"data":"payload"}',
+    body: '{"__healthCheck":true,"correlationId":"queue-do-test"}',
     targetBaseUrl: 'http://app.test:3000',
     attempt: 0,
     enqueuedAt: now,
@@ -102,7 +108,7 @@ describe('QueueDO', () => {
     expect(init.headers['x-vqs-queue-name']).toBe('__wkf_workflow_test');
     expect(init.headers['x-vqs-message-id']).toBe('msg_1');
     expect(init.headers['x-vqs-message-attempt']).toBe('1');
-    expect(init.body).toBe('{"data":"payload"}');
+    expect(init.body).toBe('{"__healthCheck":true,"correlationId":"queue-do-test"}');
 
     // Fully settled: no message, schedule, claim, or alarm left behind.
     const keys = Array.from(storage().keys());
@@ -158,11 +164,18 @@ describe('QueueDO', () => {
   it.each([
     { config: { targetBaseUrl: 'http://app.test:3000', queueShards: 0 } },
     { config: { targetBaseUrl: 'http://app.test:3000', queueShards: 1.5 } },
-    { config: { targetBaseUrl: 'http://app.test:3000', queueShards: 129 } },
+    {
+      config: {
+        targetBaseUrl: 'http://app.test:3000',
+        queueShards: Number.MAX_SAFE_INTEGER + 1,
+      },
+    },
     { delaySeconds: -1 },
     { delaySeconds: MAX_QUEUE_DELAY_SECONDS },
     { delaySeconds: Number.MAX_SAFE_INTEGER },
     { body: 'null' },
+    { body: '{}' },
+    { body: '{"data":"not-a-queue-payload"}' },
     { body: '{"payload":{"__type":"Uint8Array"}}' },
   ])('rejects malformed enqueue envelope before queue mutation: %j', async (over) => {
     await expect(queue.enqueue(enqueueReq(over as Partial<EnqueueRequest>))).rejects.toThrow(
@@ -172,6 +185,54 @@ describe('QueueDO', () => {
     expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBeNull();
     expect(fetchStub).not.toHaveBeenCalled();
   });
+
+  it('classifies an invalid payload as permanent 422 without storage or delivery', async () => {
+    await expect(queue.enqueue(enqueueReq({ body: '{}' }))).rejects.toMatchObject({ status: 422 });
+    expect(storage().size).toBe(0);
+    expect(fleet.cell('queue', 'q:0').storage.alarmAt).toBeNull();
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it('accepts and stores a valid tagged-JSON queue payload byte-identically', async () => {
+    const runId = 'wrun_tagged_queue_payload';
+    setRunStatus(runId, 'active');
+    const body = stringify({
+      runId,
+      runInput: {
+        input: new Uint8Array([0, 1, 254, 255]),
+        deploymentId: 'queue-do-tests',
+        workflowName: 'tagged-payload',
+        specVersion: 6,
+      },
+    });
+
+    await expect(
+      queue.enqueue(enqueueReq({ messageId: 'msg_tagged_payload', runId, body, delaySeconds: 60 })),
+    ).resolves.toMatchObject({ ok: true });
+    expect(storage().get('msg:msg_tagged_payload')).toMatchObject({ body });
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it.each([129, Number.MAX_SAFE_INTEGER])(
+    'accepts a positive safe queue shard count %s',
+    async (queueShards) => {
+      const isolatedFleet = new FakeFleet(
+        { queue: QueueDO, runs: TestRunLifecycleDO as never },
+        { clock: () => isolatedFleet.now, fetch: fetchStub },
+      );
+      const isolatedQueue = isolatedFleet.namespace('queue').get({
+        toString: () => 'q:0',
+      }) as QueueDO;
+      await expect(
+        isolatedQueue.enqueue(
+          enqueueReq({
+            messageId: `msg_shards_${queueShards}`,
+            config: { targetBaseUrl: 'http://app.test:3000', queueShards },
+          }),
+        ),
+      ).resolves.toMatchObject({ ok: true });
+    },
+  );
 
   it('rejects a run-owned enqueue when WORKFLOW_DB is missing without persisting it', async () => {
     const missingBindingFleet = new FakeFleet(
@@ -339,6 +400,49 @@ describe('QueueDO', () => {
     expect(fetchStub).toHaveBeenCalledOnce();
   });
 
+  it('orders ordinary and far-future deadlines and accepts the exact 13-digit boundary', async () => {
+    const startTime = 999;
+    const boundaryFleet = new FakeFleet(
+      { queue: QueueDO },
+      { clock: () => boundaryFleet.now, fetch: fetchStub },
+      startTime,
+    );
+    const boundaryQueue = boundaryFleet.namespace('queue').get({
+      toString: () => 'q:0',
+    }) as QueueDO;
+    const exactBoundaryDelay = (MAX_QUEUE_TIMESTAMP_MS - startTime) / 1000;
+
+    await boundaryQueue.enqueue(
+      enqueueReq({ messageId: 'msg_boundary', delaySeconds: exactBoundaryDelay }),
+    );
+    await boundaryQueue.enqueue(enqueueReq({ messageId: 'msg_ordinary', delaySeconds: 1 }));
+    const boundaryStorage = boundaryFleet.cell('queue', 'q:0').storage;
+    expect(Array.from((await boundaryStorage.list<string>({ prefix: 'due:' })).keys())).toEqual([
+      `due:${padded(startTime + 1_000)}:msg_ordinary`,
+      `due:${padded(MAX_QUEUE_TIMESTAMP_MS)}:msg_boundary`,
+    ]);
+    expect(boundaryStorage.alarmAt).toBe(startTime + 1_000);
+    await expect(
+      boundaryQueue.enqueue(
+        enqueueReq({
+          messageId: 'msg_over_boundary',
+          delaySeconds: exactBoundaryDelay + 1,
+        }),
+      ),
+    ).rejects.toThrow(/delaySeconds/);
+
+    boundaryFleet.advance(1_000);
+    await boundaryFleet.fireDueAlarms();
+    expect(fetchStub).toHaveBeenCalledOnce();
+    expect(boundaryStorage.data.has('msg:msg_boundary')).toBe(true);
+    expect(boundaryStorage.alarmAt).toBe(MAX_QUEUE_TIMESTAMP_MS);
+
+    boundaryFleet.advance(MAX_QUEUE_TIMESTAMP_MS - boundaryFleet.now);
+    await boundaryFleet.fireDueAlarms();
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+    expect(boundaryStorage.data.has('msg:msg_boundary')).toBe(false);
+  });
+
   it('redelivers after 503 {timeoutSeconds} without advancing the attempt', async () => {
     fetchStub
       .mockResolvedValueOnce(jsonResponse(503, { timeoutSeconds: 30 }))
@@ -372,6 +476,24 @@ describe('QueueDO', () => {
       expect(Array.from(storage().keys()).some((key) => key.startsWith('dlq:'))).toBe(false);
     },
   );
+
+  it('consumes attempts and reaches the DLQ for malformed 503 retry hints', async () => {
+    fetchStub.mockResolvedValue(jsonResponse(503, { timeoutSeconds: '5junk' }));
+    await queue.enqueue(enqueueReq({ messageId: 'msg_malformed_retry_hint' }));
+
+    for (const advance of [0, 2_100, 4_100, 8_100, 16_100]) await tick(advance);
+
+    expect(fetchStub.mock.calls.map((call) => call[1].headers['x-vqs-message-attempt'])).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+    ]);
+    await expect(queue.listDeadLetters()).resolves.toMatchObject({
+      data: [expect.objectContaining({ messageId: 'msg_malformed_retry_hint', attempt: 5 })],
+    });
+  });
 
   it('drops permanently on 404/409/410/422 without retrying', async () => {
     fetchStub.mockResolvedValue(jsonResponse(410, { error: 'gone', permanent: true }));

--- a/test/queue-do.test.ts
+++ b/test/queue-do.test.ts
@@ -7,9 +7,18 @@ import type { EnqueueRequest } from '../src/queue.js';
 import { stringify } from '../src/vendor/shared/index.js';
 import { QueueDO, type MessageRow } from '../src/worker/durable-objects/QueueDO.js';
 import { FakeFleet } from '../src/testing/fake-cell.js';
-import { LIFECYCLE_COMPACTION_RETRY_MS, QUEUE_FENCE_GRACE_MS } from '../src/lifecycle.js';
+import {
+  LIFECYCLE_COMPACTION_RETRY_MS,
+  MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+  MAX_QUEUE_SCHEDULE_TIMESTAMP_MS,
+  QUEUE_FENCE_GRACE_MS,
+} from '../src/lifecycle.js';
 import type { RunLifecycleStatus } from '../src/retention.js';
-import { MAX_QUEUE_DELAY_SECONDS, MAX_QUEUE_TIMESTAMP_MS } from '../src/validation.js';
+import {
+  checkedQueueTimestampAdd,
+  MAX_QUEUE_DELAY_SECONDS,
+  MAX_QUEUE_TIMESTAMP_MS,
+} from '../src/validation.js';
 
 class TestRunLifecycleDO {
   constructor(private ctx: { storage: DurableObjectStorage }) {}
@@ -56,6 +65,16 @@ function storedMessage(messageId: string, now: number): MessageRow {
     attempt: 0,
     enqueuedAt: now,
   };
+}
+
+function expectQueueTimestampContract(data: Map<string, unknown>, alarmAt: number | null): void {
+  const timestamped = /^(?:due|inflight-deadline|dlq|expired-run-gc):(\d+):/;
+  const timestamps = Array.from(data.keys()).flatMap((key) => {
+    const match = timestamped.exec(key);
+    return match ? [match[1]] : [];
+  });
+  expect(timestamps.every((timestamp) => /^\d{13}$/.test(timestamp))).toBe(true);
+  expect(alarmAt === null || alarmAt <= MAX_QUEUE_TIMESTAMP_MS).toBe(true);
 }
 
 describe('QueueDO', () => {
@@ -400,8 +419,8 @@ describe('QueueDO', () => {
     expect(fetchStub).toHaveBeenCalledOnce();
   });
 
-  it('orders ordinary and far-future deadlines and accepts the exact 13-digit boundary', async () => {
-    const startTime = 999;
+  it('orders ordinary and far-future deadlines through the exact admissible boundary', async () => {
+    const startTime = 998;
     const boundaryFleet = new FakeFleet(
       { queue: QueueDO },
       { clock: () => boundaryFleet.now, fetch: fetchStub },
@@ -410,7 +429,7 @@ describe('QueueDO', () => {
     const boundaryQueue = boundaryFleet.namespace('queue').get({
       toString: () => 'q:0',
     }) as QueueDO;
-    const exactBoundaryDelay = (MAX_QUEUE_TIMESTAMP_MS - startTime) / 1000;
+    const exactBoundaryDelay = (MAX_QUEUE_SCHEDULE_TIMESTAMP_MS - startTime) / 1000;
 
     await boundaryQueue.enqueue(
       enqueueReq({ messageId: 'msg_boundary', delaySeconds: exactBoundaryDelay }),
@@ -419,7 +438,7 @@ describe('QueueDO', () => {
     const boundaryStorage = boundaryFleet.cell('queue', 'q:0').storage;
     expect(Array.from((await boundaryStorage.list<string>({ prefix: 'due:' })).keys())).toEqual([
       `due:${padded(startTime + 1_000)}:msg_ordinary`,
-      `due:${padded(MAX_QUEUE_TIMESTAMP_MS)}:msg_boundary`,
+      `due:${padded(MAX_QUEUE_SCHEDULE_TIMESTAMP_MS)}:msg_boundary`,
     ]);
     expect(boundaryStorage.alarmAt).toBe(startTime + 1_000);
     await expect(
@@ -430,17 +449,128 @@ describe('QueueDO', () => {
         }),
       ),
     ).rejects.toThrow(/delaySeconds/);
+    expect(
+      checkedQueueTimestampAdd(
+        MAX_QUEUE_SCHEDULE_TIMESTAMP_MS,
+        MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+      ),
+    ).toBe(MAX_QUEUE_TIMESTAMP_MS);
+    expect(
+      checkedQueueTimestampAdd(
+        MAX_QUEUE_SCHEDULE_TIMESTAMP_MS + 1,
+        0,
+        MAX_QUEUE_DERIVED_DEADLINE_HEADROOM_MS,
+      ),
+    ).toBeNull();
+    expect(checkedQueueTimestampAdd(MAX_QUEUE_TIMESTAMP_MS, 0)).toBe(MAX_QUEUE_TIMESTAMP_MS);
+    expect(checkedQueueTimestampAdd(MAX_QUEUE_TIMESTAMP_MS, 1)).toBeNull();
+    const oneMillisecondOverFleet = new FakeFleet(
+      { queue: QueueDO },
+      { clock: () => oneMillisecondOverFleet.now, fetch: fetchStub },
+      MAX_QUEUE_SCHEDULE_TIMESTAMP_MS + 1,
+    );
+    const oneMillisecondOverQueue = oneMillisecondOverFleet.namespace('queue').get({
+      toString: () => 'q:0',
+    }) as QueueDO;
+    await expect(
+      oneMillisecondOverQueue.enqueue(enqueueReq({ messageId: 'msg_one_ms_over' })),
+    ).rejects.toThrow(/delivery headroom/);
+    const oneMillisecondOverStorage = oneMillisecondOverFleet.cell('queue', 'q:0').storage;
+    expect(oneMillisecondOverStorage.data.size).toBe(0);
+    expect(oneMillisecondOverStorage.alarmAt).toBeNull();
 
     boundaryFleet.advance(1_000);
     await boundaryFleet.fireDueAlarms();
     expect(fetchStub).toHaveBeenCalledOnce();
     expect(boundaryStorage.data.has('msg:msg_boundary')).toBe(true);
-    expect(boundaryStorage.alarmAt).toBe(MAX_QUEUE_TIMESTAMP_MS);
+    expect(boundaryStorage.alarmAt).toBe(MAX_QUEUE_SCHEDULE_TIMESTAMP_MS);
 
-    boundaryFleet.advance(MAX_QUEUE_TIMESTAMP_MS - boundaryFleet.now);
+    boundaryFleet.advance(MAX_QUEUE_SCHEDULE_TIMESTAMP_MS - boundaryFleet.now);
     await boundaryFleet.fireDueAlarms();
     expect(fetchStub).toHaveBeenCalledTimes(2);
     expect(boundaryStorage.data.has('msg:msg_boundary')).toBe(false);
+    expectQueueTimestampContract(boundaryStorage.data, boundaryStorage.alarmAt);
+  });
+
+  it.each([
+    ['HTTP 500', jsonResponse(500, { error: 'boom' })],
+    ['valid 503 hint', jsonResponse(503, { timeoutSeconds: 1 })],
+    ['missing 503 hint', jsonResponse(503, {})],
+    ['malformed 503 hint', jsonResponse(503, { timeoutSeconds: '5junk' })],
+  ])('dead-letters %s at the retry horizon without an overflow cycle', async (_, response) => {
+    const boundaryFleet = new FakeFleet(
+      { queue: QueueDO },
+      { clock: () => boundaryFleet.now, fetch: fetchStub },
+      MAX_QUEUE_SCHEDULE_TIMESTAMP_MS,
+    );
+    const boundaryQueue = boundaryFleet.namespace('queue').get({
+      toString: () => 'q:0',
+    }) as QueueDO;
+    const boundaryStorage = boundaryFleet.cell('queue', 'q:0').storage;
+    let sawExactMaxClaim = false;
+    fetchStub.mockImplementation(async () => {
+      sawExactMaxClaim = boundaryStorage.data.has(
+        `${INFLIGHT_DEADLINE_PREFIX}${padded(MAX_QUEUE_TIMESTAMP_MS)}:msg_horizon_retry`,
+      );
+      return response;
+    });
+
+    await boundaryQueue.enqueue(enqueueReq({ messageId: 'msg_horizon_retry' }));
+    boundaryFleet.advance(1);
+    await boundaryFleet.fireDueAlarms();
+    await boundaryFleet.settle();
+
+    expect(fetchStub).toHaveBeenCalledOnce();
+    await expect(boundaryQueue.listDeadLetters()).resolves.toMatchObject({
+      data: [
+        expect.objectContaining({
+          messageId: 'msg_horizon_retry',
+          attempt: 1,
+          lastError: expect.stringContaining('timestamp horizon'),
+        }),
+      ],
+    });
+    expect(sawExactMaxClaim).toBe(true);
+    expect(boundaryStorage.alarmAt).toBeNull();
+    expectQueueTimestampContract(boundaryStorage.data, boundaryStorage.alarmAt);
+  });
+
+  it('dead-letters an unrecoverable max-deadline inflight claim after restart', async () => {
+    const boundaryFleet = new FakeFleet(
+      { queue: QueueDO },
+      { clock: () => boundaryFleet.now, fetch: fetchStub },
+      MAX_QUEUE_TIMESTAMP_MS,
+    );
+    const messageId = 'msg_horizon_restart';
+    const boundaryStorage = boundaryFleet.cell('queue', 'q:0').storage;
+    boundaryStorage.data.set(`msg:${messageId}`, {
+      ...storedMessage(messageId, boundaryFleet.now),
+      attempt: 2,
+    });
+    boundaryStorage.data.set(
+      `${INFLIGHT_DEADLINE_PREFIX}${padded(MAX_QUEUE_TIMESTAMP_MS)}:${messageId}`,
+      messageId,
+    );
+    boundaryStorage.alarmAt = MAX_QUEUE_TIMESTAMP_MS;
+    boundaryFleet.restartCell('queue', 'q:0');
+
+    await boundaryFleet.fireDueAlarms();
+
+    const boundaryQueue = boundaryFleet.namespace('queue').get({
+      toString: () => 'q:0',
+    }) as QueueDO;
+    await expect(boundaryQueue.listDeadLetters()).resolves.toMatchObject({
+      data: [
+        expect.objectContaining({
+          messageId,
+          attempt: 2,
+          lastError: expect.stringContaining('inflight recovery'),
+        }),
+      ],
+    });
+    expect(fetchStub).not.toHaveBeenCalled();
+    expect(boundaryStorage.alarmAt).toBeNull();
+    expectQueueTimestampContract(boundaryStorage.data, boundaryStorage.alarmAt);
   });
 
   it('redelivers after 503 {timeoutSeconds} without advancing the attempt', async () => {
@@ -1089,6 +1219,55 @@ describe('QueueDO', () => {
     fleet.advance(QUEUE_FENCE_GRACE_MS);
     await fleet.fireDueAlarms();
     expect(storage().has(`expired-run:${runId}`)).toBe(false);
+  });
+
+  it('schedules expiry-fence GC at the exact timestamp boundary and retains it past the horizon', async () => {
+    const exactFleet = new FakeFleet(
+      { queue: QueueDO },
+      { clock: () => exactFleet.now, fetch: fetchStub },
+      MAX_QUEUE_TIMESTAMP_MS - QUEUE_FENCE_GRACE_MS,
+    );
+    const exactQueue = exactFleet.namespace('queue').get({ toString: () => 'q:0' }) as QueueDO;
+    const exactRunId = 'wrun_exact_gc_horizon';
+    const exactReceipt = await exactQueue.expireRun(exactRunId, exactFleet.now);
+    if (!exactReceipt.done) throw new Error('expected exact-boundary expiry receipt');
+    await expect(
+      exactQueue.acknowledgeExpireRun(exactRunId, exactReceipt.receipt),
+    ).resolves.toEqual({ acknowledged: true });
+    const exactStorage = exactFleet.cell('queue', 'q:0').storage;
+    expect(exactStorage.alarmAt).toBe(MAX_QUEUE_TIMESTAMP_MS);
+    expect(
+      Array.from(exactStorage.data.keys()).find((key) => key.startsWith('expired-run-gc:')),
+    ).toMatch(`expired-run-gc:${padded(MAX_QUEUE_TIMESTAMP_MS)}:`);
+    expectQueueTimestampContract(exactStorage.data, exactStorage.alarmAt);
+    exactFleet.advance(QUEUE_FENCE_GRACE_MS);
+    await exactFleet.fireDueAlarms();
+    expect(exactStorage.data.has(`expired-run:${exactRunId}`)).toBe(false);
+    expect(exactStorage.alarmAt).toBeNull();
+
+    const overflowFleet = new FakeFleet(
+      { queue: QueueDO },
+      { clock: () => overflowFleet.now, fetch: fetchStub },
+      MAX_QUEUE_TIMESTAMP_MS - QUEUE_FENCE_GRACE_MS + 1,
+    );
+    const overflowQueue = overflowFleet.namespace('queue').get({
+      toString: () => 'q:0',
+    }) as QueueDO;
+    const overflowRunId = 'wrun_overflow_gc_horizon';
+    const overflowReceipt = await overflowQueue.expireRun(overflowRunId, overflowFleet.now);
+    if (!overflowReceipt.done) throw new Error('expected overflow-boundary expiry receipt');
+    await expect(
+      overflowQueue.acknowledgeExpireRun(overflowRunId, overflowReceipt.receipt),
+    ).resolves.toEqual({ acknowledged: true });
+    const overflowStorage = overflowFleet.cell('queue', 'q:0').storage;
+    expect(overflowStorage.data.get(`expired-run:${overflowRunId}`)).toMatchObject({
+      compactAt: null,
+    });
+    expect(
+      Array.from(overflowStorage.data.keys()).filter((key) => key.startsWith('expired-run-gc:')),
+    ).toEqual([]);
+    expect(overflowStorage.alarmAt).toBeNull();
+    expectQueueTimestampContract(overflowStorage.data, overflowStorage.alarmAt);
   });
 
   it('compacts many acknowledged exact fences to no derivative state in paged alarm work', async () => {

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createQueue, shardFor } from '../src/queue.js';
 import { parse, stringify } from '../src/vendor/shared/index.js';
 import { clearMockData, createMockEnv, recordedEnqueues } from '../src/test-mocks.js';
+import { MAX_QUEUE_DELAY_SECONDS, MAX_QUEUE_SHARDS } from '../src/validation.js';
 
 function vqsRequest(
   message: unknown,
@@ -21,7 +22,7 @@ function vqsRequest(
 ): Request {
   return new Request('http://localhost', {
     method: 'POST',
-    headers,
+    headers: { 'content-type': 'application/json', ...headers },
     body: stringify(message),
   });
 }
@@ -45,6 +46,34 @@ describe('Queue (celld QueueDO integration)', () => {
     process.env.NODE_ENV = originalNodeEnv;
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  it.each([
+    ['queueShards', 0],
+    ['queueShards', MAX_QUEUE_SHARDS + 1],
+    ['httpTimeoutMs', 0],
+    ['httpTimeoutMs', 300_001],
+    ['maxAttempts', 0],
+    ['backoffDelayMs', -1],
+    ['backoffDelayMs', 1.5],
+    ['backoffDelayMs', 60_001],
+  ] as const)('rejects invalid queue option %s=%s', (name, value) => {
+    expect(() =>
+      createQueue({
+        env: { WORKFLOW_QUEUE: mockEnv.WORKFLOW_QUEUE },
+        deploymentId: 'test-deployment',
+        [name]: value,
+      }),
+    ).toThrow(name);
+  });
+
+  it('requires the queue binding before constructing the queue', () => {
+    expect(() =>
+      createQueue({
+        env: {} as { WORKFLOW_QUEUE: typeof mockEnv.WORKFLOW_QUEUE },
+        deploymentId: 'test-deployment',
+      }),
+    ).toThrow(/missing WORKFLOW_QUEUE/);
   });
 
   describe('queue() - Production Mode', () => {
@@ -94,6 +123,16 @@ describe('Queue (celld QueueDO integration)', () => {
       await queue.queue('__wkf_workflow_test', {}, { delaySeconds: 42 });
       expect(recordedEnqueues[0].delaySeconds).toBe(42);
     });
+
+    it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, MAX_QUEUE_DELAY_SECONDS + 1])(
+      'rejects invalid delaySeconds %s before enqueue',
+      async (delaySeconds) => {
+        await expect(queue.queue('__wkf_workflow_test', {}, { delaySeconds })).rejects.toThrow(
+          /delaySeconds/,
+        );
+        expect(recordedEnqueues).toHaveLength(0);
+      },
+    );
 
     it('should generate unique monotonic message IDs', async () => {
       const first = await queue.queue('__wkf_workflow_test', {});
@@ -284,6 +323,52 @@ describe('Queue (celld QueueDO integration)', () => {
       );
     });
 
+    it.each(['0', '-1', '1.5', '5junk', 'Infinity', '9007199254740992'])(
+      'rejects malformed attempt header %j without invoking the handler',
+      async (attempt) => {
+        const handler = vi.fn<QueueMessageHandler>();
+        const queueHandler = queue.createQueueHandler('workflow:', handler);
+        const response = await queueHandler(
+          vqsRequest(
+            { data: 'test' },
+            {
+              'x-vqs-queue-name': 'workflow:test-queue',
+              'x-vqs-message-id': 'msg_test',
+              'x-vqs-message-attempt': attempt,
+            },
+          ),
+        );
+        expect(response.status).toBe(400);
+        expect(handler).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([
+      '{',
+      'null',
+      '[]',
+      '{"data":{"__type":"Uint8Array"}}',
+      '{"data":{"__type":"Uint8Array","data":"not base64!"}}',
+      '{"data":{"__uint8array":true,"data":[0,256]}}',
+    ])('rejects malformed tagged JSON without invoking the handler', async (body) => {
+      const handler = vi.fn<QueueMessageHandler>();
+      const queueHandler = queue.createQueueHandler('workflow:', handler);
+      const response = await queueHandler(
+        new Request('http://localhost', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-vqs-queue-name': 'workflow:test-queue',
+            'x-vqs-message-id': 'msg_test',
+            'x-vqs-message-attempt': '1',
+          },
+          body,
+        }),
+      );
+      expect(response.status).toBe(422);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
     it('should signal redelivery when the handler returns timeoutSeconds', async () => {
       const handler = vi.fn<QueueMessageHandler>().mockResolvedValue({ timeoutSeconds: 30 });
       const queueHandler = queue.createQueueHandler('workflow:', handler);
@@ -294,6 +379,38 @@ describe('Queue (celld QueueDO integration)', () => {
       expect(response.headers.get('Retry-After')).toBe('30');
       const body = await response.json();
       expect(body.timeoutSeconds).toBe(30);
+    });
+
+    it.each([-1, 0, 1.5, Number.NaN, Number.POSITIVE_INFINITY, MAX_QUEUE_DELAY_SECONDS + 1])(
+      'rejects invalid handler timeoutSeconds %s as a transient failure',
+      async (timeoutSeconds) => {
+        const handler = vi.fn<QueueMessageHandler>().mockResolvedValue({ timeoutSeconds });
+        const queueHandler = queue.createQueueHandler('workflow:', handler);
+        const response = await queueHandler(vqsRequest({ data: 'test' }));
+        expect(response.status).toBe(500);
+        expect(response.headers.get('Retry-After')).toBe('2');
+      },
+    );
+
+    it('rejects the wrong method and content type before invoking the handler', async () => {
+      const handler = vi.fn<QueueMessageHandler>();
+      const queueHandler = queue.createQueueHandler('workflow:', handler);
+      const getResponse = await queueHandler(
+        new Request('http://localhost', {
+          method: 'GET',
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      expect(getResponse.status).toBe(405);
+      const contentTypeResponse = await queueHandler(
+        new Request('http://localhost', {
+          method: 'POST',
+          headers: { 'content-type': 'text/plain' },
+          body: '{}',
+        }),
+      );
+      expect(contentTypeResponse.status).toBe(415);
+      expect(handler).not.toHaveBeenCalled();
     });
 
     it('should surface permanent errors with their own status', async () => {
@@ -345,7 +462,11 @@ describe('Queue (celld QueueDO integration)', () => {
       const queueHandler = queue.createQueueHandler('workflow:', handler);
 
       const response = await queueHandler(
-        new Request('http://localhost', { method: 'POST', body: stringify({ data: 'x' }) }),
+        new Request('http://localhost', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: stringify({ data: 'x' }),
+        }),
       );
 
       expect(response.status).toBe(400);
@@ -383,6 +504,10 @@ describe('Queue (celld QueueDO integration)', () => {
         expect(shard).toBeLessThan(8);
       }
       expect(shardFor('anything', 1)).toBe(0);
+    });
+
+    it.each([0, 1.5, MAX_QUEUE_SHARDS + 1])('rejects an invalid shard count %s', (shards) => {
+      expect(() => shardFor('anything', shards)).toThrow(/queueShards/);
     });
   });
 });

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -10,7 +10,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createQueue, shardFor } from '../src/queue.js';
 import { parse, stringify } from '../src/vendor/shared/index.js';
 import { clearMockData, createMockEnv, recordedEnqueues } from '../src/test-mocks.js';
-import { MAX_QUEUE_DELAY_SECONDS, MAX_QUEUE_SHARDS } from '../src/validation.js';
+import { MAX_QUEUE_DELAY_SECONDS } from '../src/validation.js';
+
+const WORKFLOW_PAYLOAD = { runId: 'wrun_queue_test' };
 
 function vqsRequest(
   message: unknown,
@@ -42,6 +44,7 @@ describe('Queue (celld QueueDO integration)', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     process.env.VITEST = originalVitest;
     process.env.NODE_ENV = originalNodeEnv;
     vi.unstubAllGlobals();
@@ -50,7 +53,7 @@ describe('Queue (celld QueueDO integration)', () => {
 
   it.each([
     ['queueShards', 0],
-    ['queueShards', MAX_QUEUE_SHARDS + 1],
+    ['queueShards', Number.MAX_SAFE_INTEGER + 1],
     ['httpTimeoutMs', 0],
     ['httpTimeoutMs', 300_001],
     ['maxAttempts', 0],
@@ -65,6 +68,16 @@ describe('Queue (celld QueueDO integration)', () => {
         [name]: value,
       }),
     ).toThrow(name);
+  });
+
+  it.each([129, Number.MAX_SAFE_INTEGER])('accepts queueShards=%s', (queueShards) => {
+    expect(() =>
+      createQueue({
+        env: { WORKFLOW_QUEUE: mockEnv.WORKFLOW_QUEUE },
+        deploymentId: 'test-deployment',
+        queueShards,
+      }),
+    ).not.toThrow();
   });
 
   it('requires the queue binding before constructing the queue', () => {
@@ -90,7 +103,7 @@ describe('Queue (celld QueueDO integration)', () => {
 
     it('should enqueue into a queue cell with a tagged-JSON body', async () => {
       const queueName = '__wkf_workflow_test' as ValidQueueName;
-      const message = { data: 'test-message' };
+      const message = { runId: 'wrun_test_message', stepId: 'step_test' };
 
       const result = await queue.queue(queueName, message);
 
@@ -109,34 +122,39 @@ describe('Queue (celld QueueDO integration)', () => {
     });
 
     it('should route workflow queues to the flow pathname', async () => {
-      await queue.queue('__wkf_workflow_test', {});
+      await queue.queue('__wkf_workflow_test', WORKFLOW_PAYLOAD);
       expect(recordedEnqueues[0].pathname).toBe('flow');
     });
 
     it('should include the idempotency key in the enqueue request', async () => {
       const idempotencyKey = 'unique-key-123';
-      await queue.queue('__wkf_workflow_test', { data: 'test' }, { idempotencyKey });
+      await queue.queue('__wkf_workflow_test', WORKFLOW_PAYLOAD, { idempotencyKey });
       expect(recordedEnqueues[0].idempotencyKey).toBe(idempotencyKey);
     });
 
     it('should pass delaySeconds through to the queue cell', async () => {
-      await queue.queue('__wkf_workflow_test', {}, { delaySeconds: 42 });
+      await queue.queue('__wkf_workflow_test', WORKFLOW_PAYLOAD, { delaySeconds: 42 });
       expect(recordedEnqueues[0].delaySeconds).toBe(42);
     });
 
     it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, MAX_QUEUE_DELAY_SECONDS + 1])(
       'rejects invalid delaySeconds %s before enqueue',
       async (delaySeconds) => {
-        await expect(queue.queue('__wkf_workflow_test', {}, { delaySeconds })).rejects.toThrow(
-          /delaySeconds/,
-        );
+        await expect(
+          queue.queue('__wkf_workflow_test', WORKFLOW_PAYLOAD, { delaySeconds }),
+        ).rejects.toThrow(/delaySeconds/);
         expect(recordedEnqueues).toHaveLength(0);
       },
     );
 
+    it('rejects a malformed queue payload before resolving a cell', async () => {
+      await expect(queue.queue('__wkf_workflow_test', {})).rejects.toMatchObject({ status: 422 });
+      expect(recordedEnqueues).toHaveLength(0);
+    });
+
     it('should generate unique monotonic message IDs', async () => {
-      const first = await queue.queue('__wkf_workflow_test', {});
-      const second = await queue.queue('__wkf_workflow_test', {});
+      const first = await queue.queue('__wkf_workflow_test', WORKFLOW_PAYLOAD);
+      const second = await queue.queue('__wkf_workflow_test', WORKFLOW_PAYLOAD);
 
       expect(first.messageId).toMatch(/^msg_/);
       expect(second.messageId).toMatch(/^msg_/);
@@ -146,12 +164,12 @@ describe('Queue (celld QueueDO integration)', () => {
     it('should return the original messageId when the cell dedups on idempotencyKey', async () => {
       const first = await queue.queue(
         '__wkf_workflow_a',
-        { data: 1 },
+        { ...WORKFLOW_PAYLOAD, stepId: 'step_1' },
         { idempotencyKey: 'step-abc' },
       );
       const second = await queue.queue(
         '__wkf_workflow_a',
-        { data: 1 },
+        { ...WORKFLOW_PAYLOAD, stepId: 'step_1' },
         { idempotencyKey: 'step-abc' },
       );
 
@@ -184,8 +202,8 @@ describe('Queue (celld QueueDO integration)', () => {
         queueShards: 4,
       });
 
-      await queue.queue('__wkf_workflow_a', { n: 1 }, { idempotencyKey: 'k-1' });
-      await queue.queue('__wkf_workflow_b', { n: 2 }, { idempotencyKey: 'k-1' });
+      await queue.queue('__wkf_workflow_a', WORKFLOW_PAYLOAD, { idempotencyKey: 'k-1' });
+      await queue.queue('__wkf_workflow_b', WORKFLOW_PAYLOAD, { idempotencyKey: 'k-1' });
 
       // Cell-level dedup on the same key means only the first enqueue lands.
       expect(recordedEnqueues).toHaveLength(1);
@@ -203,7 +221,7 @@ describe('Queue (celld QueueDO integration)', () => {
     });
 
     it('should not enqueue into queue cells in test mode', async () => {
-      await queue.queue('__wkf_workflow_q', { data: 'test' });
+      await queue.queue('__wkf_workflow_q', WORKFLOW_PAYLOAD);
       expect(recordedEnqueues).toHaveLength(0);
     });
 
@@ -216,19 +234,19 @@ describe('Queue (celld QueueDO integration)', () => {
         deploymentId: 'test-deployment',
       });
 
-      await queue.queue('__wkf_workflow_q', { data: 'test' });
+      await queue.queue('__wkf_workflow_q', WORKFLOW_PAYLOAD);
       expect(recordedEnqueues).toHaveLength(0);
     });
 
     it('should dedup messages on idempotencyKey while inflight', async () => {
       const first = await queue.queue(
         '__wkf_workflow_a',
-        { data: 1 },
+        { ...WORKFLOW_PAYLOAD, stepId: 'step_1' },
         { idempotencyKey: 'step-abc' },
       );
       const second = await queue.queue(
         '__wkf_workflow_a',
-        { data: 1 },
+        { ...WORKFLOW_PAYLOAD, stepId: 'step_1' },
         { idempotencyKey: 'step-abc' },
       );
 
@@ -236,7 +254,7 @@ describe('Queue (celld QueueDO integration)', () => {
 
       const third = await queue.queue(
         '__wkf_workflow_a',
-        { data: 2 },
+        { ...WORKFLOW_PAYLOAD, stepId: 'step_2' },
         { idempotencyKey: 'step-other' },
       );
       expect(third.messageId).not.toBe(first.messageId);
@@ -255,9 +273,46 @@ describe('Queue (celld QueueDO integration)', () => {
       vi.stubGlobal('fetch', fetchStub);
 
       await queue.start();
-      await queue.queue('__wkf_workflow_q', { data: 'test' });
+      await queue.queue('__wkf_workflow_q', WORKFLOW_PAYLOAD);
 
       await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+    });
+
+    it('chunks waits beyond the host timer ceiling without early delivery', async () => {
+      vi.useFakeTimers({ now: Date.now() });
+      const fetchStub = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 204 }));
+      vi.stubGlobal('fetch', fetchStub);
+      const delaySeconds = Math.floor(0x7fffffff / 1000) + 2;
+
+      await queue.start();
+      await queue.queue('__wkf_workflow_q', WORKFLOW_PAYLOAD, { delaySeconds });
+      await vi.advanceTimersByTimeAsync(0x7fffffff);
+      expect(fetchStub).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(delaySeconds * 1000 - 0x7fffffff - 1);
+      expect(fetchStub).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledOnce());
+    });
+
+    it('delivers at the exact queue timestamp boundary and rejects one second beyond it', async () => {
+      const startTime = 9_999_999_998_999;
+      vi.useFakeTimers({ now: startTime });
+      const fetchStub = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 204 }));
+      vi.stubGlobal('fetch', fetchStub);
+
+      await queue.start();
+      await queue.queue('__wkf_workflow_q', WORKFLOW_PAYLOAD, { delaySeconds: 1 });
+      await expect(
+        queue.queue('__wkf_workflow_q', WORKFLOW_PAYLOAD, { delaySeconds: 2 }),
+      ).rejects.toThrow(/delaySeconds/);
+      await vi.advanceTimersByTimeAsync(999);
+      expect(fetchStub).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledOnce());
     });
   });
 
@@ -273,14 +328,16 @@ describe('Queue (celld QueueDO integration)', () => {
       const handler = vi.fn<QueueMessageHandler>().mockResolvedValue(undefined);
       const queueHandler = queue.createQueueHandler('workflow:', handler);
 
-      const response = await queueHandler(vqsRequest({ data: 'test-data' }));
+      const response = await queueHandler(
+        vqsRequest({ runId: 'wrun_handler', stepId: 'step_handler' }),
+      );
 
       expect(response.status).toBe(204);
       expect(response.body).toBeNull();
       await expect(response.text()).resolves.toBe('');
       expect(handler).toHaveBeenCalledOnce();
       expect(handler).toHaveBeenCalledWith(
-        { data: 'test-data' },
+        { runId: 'wrun_handler', stepId: 'step_handler' },
         expect.objectContaining({
           queueName: 'workflow:test-queue',
           attempt: 1,
@@ -294,7 +351,17 @@ describe('Queue (celld QueueDO integration)', () => {
       const queueHandler = queue.createQueueHandler('workflow:', handler);
 
       const input = new Uint8Array([9, 8, 7]);
-      const response = await queueHandler(vqsRequest({ runInput: { input } }));
+      const response = await queueHandler(
+        vqsRequest({
+          runId: 'wrun_binary',
+          runInput: {
+            input,
+            deploymentId: 'deployment',
+            workflowName: 'workflow',
+            specVersion: SPEC_VERSION_CURRENT,
+          },
+        }),
+      );
 
       expect(response.status).toBe(204);
       const [message] = handler.mock.calls[0];
@@ -307,14 +374,11 @@ describe('Queue (celld QueueDO integration)', () => {
       const queueHandler = queue.createQueueHandler('workflow:', handler);
 
       await queueHandler(
-        vqsRequest(
-          { data: 'test' },
-          {
-            'x-vqs-queue-name': 'workflow:test-queue',
-            'x-vqs-message-id': 'msg_test',
-            'x-vqs-message-attempt': '3',
-          },
-        ),
+        vqsRequest(WORKFLOW_PAYLOAD, {
+          'x-vqs-queue-name': 'workflow:test-queue',
+          'x-vqs-message-id': 'msg_test',
+          'x-vqs-message-attempt': '3',
+        }),
       );
 
       expect(handler).toHaveBeenCalledWith(
@@ -329,14 +393,11 @@ describe('Queue (celld QueueDO integration)', () => {
         const handler = vi.fn<QueueMessageHandler>();
         const queueHandler = queue.createQueueHandler('workflow:', handler);
         const response = await queueHandler(
-          vqsRequest(
-            { data: 'test' },
-            {
-              'x-vqs-queue-name': 'workflow:test-queue',
-              'x-vqs-message-id': 'msg_test',
-              'x-vqs-message-attempt': attempt,
-            },
-          ),
+          vqsRequest(WORKFLOW_PAYLOAD, {
+            'x-vqs-queue-name': 'workflow:test-queue',
+            'x-vqs-message-id': 'msg_test',
+            'x-vqs-message-attempt': attempt,
+          }),
         );
         expect(response.status).toBe(400);
         expect(handler).not.toHaveBeenCalled();
@@ -347,6 +408,8 @@ describe('Queue (celld QueueDO integration)', () => {
       '{',
       'null',
       '[]',
+      '{}',
+      '{"data":"not-a-queue-payload"}',
       '{"data":{"__type":"Uint8Array"}}',
       '{"data":{"__type":"Uint8Array","data":"not base64!"}}',
       '{"data":{"__uint8array":true,"data":[0,256]}}',
@@ -373,7 +436,7 @@ describe('Queue (celld QueueDO integration)', () => {
       const handler = vi.fn<QueueMessageHandler>().mockResolvedValue({ timeoutSeconds: 30 });
       const queueHandler = queue.createQueueHandler('workflow:', handler);
 
-      const response = await queueHandler(vqsRequest({ data: 'test' }));
+      const response = await queueHandler(vqsRequest(WORKFLOW_PAYLOAD));
 
       expect(response.status).toBe(503);
       expect(response.headers.get('Retry-After')).toBe('30');
@@ -386,7 +449,7 @@ describe('Queue (celld QueueDO integration)', () => {
       async (timeoutSeconds) => {
         const handler = vi.fn<QueueMessageHandler>().mockResolvedValue({ timeoutSeconds });
         const queueHandler = queue.createQueueHandler('workflow:', handler);
-        const response = await queueHandler(vqsRequest({ data: 'test' }));
+        const response = await queueHandler(vqsRequest(WORKFLOW_PAYLOAD));
         expect(response.status).toBe(500);
         expect(response.headers.get('Retry-After')).toBe('2');
       },
@@ -419,7 +482,7 @@ describe('Queue (celld QueueDO integration)', () => {
         .mockRejectedValue(new WorkflowWorldError('run already terminal', { status: 410 }));
       const queueHandler = queue.createQueueHandler('workflow:', handler);
 
-      const response = await queueHandler(vqsRequest({ data: 'test' }));
+      const response = await queueHandler(vqsRequest(WORKFLOW_PAYLOAD));
 
       expect(response.status).toBe(410);
       const body = await response.json();
@@ -430,7 +493,7 @@ describe('Queue (celld QueueDO integration)', () => {
       const handler = vi.fn<QueueMessageHandler>().mockRejectedValue(new Error('Handler error'));
       const queueHandler = queue.createQueueHandler('workflow:', handler);
 
-      const response = await queueHandler(vqsRequest({ data: 'test' }));
+      const response = await queueHandler(vqsRequest(WORKFLOW_PAYLOAD));
 
       expect(response.status).toBe(500);
       expect(response.headers.get('Retry-After')).toBeDefined();
@@ -443,14 +506,11 @@ describe('Queue (celld QueueDO integration)', () => {
       const queueHandler = queue.createQueueHandler('workflow:', handler);
 
       const response = await queueHandler(
-        vqsRequest(
-          { data: 'test' },
-          {
-            'x-vqs-queue-name': 'invalid:test-queue',
-            'x-vqs-message-id': 'msg_test',
-            'x-vqs-message-attempt': '1',
-          },
-        ),
+        vqsRequest(WORKFLOW_PAYLOAD, {
+          'x-vqs-queue-name': 'invalid:test-queue',
+          'x-vqs-message-id': 'msg_test',
+          'x-vqs-message-attempt': '1',
+        }),
       );
 
       expect(response.status).toBe(400);
@@ -465,7 +525,7 @@ describe('Queue (celld QueueDO integration)', () => {
         new Request('http://localhost', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: stringify({ data: 'x' }),
+          body: stringify(WORKFLOW_PAYLOAD),
         }),
       );
 
@@ -506,8 +566,16 @@ describe('Queue (celld QueueDO integration)', () => {
       expect(shardFor('anything', 1)).toBe(0);
     });
 
-    it.each([0, 1.5, MAX_QUEUE_SHARDS + 1])('rejects an invalid shard count %s', (shards) => {
-      expect(() => shardFor('anything', shards)).toThrow(/queueShards/);
+    it.each([0, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+      'rejects an invalid shard count %s',
+      (shards) => {
+        expect(() => shardFor('anything', shards)).toThrow(/queueShards/);
+      },
+    );
+
+    it.each([129, Number.MAX_SAFE_INTEGER])('accepts a positive safe shard count %s', (shards) => {
+      expect(shardFor('anything', shards)).toBeGreaterThanOrEqual(0);
+      expect(shardFor('anything', shards)).toBeLessThan(shards);
     });
   });
 });

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createQueue, shardFor } from '../src/queue.js';
 import { parse, stringify } from '../src/vendor/shared/index.js';
 import { clearMockData, createMockEnv, recordedEnqueues } from '../src/test-mocks.js';
+import { MAX_QUEUE_SCHEDULE_TIMESTAMP_MS } from '../src/lifecycle.js';
 import { MAX_QUEUE_DELAY_SECONDS } from '../src/validation.js';
 
 const WORKFLOW_PAYLOAD = { runId: 'wrun_queue_test' };
@@ -296,8 +297,8 @@ describe('Queue (celld QueueDO integration)', () => {
       await vi.waitFor(() => expect(fetchStub).toHaveBeenCalledOnce());
     });
 
-    it('delivers at the exact queue timestamp boundary and rejects one second beyond it', async () => {
-      const startTime = 9_999_999_998_999;
+    it('delivers at the exact admissible queue boundary and rejects one second beyond it', async () => {
+      const startTime = MAX_QUEUE_SCHEDULE_TIMESTAMP_MS - 1_000;
       vi.useFakeTimers({ now: startTime });
       const fetchStub = vi
         .fn<typeof fetch>()

--- a/test/retention-sweep.test.ts
+++ b/test/retention-sweep.test.ts
@@ -81,6 +81,52 @@ describe('fleet-wide workflow retention sweep', () => {
     harness = undefined;
   });
 
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid scheduledTime %s before reading bindings',
+    async (scheduledTime) => {
+      await expect(runRetentionSweep(scheduledTime, {} as RetentionSweepEnv)).rejects.toThrow(
+        /scheduledTime/,
+      );
+    },
+  );
+
+  it.each([
+    ['WORKFLOW_RETENTION_MS', ''],
+    ['WORKFLOW_RETENTION_MS', ' '],
+    ['WORKFLOW_RETENTION_MS', '5junk'],
+    ['WORKFLOW_RETENTION_MS', '1.5'],
+    ['WORKFLOW_RETENTION_MS', 'Infinity'],
+    ['WORKFLOW_RETENTION_BATCH_SIZE', ''],
+    ['WORKFLOW_RETENTION_BATCH_SIZE', '2junk'],
+    ['WORKFLOW_RETENTION_BATCH_SIZE', 0],
+    ['WORKFLOW_RETENTION_BATCH_SIZE', 1001],
+    ['WORKFLOW_RETENTION_QUEUE_SHARDS', ''],
+    ['WORKFLOW_RETENTION_QUEUE_SHARDS', '2junk'],
+    ['WORKFLOW_RETENTION_QUEUE_SHARDS', 0],
+    ['WORKFLOW_RETENTION_QUEUE_SHARDS', 1.5],
+    ['WORKFLOW_RETENTION_QUEUE_SHARDS', 129],
+  ] as const)('rejects malformed retention setting %s=%j', async (name, value) => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const env = sweepEnv(harness, {
+      WORKFLOW_RETENTION_MS: 1,
+      WORKFLOW_RETENTION_BATCH_SIZE: 1,
+      WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+      [name]: value,
+    });
+    harness.fleet.advance(10);
+    await expect(runRetentionSweep(harness.fleet.now, env)).rejects.toThrow(name);
+  });
+
+  it('fails deterministically when an enabled sweep is missing a required binding', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    harness.fleet.advance(10);
+    const env = sweepEnv(harness, { WORKFLOW_RETENTION_MS: 1 });
+    (env as Partial<RetentionSweepEnv>).WORKFLOW_DB = undefined;
+    await expect(runRetentionSweep(harness.fleet.now, env)).rejects.toThrow(
+      /missing binding WORKFLOW_DB/,
+    );
+  });
+
   it('expires pending, running, and terminal workflows by creation age', async () => {
     process.env.CELLD_QUEUE_MODE = 'cells';
     harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
@@ -346,6 +392,53 @@ describe('fleet-wide workflow retention sweep', () => {
     );
   });
 
+  it('removes malformed catalog values while preserving valid cleanup in the same page', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+    });
+    const validRunId = await createRun(world, 'valid-with-corrupt-neighbors', 'pending');
+    const validRun = await world.runs.get(validRunId);
+    const corruptEntries = [
+      { runId: 'wrun_corrupt_json', value: '{' },
+      { runId: 'wrun_corrupt_null', value: 'null' },
+      { runId: 'wrun_corrupt_mismatch', value: JSON.stringify({ runId: 'wrun_other' }) },
+    ].map((entry, index) =>
+      Object.assign(entry, {
+        key: `runall:${sortableTimestamp(new Date(validRun.createdAt.getTime() - 10_000 + index))}:${entry.runId}`,
+      }),
+    );
+    for (const entry of corruptEntries) {
+      harness.fleet
+        .cell('run-catalog', runCatalogShardName(entry.runId))
+        .storage.data.set(entry.key, entry.value);
+    }
+    harness.fleet.advance(1_000);
+
+    await expect(
+      runRetentionSweep(
+        harness.fleet.now,
+        sweepEnv(harness, {
+          WORKFLOW_RETENTION_MS: 100,
+          WORKFLOW_RETENTION_BATCH_SIZE: 4,
+          WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+        }),
+      ),
+    ).resolves.toMatchObject({ scanned: 4, invalid: 3, expired: 1 });
+    for (const entry of corruptEntries) {
+      expect(
+        harness.fleet
+          .cell('run-catalog', runCatalogShardName(entry.runId))
+          .storage.data.has(entry.key),
+      ).toBe(false);
+    }
+    await expect(world.runs.get(validRunId)).rejects.toSatisfy((error) =>
+      RunExpiredError.is(error),
+    );
+  });
+
   it('does no catalog work while the policy is disabled', async () => {
     harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
     const result = await runRetentionSweep(
@@ -360,6 +453,7 @@ describe('fleet-wide workflow retention sweep', () => {
       expired: 0,
       missing: 0,
       notDue: 0,
+      invalid: 0,
     });
   });
 });

--- a/test/retention-sweep.test.ts
+++ b/test/retention-sweep.test.ts
@@ -1,11 +1,12 @@
 import { RunExpiredError } from '@workflow/errors';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createCelldWorld } from '../src/index.js';
-import { runCatalogShardName } from '../src/indexes.js';
+import { allRunCatalogShardNames, runCatalogShardName } from '../src/indexes.js';
 import { sortableTimestamp } from '../src/retention.js';
 import { startHarness, type Harness } from '../src/testing/http-harness.js';
 import type { QueueDO } from '../src/worker/durable-objects/QueueDO.js';
 import type { WorkflowRunDO } from '../src/worker/durable-objects/WorkflowRunDO.js';
+import type { RunCatalogDO } from '../src/worker/durable-objects/RunCatalogDO.js';
 import { runRetentionSweep, type RetentionSweepEnv } from '../src/worker/retention-sweep.js';
 
 function sweepEnv(
@@ -104,7 +105,7 @@ describe('fleet-wide workflow retention sweep', () => {
     ['WORKFLOW_RETENTION_QUEUE_SHARDS', '2junk'],
     ['WORKFLOW_RETENTION_QUEUE_SHARDS', 0],
     ['WORKFLOW_RETENTION_QUEUE_SHARDS', 1.5],
-    ['WORKFLOW_RETENTION_QUEUE_SHARDS', 129],
+    ['WORKFLOW_RETENTION_QUEUE_SHARDS', Number.MAX_SAFE_INTEGER + 1],
   ] as const)('rejects malformed retention setting %s=%j', async (name, value) => {
     harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
     const env = sweepEnv(harness, {
@@ -116,6 +117,24 @@ describe('fleet-wide workflow retention sweep', () => {
     harness.fleet.advance(10);
     await expect(runRetentionSweep(harness.fleet.now, env)).rejects.toThrow(name);
   });
+
+  it.each([129, Number.MAX_SAFE_INTEGER])(
+    'accepts WORKFLOW_RETENTION_QUEUE_SHARDS=%s',
+    async (queueShards) => {
+      harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+      harness.fleet.advance(10);
+      await expect(
+        runRetentionSweep(
+          harness.fleet.now,
+          sweepEnv(harness, {
+            WORKFLOW_RETENTION_MS: 1,
+            WORKFLOW_RETENTION_BATCH_SIZE: 1,
+            WORKFLOW_RETENTION_QUEUE_SHARDS: queueShards,
+          }),
+        ),
+      ).resolves.toMatchObject({ scanned: 0 });
+    },
+  );
 
   it('fails deterministically when an enabled sweep is missing a required binding', async () => {
     harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
@@ -439,6 +458,91 @@ describe('fleet-wide workflow retention sweep', () => {
     );
   });
 
+  it('uses source-shard provenance so a wrong-shard poison cannot starve batch-one sweeps', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+    });
+    const validRunId = await createRun(world, 'after-wrong-shard-poison', 'pending');
+    const validRun = await world.runs.get(validRunId);
+    const poisonRunId = 'wrun_wrong_shard_poison';
+    const wrongShard = allRunCatalogShardNames().find(
+      (name) => name !== runCatalogShardName(poisonRunId),
+    );
+    if (!wrongShard) throw new Error('expected an alternate catalog shard');
+    const poisonKey = `runall:${sortableTimestamp(new Date(validRun.createdAt.getTime() - 10_000))}:${poisonRunId}`;
+    const poisonStorage = harness.fleet.cell('run-catalog', wrongShard).storage.data;
+    poisonStorage.set(poisonKey, '{');
+    harness.fleet.advance(1_000);
+    const env = sweepEnv(harness, {
+      WORKFLOW_RETENTION_MS: 100,
+      WORKFLOW_RETENTION_BATCH_SIZE: 1,
+      WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+    });
+
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 1,
+      invalid: 1,
+      expired: 0,
+      preserved: 0,
+    });
+    expect(poisonStorage.has(poisonKey)).toBe(false);
+    await expect(runRetentionSweep(harness.fleet.now, env)).resolves.toMatchObject({
+      scanned: 1,
+      invalid: 0,
+      expired: 1,
+    });
+    await expect(world.runs.get(validRunId)).rejects.toSatisfy((error) =>
+      RunExpiredError.is(error),
+    );
+  });
+
+  it('preserves a concurrently repaired catalog value and still cleans another candidate', async () => {
+    harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-sweep-secret',
+      deploymentId: 'retention-sweep-tests',
+    });
+    const validRunId = await createRun(world, 'alongside-catalog-repair', 'pending');
+    const validRun = await world.runs.get(validRunId);
+    const repairedRunId = 'wrun_concurrently_repaired';
+    const repairedKey = `runall:${sortableTimestamp(new Date(validRun.createdAt.getTime() - 10_000))}:${repairedRunId}`;
+    const repairedValue = JSON.stringify({ runId: repairedRunId });
+    const shard = runCatalogShardName(repairedRunId);
+    const catalogCell = harness.fleet.cell('run-catalog', shard);
+    catalogCell.storage.data.set(repairedKey, '{');
+    const catalog = catalogCell.instance as RunCatalogDO;
+    const originalDelete = catalog.deleteStaleGlobalRun.bind(catalog);
+    catalog.deleteStaleGlobalRun = async (runId, key, expectedValue) => {
+      if (key === repairedKey) catalogCell.storage.data.set(repairedKey, repairedValue);
+      return await originalDelete(runId, key, expectedValue);
+    };
+    harness.fleet.advance(1_000);
+
+    await expect(
+      runRetentionSweep(
+        harness.fleet.now,
+        sweepEnv(harness, {
+          WORKFLOW_RETENTION_MS: 100,
+          WORKFLOW_RETENTION_BATCH_SIZE: 2,
+          WORKFLOW_RETENTION_QUEUE_SHARDS: 1,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      scanned: 2,
+      invalid: 1,
+      preserved: 1,
+      expired: 1,
+    });
+    expect(catalogCell.storage.data.get(repairedKey)).toBe(repairedValue);
+    await expect(world.runs.get(validRunId)).rejects.toSatisfy((error) =>
+      RunExpiredError.is(error),
+    );
+  });
+
   it('does no catalog work while the policy is disabled', async () => {
     harness = await startHarness({ secret: 'retention-sweep-secret', virtualClock: true });
     const result = await runRetentionSweep(
@@ -454,6 +558,7 @@ describe('fleet-wide workflow retention sweep', () => {
       missing: 0,
       notDue: 0,
       invalid: 0,
+      preserved: 0,
     });
   });
 });

--- a/test/retention.test.ts
+++ b/test/retention.test.ts
@@ -105,6 +105,61 @@ describe('terminal workflow retention', () => {
     harness = undefined;
   });
 
+  it('rejects malformed retention admin requests before state mutation', async () => {
+    harness = await startHarness({ secret: 'retention-secret', virtualClock: true });
+    const world = createCelldWorld({
+      fleetUrl: harness.url,
+      secret: 'retention-secret',
+      deploymentId: 'retention-tests',
+    });
+    const runId = await createCompletedRun(world, 'invalid-admin');
+    await finishRun(world, runId);
+    const run = harness.fleet.cell('runs', runId).instance as WorkflowRunDO;
+    const storage = harness.fleet.cell('runs', runId).storage;
+    await driveTerminalCleanup(harness, runId);
+    const before = structuredClone(Array.from(storage.data.entries()));
+    storage.resetOperationCounts();
+
+    for (const request of [
+      { retentionMs: 0, queueShards: 1 },
+      { retentionMs: -1, queueShards: 1 },
+      { retentionMs: 1.5, queueShards: 1 },
+      { retentionMs: Number.NaN, queueShards: 1 },
+      { retentionMs: 1, queueShards: 0 },
+      { retentionMs: 1, queueShards: 1.5 },
+      { retentionMs: 1, queueShards: 129 },
+    ]) {
+      await expect(run.scheduleCleanup(request)).rejects.toThrow(/retention/);
+      await expect(run.cleanupNow(request)).rejects.toThrow(/retention/);
+    }
+
+    expect(Array.from(storage.data.entries())).toEqual(before);
+    expect(storage.operationCounts.transaction).toBe(0);
+  });
+
+  it('rejects invalid event cleanup metadata before creating a run', async () => {
+    const fleet = new FakeFleet({ runs: WorkflowRunDO });
+    const runId = 'wrun_invalid_cleanup_metadata';
+    const run = fleet.namespace('runs').get({ toString: () => runId }) as WorkflowRunDO;
+    await expect(
+      run.applyEvent({
+        runId,
+        data: {
+          eventType: 'run_created',
+          eventData: {
+            deploymentId: 'retention-tests',
+            workflowName: 'invalid-cleanup',
+            input: [],
+          },
+        },
+        cleanup: { retentionMs: 0, queueShards: 0 },
+      }),
+    ).rejects.toThrow(/queueShards/);
+    const storage = fleet.cell('runs', runId).storage;
+    expect(storage.data.size).toBe(0);
+    expect(storage.operationCounts.transaction).toBe(0);
+  });
+
   it('purges payloads, indexes, streams, and queued work without allowing resurrection', async () => {
     process.env.CELLD_QUEUE_MODE = 'cells';
     harness = await startHarness({ secret: 'retention-secret', virtualClock: true });

--- a/test/retention.test.ts
+++ b/test/retention.test.ts
@@ -127,7 +127,7 @@ describe('terminal workflow retention', () => {
       { retentionMs: Number.NaN, queueShards: 1 },
       { retentionMs: 1, queueShards: 0 },
       { retentionMs: 1, queueShards: 1.5 },
-      { retentionMs: 1, queueShards: 129 },
+      { retentionMs: 1, queueShards: Number.MAX_SAFE_INTEGER + 1 },
     ]) {
       await expect(run.scheduleCleanup(request)).rejects.toThrow(/retention/);
       await expect(run.cleanupNow(request)).rejects.toThrow(/retention/);
@@ -136,6 +136,32 @@ describe('terminal workflow retention', () => {
     expect(Array.from(storage.data.entries())).toEqual(before);
     expect(storage.operationCounts.transaction).toBe(0);
   });
+
+  it.each([129, Number.MAX_SAFE_INTEGER])(
+    'accepts positive safe queueShards %s in run cleanup metadata',
+    async (queueShards) => {
+      const fleet = new FakeFleet({ runs: WorkflowRunDO });
+      const runId = `wrun_valid_cleanup_${queueShards}`;
+      const run = fleet.namespace('runs').get({ toString: () => runId }) as WorkflowRunDO;
+      await expect(
+        run.applyEvent({
+          runId,
+          data: {
+            eventType: 'run_created',
+            eventData: {
+              deploymentId: 'retention-tests',
+              workflowName: 'valid-cleanup',
+              input: [],
+            },
+          },
+          cleanup: { retentionMs: 1_000, queueShards },
+        }),
+      ).resolves.toMatchObject({ ok: true });
+      expect(fleet.cell('runs', runId).storage.data.get('retention:queue-shards')).toBe(
+        queueShards,
+      );
+    },
+  );
 
   it('rejects invalid event cleanup metadata before creating a run', async () => {
     const fleet = new FakeFleet({ runs: WorkflowRunDO });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -7,7 +7,12 @@ import { createConnection } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { rpcParse, rpcStringify } from '../src/codec.js';
 import { createRemoteEnv } from '../src/remote/namespaces.js';
-import { allRunCatalogShardNames, hookIdShardName, runCatalogShardName } from '../src/indexes.js';
+import {
+  allRunCatalogShardNames,
+  hookIdShardName,
+  hookTokenShardName,
+  runCatalogShardName,
+} from '../src/indexes.js';
 import {
   MAX_STREAM_BATCH_BYTES,
   MAX_STREAM_CHUNK_BYTES,
@@ -154,6 +159,77 @@ describe('router auth and shape', () => {
     const res = await rpc('/v1/rpc/runs/wrun_x/getRun', { not: 'an array' }, SECRET);
     expect(res.status).toBe(400);
     expect((await rpc('/v1/index/runs/list', { not: 'an array' }, SECRET)).status).toBe(400);
+  });
+
+  it.each([
+    ['/v1/index/runs/list', [{ limit: '5junk' }]],
+    ['/v1/index/runs/commit', [{ runId: 'wrun_only' }, '{}', 1]],
+    ['/v1/index/runs/expire', [{ runId: 'wrun_expire', keys: [], hooks: [], expiredAt: 1 }]],
+    ['/v1/index/hooks/reserve', ['', { runId: 'wrun_reserve', hookId: 'hook_reserve' }]],
+    ['/v1/index/hooks/reserve', ['token', { hookId: 'hook_missing_run' }]],
+    ['/v1/index/hooks/reserve', ['victim-token', { runId: 'wrun_missing_hook_id' }]],
+    [
+      '/v1/index/hooks/finalize',
+      ['token', 'hook', '{}', { runId: 'wrun_finalize', hookId: 'hook' }],
+    ],
+    [
+      '/v1/index/hooks/release-reservation',
+      ['token', { runId: 'wrun_release', hookId: 'hook' }, { claimId: '' }],
+    ],
+    [
+      '/v1/index/hooks/release',
+      [{ runId: 'wrun_release', hooks: [{ hookId: '', token: 'token' }] }],
+    ],
+  ])(
+    'rejects invalid operation arguments before resolving an index stub: %s',
+    async (path, body) => {
+      const idFromName = vi.fn<(name: string) => { toString(): string }>((name) => ({
+        toString: () => name,
+      }));
+      const get = vi.fn<(id: { toString(): string }) => unknown>();
+      const namespace = { idFromName, get };
+      const router = createRouter({
+        WORKFLOW_RUN_CATALOG: namespace,
+        WORKFLOW_HOOK_TOKENS: namespace,
+        WORKFLOW_HOOK_IDS: namespace,
+        WORLD_SECRET: SECRET,
+      } as unknown as WorkerEnv);
+      const response = await router(
+        new Request(`http://world.test${path}`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${SECRET}`,
+            'content-type': 'application/json',
+          },
+          body: rpcStringify(body),
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(idFromName).not.toHaveBeenCalled();
+      expect(get).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not persist token or undefined-hook claims for a malformed reservation', async () => {
+    const token = 'victim-token';
+    const response = await rpc(
+      '/v1/index/hooks/reserve',
+      [token, { runId: 'wrun_missing_hook_id' }],
+      SECRET,
+    );
+    expect(response.status).toBe(400);
+    expect(
+      harness.fleet
+        .cell('hook-tokens', hookTokenShardName(token))
+        .storage.data.has(`claim:${token}`),
+    ).toBe(false);
+    for (const shard of Array.from(
+      { length: 32 },
+      (_, index) => `hook-id:v1:${index.toString(16).padStart(2, '0')}`,
+    )) {
+      expect(harness.fleet.cell('hook-ids', shard).storage.data.has('claim:undefined')).toBe(false);
+    }
   });
 
   it.each([

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -9,6 +9,7 @@ import { rpcParse, rpcStringify } from '../src/codec.js';
 import { createRemoteEnv } from '../src/remote/namespaces.js';
 import { allRunCatalogShardNames, hookIdShardName, runCatalogShardName } from '../src/indexes.js';
 import {
+  MAX_STREAM_BATCH_BYTES,
   MAX_STREAM_CHUNK_BYTES,
   MAX_STREAM_READ_BYTES,
   MAX_STREAM_WRITE_CHUNKS,
@@ -19,6 +20,7 @@ import { createStorage } from '../src/storage.js';
 import { createStreamer } from '../src/streamer.js';
 import { startHarness, type Harness } from '../src/testing/http-harness.js';
 import { createRouter } from '../src/worker/router.js';
+import type { DONamespaceLike, WorkerEnv } from '../src/worker/router.js';
 
 const SECRET = 'test-secret';
 
@@ -84,6 +86,11 @@ describe('router auth and shape', () => {
     expect(body.specVersion).toBeTypeOf('number');
   });
 
+  it('rejects the wrong health method deterministically', async () => {
+    const response = await fetch(`${harness.url}/v1/health`, { method: 'POST' });
+    expect(response.status).toBe(405);
+  });
+
   it('rejects rpc without a token', async () => {
     const res = await rpc('/v1/rpc/runs/wrun_x/getRun', []);
     expect(res.status).toBe(401);
@@ -147,6 +154,214 @@ describe('router auth and shape', () => {
     const res = await rpc('/v1/rpc/runs/wrun_x/getRun', { not: 'an array' }, SECRET);
     expect(res.status).toBe(400);
     expect((await rpc('/v1/index/runs/list', { not: 'an array' }, SECRET)).status).toBe(400);
+  });
+
+  it.each([
+    '[{"__type":"Date"}]',
+    '[{"__type":"Date","iso":"not-a-date"}]',
+    '[{"__type":"Uint8Array"}]',
+    '[{"__type":"Uint8Array","data":"not base64!"}]',
+  ])('400s malformed tagged RPC JSON without dispatch: %s', async (body) => {
+    const get = vi.fn<(id: { toString(): string }) => unknown>();
+    const namespace: DONamespaceLike = {
+      idFromName: (name) => ({ toString: () => name }),
+      get,
+    };
+    const router = createRouter({
+      WORKFLOW_DB: namespace,
+      WORLD_SECRET: SECRET,
+    } as WorkerEnv);
+    const response = await router(
+      new Request('http://world.test/v1/rpc/runs/wrun_x/getRun', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${SECRET}`,
+          'content-type': 'application/json',
+        },
+        body,
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('maps RPC method, content type, path encoding, and missing bindings before dispatch', async () => {
+    const get = vi.fn<(id: { toString(): string }) => unknown>();
+    const namespace: DONamespaceLike = {
+      idFromName: (name) => ({ toString: () => name }),
+      get,
+    };
+    const router = createRouter({ WORKFLOW_DB: namespace, WORLD_SECRET: SECRET } as WorkerEnv);
+    const headers = { authorization: `Bearer ${SECRET}`, 'content-type': 'application/json' };
+
+    expect(
+      (
+        await router(
+          new Request('http://world.test/v1/rpc/runs/wrun_x/getRun', {
+            method: 'GET',
+            headers,
+          }),
+        )
+      ).status,
+    ).toBe(405);
+    expect(
+      (
+        await router(
+          new Request('http://world.test/v1/rpc/runs/wrun_x/getRun', {
+            method: 'POST',
+            headers: { authorization: `Bearer ${SECRET}`, 'content-type': 'text/plain' },
+            body: '[]',
+          }),
+        )
+      ).status,
+    ).toBe(415);
+    expect(
+      (
+        await router(
+          new Request('http://world.test/v1/rpc/runs/wrun_x/getRun', {
+            method: 'POST',
+            headers: { ...headers, 'content-length': '2junk' },
+            body: '[]',
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await router(
+          new Request('http://world.test/v1/rpc/runs/%ZZ/getRun', {
+            method: 'POST',
+            headers,
+            body: '[]',
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    const missing = createRouter({ WORLD_SECRET: SECRET } as WorkerEnv);
+    expect(
+      (
+        await missing(
+          new Request('http://world.test/v1/rpc/runs/wrun_x/getRun', {
+            method: 'POST',
+            headers,
+            body: '[]',
+          }),
+        )
+      ).status,
+    ).toBe(500);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed stream requests before resolving a Durable Object', async () => {
+    const get = vi.fn<(id: { toString(): string }) => unknown>();
+    const namespace: DONamespaceLike = {
+      idFromName: (name) => ({ toString: () => name }),
+      get,
+    };
+    const router = createRouter({
+      WORKFLOW_STREAMS: namespace,
+      WORLD_SECRET: SECRET,
+    } as WorkerEnv);
+    const authorization = { authorization: `Bearer ${SECRET}` };
+    const validQuery = `runId=wrun_x&startIndex=0&maxChunks=1&maxBytes=${MAX_STREAM_CHUNK_BYTES}&waitMs=0`;
+
+    expect(
+      (
+        await router(
+          new Request('http://world.test/v1/streams/stream%3Ax/chunks', {
+            headers: authorization,
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await router(
+          new Request(`http://world.test/v1/streams/stream%3Ax/chunks?${validQuery}`, {
+            method: 'PUT',
+            headers: authorization,
+          }),
+        )
+      ).status,
+    ).toBe(405);
+    expect(
+      (
+        await router(
+          new Request('http://world.test/v1/streams/stream%3Ax/chunks?runId=wrun_x', {
+            method: 'POST',
+            headers: { ...authorization, 'content-type': 'application/json' },
+            body: 'x',
+          }),
+        )
+      ).status,
+    ).toBe(415);
+    expect(
+      (
+        await router(
+          new Request('http://world.test/v1/streams/stream%3Ax/chunks?runId=wrun_x', {
+            method: 'POST',
+            headers: {
+              ...authorization,
+              'content-type': STREAM_BATCH_CONTENT_TYPE,
+              'content-length': String(MAX_STREAM_BATCH_BYTES + 1025),
+            },
+            body: new Uint8Array(),
+          }),
+        )
+      ).status,
+    ).toBe(413);
+    expect(
+      (
+        await router(
+          new Request('http://world.test/v1/streams/stream%3Ax/chunks?runId=wrun_x', {
+            method: 'POST',
+            headers: { ...authorization, 'content-type': STREAM_BATCH_CONTENT_TYPE },
+            body: new Uint8Array(),
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    for (const [name, value] of [
+      ['startIndex', ''],
+      ['startIndex', ' 0'],
+      ['maxChunks', '1junk'],
+      ['maxBytes', '1e6'],
+      ['waitMs', '0.5'],
+    ]) {
+      const url = new URL('http://world.test/v1/streams/stream%3Ax/chunks');
+      url.searchParams.set('runId', 'wrun_x');
+      url.searchParams.set('startIndex', '0');
+      url.searchParams.set('maxChunks', '1');
+      url.searchParams.set('maxBytes', String(MAX_STREAM_CHUNK_BYTES));
+      url.searchParams.set('waitMs', '0');
+      url.searchParams.set(name, value);
+      const response = await router(new Request(url, { headers: authorization }));
+      expect(response.status, `${name}=${JSON.stringify(value)}`).toBe(400);
+    }
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('413s an oversized stream body without content-length before resolving a cell', async () => {
+    const get = vi.fn<(id: { toString(): string }) => unknown>();
+    const namespace: DONamespaceLike = {
+      idFromName: (name) => ({ toString: () => name }),
+      get,
+    };
+    const router = createRouter({
+      WORKFLOW_STREAMS: namespace,
+      WORLD_SECRET: SECRET,
+    } as WorkerEnv);
+    const request = new Request('http://world.test/v1/streams/stream%3Ax/chunks?runId=wrun_x', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${SECRET}`,
+        'content-type': STREAM_BATCH_CONTENT_TYPE,
+      },
+      body: new Uint8Array(MAX_STREAM_BATCH_BYTES + 1025),
+    });
+    expect(request.headers.has('content-length')).toBe(false);
+    expect((await router(request)).status).toBe(413);
+    expect(get).not.toHaveBeenCalled();
   });
 
   it('413s an oversized RPC body even when content-length is absent', async () => {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -13,6 +13,7 @@ import {
   hookTokenShardName,
   runCatalogShardName,
 } from '../src/indexes.js';
+import { MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS } from '../src/lifecycle.js';
 import {
   MAX_STREAM_BATCH_BYTES,
   MAX_STREAM_CHUNK_BYTES,
@@ -26,6 +27,7 @@ import { createStreamer } from '../src/streamer.js';
 import { startHarness, type Harness } from '../src/testing/http-harness.js';
 import { createRouter } from '../src/worker/router.js';
 import type { DONamespaceLike, WorkerEnv } from '../src/worker/router.js';
+import { RunCatalogDO } from '../src/worker/durable-objects/RunCatalogDO.js';
 
 const SECRET = 'test-secret';
 
@@ -164,7 +166,18 @@ describe('router auth and shape', () => {
   it.each([
     ['/v1/index/runs/list', [{ limit: '5junk' }]],
     ['/v1/index/runs/commit', [{ runId: 'wrun_only' }, '{}', 1]],
-    ['/v1/index/runs/expire', [{ runId: 'wrun_expire', keys: [], hooks: [], expiredAt: 1 }]],
+    ['/v1/index/runs/expire', [{ runId: 'wrun_expire', expiredAt: 1 }]],
+    [
+      '/v1/index/runs/expire',
+      [
+        {
+          runId: 'wrun_expire',
+          keys: ['run:workflow:1767225600000:wrun_expire', 'runall:1767225600000:wrun_expire'],
+          hooks: [],
+          expiredAt: 1,
+        },
+      ],
+    ],
     ['/v1/index/hooks/reserve', ['', { runId: 'wrun_reserve', hookId: 'hook_reserve' }]],
     ['/v1/index/hooks/reserve', ['token', { hookId: 'hook_missing_run' }]],
     ['/v1/index/hooks/reserve', ['victim-token', { runId: 'wrun_missing_hook_id' }]],
@@ -210,6 +223,66 @@ describe('router auth and shape', () => {
       expect(get).not.toHaveBeenCalled();
     },
   );
+
+  it('rejects every caller-supplied run expiry key shape without catalog mutation', async () => {
+    const runId = 'wrun_marker_probe';
+    const timestamp = '1767225600000';
+    const canonical = [`run:workflow:${timestamp}:${runId}`, `runall:${timestamp}:${runId}`];
+    const suppliedKeyPairs = [
+      [`arbitrary:workflow:${timestamp}:${runId}`, canonical[1]],
+      [canonical[1], canonical[0]],
+      [canonical[0], canonical[0]],
+      [canonical[0], `runall:1767225600001:${runId}`],
+      [`expired:${runId}`, `expiry-gc:${timestamp}:${runId}`],
+      [`run%3Aworkflow%3A${timestamp}%3A${runId}`, canonical[1]],
+      [canonical[0], `runall:${timestamp}:wrun_wrong`],
+    ];
+    const before = allRunCatalogShardNames().map(
+      (shard) => new Map(harness.fleet.cell('run-catalog', shard).storage.data),
+    );
+
+    for (const keys of suppliedKeyPairs) {
+      const response = await rpc(
+        '/v1/index/runs/expire',
+        [{ runId, keys, hooks: [], expiredAt: 1 }],
+        SECRET,
+      );
+      expect(response.status).toBe(400);
+    }
+
+    for (const [index, shard] of allRunCatalogShardNames().entries()) {
+      expect(harness.fleet.cell('run-catalog', shard).storage.data).toEqual(before[index]);
+    }
+  });
+
+  it('expires only the catalog key pair retained by the authoritative commit', async () => {
+    const runId = 'wrun_canonical_expiry_wire';
+    const timestamp = String(harness.fleet.now).padStart(13, '0');
+    const keys = [`run:canonical-wire:${timestamp}:${runId}`, `runall:${timestamp}:${runId}`];
+    const shard = runCatalogShardName(runId);
+    const catalog = harness.fleet.namespace('run-catalog').get({
+      toString: () => shard,
+    }) as RunCatalogDO;
+    await catalog.upsertRun(
+      runId,
+      keys,
+      JSON.stringify({ runId }),
+      harness.fleet.now + MAX_RUN_INDEX_PUBLICATION_LIFETIME_MS,
+    );
+
+    const response = await rpc(
+      '/v1/index/runs/expire',
+      [{ runId, hooks: [], expiredAt: harness.fleet.now }],
+      SECRET,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ deleted: 2 });
+    const data = harness.fleet.cell('run-catalog', shard).storage.data;
+    expect(keys.every((key) => !data.has(key))).toBe(true);
+    expect(data.has(`expired:${runId}`)).toBe(true);
+    expect(Array.from(data.keys()).some((key) => key.startsWith('catalog-keys:'))).toBe(false);
+  });
 
   it('does not persist token or undefined-hook claims for a malformed reservation', async () => {
     const token = 'victim-token';


### PR DESCRIPTION
## Summary

- add one strict integer-validation boundary for typed options and environment/header strings, with explicit defaults and documented shard limits
- fail closed before Durable Object or queue mutation for malformed configuration, administrative RPC input, tagged JSON, queue envelopes, and HTTP route input
- make fleet retention discard race-safely identifiable corrupt catalog values while continuing valid cleanup in the same page
- add focused deterministic failure coverage across runtime config, QueueDO and queue handlers, retention/admin paths, and router/stream routes

## Production defects fixed

- `parseInt` accepted prefixes such as `5junk` for retention, queue runtime settings, and attempt headers; empty/malformed settings could also fall through to defaults
- direct retention admin calls accepted invalid shard/timing data, returned status for zero retention, or coerced invalid cleanup timing to `1`
- queue admin limits were floored/clamped instead of rejected, and malformed enqueue bodies/configuration could reach storage
- invalid `503 {timeoutSeconds}` responses could redeliver immediately without consuming retry budget; they now follow the existing transient-retry contract
- malformed recognized Date/Uint8Array tags could survive decoding as ordinary objects
- malformed catalog values repeatedly aborted retention discovery; exact key/value compare-delete now removes safely attributable corrupt entries without preventing valid candidates from expiring
- HTTP query parsing accepted whitespace/exponent forms, malformed content lengths were not rejected deterministically, and several method/content-type/body failures resolved a Durable Object too early
- missing in-process, queue, router, and enabled-retention bindings now fail explicitly at their boundary

## Coverage

- config: defaults; shard zero/negative/fraction/non-finite/string/over-128; retention missing/zero/decimal/empty/whitespace/partial/fraction/exponent/non-finite/negative/unsafe; RPC timeout and stream long-poll bounds/relation; flush timing; required bindings and fleet secret
- queue: invalid max attempts, max in-flight, delivery timeout, test-pump timeout/backoff, shard count, delay deadlines, missing `WORKFLOW_DB`/`WORKFLOW_QUEUE`, malformed attempt headers and tagged envelopes; assertions cover no handler call, storage write, alarm, ack, or unintended retry
- retention/admin: invalid scheduled time, sweep settings and bindings, malformed schedule/cleanup/event metadata, corrupt catalog JSON/null/mismatched run IDs, and successful cleanup alongside bad candidates
- router/stream: missing run ID, wrong methods/content types, malformed path encoding/content length, oversized bodies with and without `Content-Length`, strict bounded decimal queries, deterministic status mapping, and no Durable Object resolution on rejected input

Existing strong coverage was retained rather than duplicated for authentication without `WORLD_SECRET`, generic oversized RPC bodies without `Content-Length`, binary stream frame/chunk limits, RPC client timeout bounds, retention compare-delete races, multi-candidate partial success, QueueDO config mismatch, and retry/dead-letter/expiry state machines.

## Validation

- `pnpm exec vitest run test/config.test.ts test/queue.test.ts test/queue-do.test.ts test/router.test.ts test/retention.test.ts test/retention-sweep.test.ts` — 6 files, 237 tests passed
- `pnpm check` — format, lint, typecheck, build, 23 files / 475 tests, worker bundle, and package checks passed

## Residual limitations

- a corrupt global catalog key whose key shape does not safely identify a run shard remains an aggregated sweep failure; deleting it would require guessing ownership
- decimal strings are intentionally strict but allow leading zeroes; HTTP header implementations may normalize surrounding whitespace before application validation
- positive safe-integer `QUEUE_MAX_ATTEMPTS` values have no arbitrary upper cap; delivery timeout, concurrency, shard fanout, body size, and representable alarm deadlines do have concrete bounds
