### PR TITLE
fix: enforce negative apply-event contracts

### DIFF
--- a/src/apply-event.ts
+++ b/src/apply-event.ts
@@ -36,6 +36,7 @@ import type {
 } from '@workflow/world';
 import {
   applyAttributeChanges,
+  CreateEventSchema,
   eventIdToSlot,
   EventSchema,
   getMaxEventsPerRun,
@@ -163,6 +164,84 @@ export interface ApplyEventRequest {
   hookClaimId?: string;
   /** Internal world-celld retention policy captured with the event. */
   cleanup?: ScheduleCleanupRequest;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Validate and canonicalize the untyped fleet-facing applyEvent envelope.
+ * This runs before a RunDO transaction starts; in particular, malformed hook
+ * events cannot allocate a sequence or touch hook/entity storage.
+ */
+export function parseApplyEventRequest(value: unknown): ApplyEventRequest {
+  if (!isRecord(value)) throw new TypeError('applyEvent request must be an object');
+  if (typeof value.runId !== 'string' || value.runId.length === 0) {
+    throw new TypeError('applyEvent runId must be a non-empty string');
+  }
+
+  const data = CreateEventSchema.parse(isRecord(value.data) ? compact(value.data) : value.data);
+  const params = value.params;
+  if (params !== undefined) {
+    if (!isRecord(params)) throw new TypeError('applyEvent params must be an object');
+    if (
+      params.occurredAt !== undefined &&
+      (!(params.occurredAt instanceof Date) || Number.isNaN(params.occurredAt.getTime()))
+    ) {
+      throw new TypeError('applyEvent params.occurredAt must be a valid Date');
+    }
+    for (const key of ['resumeId', 'resumePayloadDigest', 'sinceCursor'] as const) {
+      if (params[key] !== undefined && typeof params[key] !== 'string') {
+        throw new TypeError(`applyEvent params.${key} must be a string`);
+      }
+    }
+    if (
+      params.eventCount !== undefined &&
+      (typeof params.eventCount !== 'number' ||
+        !Number.isSafeInteger(params.eventCount) ||
+        params.eventCount < 0)
+    ) {
+      throw new TypeError('applyEvent params.eventCount must be a non-negative safe integer');
+    }
+    for (const key of ['skipPreload', 'preloadEvents'] as const) {
+      if (params[key] !== undefined && params[key] !== true) {
+        throw new TypeError(`applyEvent params.${key} must be true when present`);
+      }
+    }
+  }
+
+  let tokenHolder: ApplyEventRequest['tokenHolder'];
+  if (value.tokenHolder === null) {
+    tokenHolder = null;
+  } else if (value.tokenHolder !== undefined) {
+    if (
+      !isRecord(value.tokenHolder) ||
+      typeof value.tokenHolder.runId !== 'string' ||
+      value.tokenHolder.runId.length === 0 ||
+      typeof value.tokenHolder.hookId !== 'string' ||
+      value.tokenHolder.hookId.length === 0
+    ) {
+      throw new TypeError('applyEvent tokenHolder must contain non-empty runId and hookId strings');
+    }
+    tokenHolder = { runId: value.tokenHolder.runId, hookId: value.tokenHolder.hookId };
+  }
+
+  if (
+    value.hookClaimId !== undefined &&
+    (typeof value.hookClaimId !== 'string' || value.hookClaimId.length === 0)
+  ) {
+    throw new TypeError('applyEvent hookClaimId must be a non-empty string');
+  }
+
+  return {
+    runId: value.runId,
+    data,
+    ...(params === undefined ? {} : { params }),
+    ...(value.tokenHolder === undefined ? {} : { tokenHolder }),
+    ...(value.hookClaimId === undefined ? {} : { hookClaimId: value.hookClaimId }),
+    ...(value.cleanup === undefined ? {} : { cleanup: value.cleanup as ScheduleCleanupRequest }),
+  };
 }
 
 export type ApplyEventErrorCode =

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -136,6 +136,7 @@ interface ApplyEventWireFailure {
   message: string;
   status?: number;
   retryAfter?: number;
+  retryAfterMs?: number;
   retryAfterSeconds?: number;
   runSpecVersion?: number;
   worldSpecVersion?: number;
@@ -168,6 +169,16 @@ function validateOptionalNumber(
       (integer && !Number.isSafeInteger(value)))
   ) {
     malformedApplyEventOutcome(`${key} must be ${integer ? 'a safe integer' : 'a finite number'}`);
+  }
+}
+
+function validateOptionalRetryAfterMs(outcome: Record<string, unknown>): void {
+  const value = outcome.retryAfterMs;
+  if (
+    value !== undefined &&
+    (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0)
+  ) {
+    malformedApplyEventOutcome('retryAfterMs must be a non-negative safe integer');
   }
 }
 
@@ -205,6 +216,7 @@ function parseApplyEventOutcome(value: unknown): ParsedApplyEventOutcome {
     }
     validateOptionalNumber(value, 'status', true);
     validateOptionalNumber(value, 'retryAfter', false);
+    validateOptionalRetryAfterMs(value);
     validateOptionalNumber(value, 'retryAfterSeconds', false);
     validateOptionalNumber(value, 'runSpecVersion', true);
     validateOptionalNumber(value, 'worldSpecVersion', true);
@@ -390,6 +402,7 @@ function throwOutcomeError(
         retryAfter: outcome.retryAfter,
       });
       for (const key of [
+        'retryAfterMs',
         'retryAfterSeconds',
         'runSpecVersion',
         'worldSpecVersion',

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -31,6 +31,7 @@ import type {
   WorkflowRunWithoutData,
 } from '@workflow/world';
 import {
+  CreateEventSchema,
   EventSchema,
   HookSchema,
   isTerminalWorkflowRunStatus,
@@ -152,25 +153,30 @@ function throwOutcomeError(
   runId: string,
   data: CreateEventRequest | RunCreatedEventRequest,
 ): never {
+  const withCode = <T extends Error>(error: T): T => {
+    Object.assign(error, { code: outcome.code });
+    return error;
+  };
+
   switch (outcome.code) {
     case 'RUN_NOT_FOUND':
-      throw new WorkflowRunNotFoundError(runId);
+      throw withCode(new WorkflowRunNotFoundError(runId));
     case 'STEP_NOT_FOUND':
-      throw new WorkflowWorldError(outcome.message, { status: 404 });
+      throw new WorkflowWorldError(outcome.message, { status: 404, code: outcome.code });
     case 'HOOK_NOT_FOUND':
-      throw new HookNotFoundError(data.correlationId ?? runId);
+      throw withCode(new HookNotFoundError(data.correlationId ?? runId));
     case 'WAIT_NOT_FOUND':
-      throw new WorkflowWorldError(outcome.message, { status: 404 });
+      throw new WorkflowWorldError(outcome.message, { status: 404, code: outcome.code });
     case 'ENTITY_CONFLICT':
-      throw new EntityConflictError(outcome.message);
+      throw withCode(new EntityConflictError(outcome.message));
     case 'HOOK_CLAIM_CANCELLED':
-      throw new WorkflowWorldError(outcome.message, { status: 503 });
+      throw new WorkflowWorldError(outcome.message, { status: 503, code: outcome.code });
     case 'RUN_EXPIRED':
-      throw new RunExpiredError(outcome.message);
+      throw withCode(new RunExpiredError(outcome.message));
     case 'TOO_EARLY':
-      throw new TooEarlyError(outcome.message, { retryAfter: outcome.retryAfterSeconds });
+      throw withCode(new TooEarlyError(outcome.message, { retryAfter: outcome.retryAfterSeconds }));
     case 'RUN_NOT_SUPPORTED':
-      throw new RunNotSupportedError(outcome.runSpecVersion ?? 0, SPEC_VERSION_CURRENT);
+      throw withCode(new RunNotSupportedError(outcome.runSpecVersion ?? 0, SPEC_VERSION_CURRENT));
   }
 }
 
@@ -328,6 +334,15 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
         data: RunCreatedEventRequest | CreateEventRequest,
         params?: CreateEventParams,
       ): Promise<EventResult> {
+        // Parse the public runtime value before run routing or hook admission.
+        // The canonical Workflow schema strips unknown fields and rejects bad
+        // discriminants/missing/wrong-typed fields without any external side
+        // effects.
+        data = CreateEventSchema.parse(compact(data));
+        if (runId !== null && typeof runId !== 'string') {
+          throw new WorkflowWorldError('runId must be a string or null', { status: 400 });
+        }
+
         // For run_created events, generate a runId server-side if absent.
         let effectiveRunId: string;
         if (data.eventType === 'run_created' && (!runId || runId === '')) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -37,13 +37,21 @@ import {
   isTerminalWorkflowRunStatus,
   SPEC_VERSION_CURRENT,
   StepSchema,
+  WaitSchema,
   WorkflowRunSchema,
 } from '@workflow/world';
 import { parse, stringify } from './vendor/shared/index.js';
 import { monotonicFactory } from 'ulid';
-import type { ApplyEventFailure, ApplyEventOutcome, ApplyEventRequest } from './apply-event.js';
+import type {
+  ApplyEventErrorCode,
+  ApplyEventFailure,
+  ApplyEventOutcome,
+  ApplyEventRequest,
+  ApplyEventSuccess,
+} from './apply-event.js';
 import type { HookTokenOwner, IndexNamespace } from './config.js';
 import type { HookReservation } from './indexes.js';
+import { FleetTransportError } from './remote/errors.js';
 import { compact } from './util.js';
 import type { RunReadOutcome } from './retention.js';
 
@@ -110,6 +118,204 @@ function hookOwner(hook: Pick<Hook, 'runId' | 'hookId'>): HookTokenOwner {
   return { runId: hook.runId, hookId: hook.hookId };
 }
 
+const APPLY_EVENT_ERROR_CODES = new Set<string>([
+  'RUN_NOT_FOUND',
+  'STEP_NOT_FOUND',
+  'HOOK_NOT_FOUND',
+  'WAIT_NOT_FOUND',
+  'ENTITY_CONFLICT',
+  'HOOK_CLAIM_CANCELLED',
+  'RUN_EXPIRED',
+  'TOO_EARLY',
+  'RUN_NOT_SUPPORTED',
+] satisfies ApplyEventErrorCode[]);
+
+interface ApplyEventWireFailure {
+  ok: false;
+  code: string;
+  message: string;
+  status?: number;
+  retryAfter?: number;
+  retryAfterSeconds?: number;
+  runSpecVersion?: number;
+  worldSpecVersion?: number;
+  details?: unknown;
+}
+
+type ParsedApplyEventOutcome =
+  | { kind: 'success'; outcome: ApplyEventSuccess }
+  | { kind: 'known-failure'; outcome: ApplyEventFailure & ApplyEventWireFailure }
+  | { kind: 'unknown-failure'; outcome: ApplyEventWireFailure };
+
+function malformedApplyEventOutcome(reason: string): never {
+  throw new FleetTransportError(`world-celld: malformed applyEvent outcome: ${reason}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateOptionalNumber(
+  outcome: Record<string, unknown>,
+  key: 'status' | 'retryAfter' | 'retryAfterSeconds' | 'runSpecVersion' | 'worldSpecVersion',
+  integer: boolean,
+): void {
+  const value = outcome[key];
+  if (
+    value !== undefined &&
+    (typeof value !== 'number' ||
+      !Number.isFinite(value) ||
+      (integer && !Number.isSafeInteger(value)))
+  ) {
+    malformedApplyEventOutcome(`${key} must be ${integer ? 'a safe integer' : 'a finite number'}`);
+  }
+}
+
+function parseSuccessEntity<T>(
+  outcome: Record<string, unknown>,
+  key: 'event' | 'run' | 'step' | 'hook' | 'wait' | 'hookToIndex',
+  schema: {
+    safeParse(value: unknown): { success: true; data: T } | { success: false };
+  },
+): T | undefined {
+  const value = outcome[key];
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) malformedApplyEventOutcome(`${key} is invalid`);
+  const result = schema.safeParse(compact(value));
+  if (!result.success) malformedApplyEventOutcome(`${key} is invalid`);
+  return result.data;
+}
+
+/**
+ * Validate the untrusted value decoded from the remote applyEvent RPC.
+ * Unknown failure codes are intentionally valid and classified separately so
+ * an older client can reconstruct their wire metadata without treating them
+ * as success. All fields consumed by the success path are checked before any
+ * derivative index operation can run.
+ */
+function parseApplyEventOutcome(value: unknown): ParsedApplyEventOutcome {
+  if (!isRecord(value)) malformedApplyEventOutcome('response must be an object');
+
+  if (value.ok === false) {
+    if (typeof value.code !== 'string' || value.code.length === 0) {
+      malformedApplyEventOutcome('failure code must be a non-empty string');
+    }
+    if (typeof value.message !== 'string') {
+      malformedApplyEventOutcome('failure message must be a string');
+    }
+    validateOptionalNumber(value, 'status', true);
+    validateOptionalNumber(value, 'retryAfter', false);
+    validateOptionalNumber(value, 'retryAfterSeconds', false);
+    validateOptionalNumber(value, 'runSpecVersion', true);
+    validateOptionalNumber(value, 'worldSpecVersion', true);
+
+    const outcome = value as unknown as ApplyEventWireFailure;
+    return APPLY_EVENT_ERROR_CODES.has(outcome.code)
+      ? {
+          kind: 'known-failure',
+          outcome: outcome as ApplyEventFailure & ApplyEventWireFailure,
+        }
+      : { kind: 'unknown-failure', outcome };
+  }
+
+  if (value.ok !== true) malformedApplyEventOutcome('ok must be true or false');
+  if (!Array.isArray(value.releasedHooks)) {
+    malformedApplyEventOutcome('releasedHooks must be an array');
+  }
+  for (const releasedHook of value.releasedHooks) {
+    if (
+      !isRecord(releasedHook) ||
+      typeof releasedHook.hookId !== 'string' ||
+      releasedHook.hookId.length === 0 ||
+      typeof releasedHook.token !== 'string' ||
+      releasedHook.token.length === 0
+    ) {
+      malformedApplyEventOutcome('releasedHooks entries must contain hookId and token strings');
+    }
+  }
+
+  const event = parseSuccessEntity(value, 'event', EventSchema);
+  const run = parseSuccessEntity(value, 'run', WorkflowRunSchema);
+  const step = parseSuccessEntity(value, 'step', StepSchema);
+  const hook = parseSuccessEntity(value, 'hook', HookSchema);
+  const wait = parseSuccessEntity(value, 'wait', WaitSchema);
+  const hookToIndex = parseSuccessEntity(value, 'hookToIndex', HookSchema);
+
+  if (value.stepCreated !== undefined && value.stepCreated !== true) {
+    malformedApplyEventOutcome('stepCreated must be true when present');
+  }
+  if (value.runCreated !== undefined) {
+    if (
+      !isRecord(value.runCreated) ||
+      typeof value.runCreated.workflowName !== 'string' ||
+      !(value.runCreated.createdAt instanceof Date) ||
+      Number.isNaN(value.runCreated.createdAt.getTime())
+    ) {
+      malformedApplyEventOutcome('runCreated is invalid');
+    }
+  }
+  let events: Event[] | undefined;
+  if (value.events !== undefined) {
+    if (!Array.isArray(value.events)) malformedApplyEventOutcome('events must be an array');
+    events = value.events.map((candidate) => {
+      if (!isRecord(candidate)) malformedApplyEventOutcome('events contains an invalid event');
+      const result = EventSchema.safeParse(compact(candidate));
+      if (!result.success) {
+        malformedApplyEventOutcome('events contains an invalid event');
+      }
+      return result.data;
+    });
+    if (value.cursor !== null && typeof value.cursor !== 'string') {
+      malformedApplyEventOutcome('cursor is required when events are present');
+    }
+    if (typeof value.hasMore !== 'boolean') {
+      malformedApplyEventOutcome('hasMore is required when events are present');
+    }
+  }
+  if (value.cursor !== undefined && value.cursor !== null && typeof value.cursor !== 'string') {
+    malformedApplyEventOutcome('cursor must be a string or null');
+  }
+  if (value.hasMore !== undefined && typeof value.hasMore !== 'boolean') {
+    malformedApplyEventOutcome('hasMore must be a boolean');
+  }
+  if (
+    value.maxEvents !== undefined &&
+    (typeof value.maxEvents !== 'number' ||
+      !Number.isSafeInteger(value.maxEvents) ||
+      value.maxEvents < 0)
+  ) {
+    malformedApplyEventOutcome('maxEvents must be a non-negative safe integer');
+  }
+  if (run !== undefined && value.indexPublicationExpiresAt === undefined) {
+    malformedApplyEventOutcome('indexPublicationExpiresAt is required when run is present');
+  }
+  if (
+    value.indexPublicationExpiresAt !== undefined &&
+    (typeof value.indexPublicationExpiresAt !== 'number' ||
+      !Number.isFinite(value.indexPublicationExpiresAt))
+  ) {
+    malformedApplyEventOutcome('indexPublicationExpiresAt must be a finite number');
+  }
+
+  return {
+    kind: 'success',
+    outcome: {
+      ...value,
+      event,
+      run,
+      step,
+      hook,
+      wait,
+      hookToIndex,
+      events,
+      releasedHooks: value.releasedHooks.map((releasedHook) => ({
+        hookId: (releasedHook as Record<string, unknown>).hookId as string,
+        token: (releasedHook as Record<string, unknown>).token as string,
+      })),
+    } as ApplyEventSuccess,
+  };
+}
+
 /**
  * Filter data based on ResolveData parameter.
  * When resolveData is 'none', strips specified keys to reduce data transfer.
@@ -149,7 +355,7 @@ function filterHookData(hook: Hook, resolveData: ResolveData): Hook {
  * outcome objects instead of throwing.
  */
 function throwOutcomeError(
-  outcome: ApplyEventFailure,
+  outcome: ApplyEventWireFailure,
   runId: string,
   data: CreateEventRequest | RunCreatedEventRequest,
 ): never {
@@ -177,6 +383,22 @@ function throwOutcomeError(
       throw withCode(new TooEarlyError(outcome.message, { retryAfter: outcome.retryAfterSeconds }));
     case 'RUN_NOT_SUPPORTED':
       throw withCode(new RunNotSupportedError(outcome.runSpecVersion ?? 0, SPEC_VERSION_CURRENT));
+    default: {
+      const error = new WorkflowWorldError(outcome.message, {
+        status: outcome.status,
+        code: outcome.code,
+        retryAfter: outcome.retryAfter,
+      });
+      for (const key of [
+        'retryAfterSeconds',
+        'runSpecVersion',
+        'worldSpecVersion',
+        'details',
+      ] as const) {
+        if (Object.hasOwn(outcome, key)) Object.assign(error, { [key]: outcome[key] });
+      }
+      throw error;
+    }
   }
 }
 
@@ -385,9 +607,9 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
         // A thrown RPC is commit-ambiguous. Resolve it inside the authoritative
         // RunDO: that transaction either observes the committed hook or fences
         // this exact reservation before its token/ID claims are released.
-        let outcome: ApplyEventOutcome;
+        let parsedOutcome: ParsedApplyEventOutcome;
         try {
-          outcome = await stub.applyEvent({
+          const wireOutcome: unknown = await stub.applyEvent({
             runId: effectiveRunId,
             data,
             params,
@@ -395,6 +617,7 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
             hookClaimId: hookAdmission?.reservation.claimId,
             cleanup,
           });
+          parsedOutcome = parseApplyEventOutcome(wireOutcome);
         } catch (error) {
           if (hookAdmission) {
             let resolution: { committed: boolean };
@@ -420,7 +643,7 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
           throw error;
         }
 
-        if (!outcome.ok) {
+        if (parsedOutcome.kind !== 'success') {
           if (hookAdmission) {
             await env.WORKFLOW_INDEX.releaseHookReservation(
               hookAdmission.token,
@@ -428,8 +651,9 @@ export function createStorage(config: CloudflareStorageConfig): Storage {
               hookAdmission.reservation,
             );
           }
-          throwOutcomeError(outcome, effectiveRunId, data);
+          throwOutcomeError(parsedOutcome.outcome, effectiveRunId, data);
         }
+        const outcome = parsedOutcome.outcome;
 
         // Derived indexes are deliberately rewritten on idempotent replay so
         // a committed run or hook can repair an interrupted index update.

--- a/src/worker/durable-objects/WorkflowRunDO.ts
+++ b/src/worker/durable-objects/WorkflowRunDO.ts
@@ -20,6 +20,7 @@ import {
   HOOK_KEY_PREFIX,
   listByCreationTime,
   listByPrefix,
+  parseApplyEventRequest,
   STEP_CREATED_KEY_PREFIX,
   STEP_KEY_PREFIX,
   WAIT_KEY_PREFIX,
@@ -276,6 +277,12 @@ export class WorkflowRunDO extends DurableObject {
 
   /** Apply an event and capture all retention metadata in the same transaction. */
   async applyEvent(request: ApplyEventRequest): Promise<ApplyEventOutcome> {
+    request = parseApplyEventRequest(request);
+    if (this.ctx.id.name !== undefined && request.runId !== this.ctx.id.name) {
+      throw new TypeError(
+        `applyEvent runId "${request.runId}" does not match durable object "${this.ctx.id.name}"`,
+      );
+    }
     if (request.cleanup !== undefined) validateCleanupRequest(request.cleanup, true);
     return await this.ctx.storage.transaction(async (txn) => {
       const now = new Date(this.now());

--- a/src/worker/router.ts
+++ b/src/worker/router.ts
@@ -12,6 +12,7 @@
  * compact binary stream protocol. Only whitelisted routes/methods dispatch.
  */
 import { SPEC_VERSION_CURRENT } from '@workflow/world';
+import { parseApplyEventRequest } from '../apply-event.js';
 import { rpcParse, rpcStringify } from '../codec.js';
 import {
   createWorkflowIndex,
@@ -496,6 +497,25 @@ export function createRouter(env: WorkerEnv) {
       args = parsed;
     } catch {
       return errorResponse(400, 'BadRequest', 'malformed rpc body');
+    }
+
+    if (bindingKey === 'runs' && method === 'applyEvent') {
+      if (args.length !== 1) {
+        return errorResponse(400, 'BadRequest', 'applyEvent expects exactly one request argument');
+      }
+      try {
+        const applyRequest = parseApplyEventRequest(args[0]);
+        if (applyRequest.runId !== name) {
+          return errorResponse(
+            400,
+            'BadRequest',
+            `applyEvent runId "${applyRequest.runId}" does not match routed run "${name}"`,
+          );
+        }
+        args = [applyRequest];
+      } catch (error) {
+        return errorResponse(400, 'BadRequest', (error as Error).message);
+      }
     }
 
     try {

--- a/test/apply-event-negative.test.ts
+++ b/test/apply-event-negative.test.ts
@@ -26,6 +26,7 @@ type ContractError = Error & {
   code?: string;
   status?: number;
   retryAfter?: number;
+  retryAfterMs?: number;
   retryAfterSeconds?: number;
   runSpecVersion?: number;
   worldSpecVersion?: number;
@@ -119,6 +120,7 @@ describe('negative apply-event contract', () => {
           message: 'the server knows more than this client',
           status: 425,
           retryAfter: 17,
+          retryAfterMs: 19_000,
           retryAfterSeconds: 19,
           runSpecVersion: SPEC_VERSION_CURRENT + 2,
           worldSpecVersion: SPEC_VERSION_CURRENT + 1,
@@ -134,6 +136,7 @@ describe('negative apply-event contract', () => {
       message: 'the server knows more than this client',
       status: 425,
       retryAfter: 17,
+      retryAfterMs: 19_000,
       retryAfterSeconds: 19,
       runSpecVersion: SPEC_VERSION_CURRENT + 2,
       worldSpecVersion: SPEC_VERSION_CURRENT + 1,
@@ -157,6 +160,7 @@ describe('negative apply-event contract', () => {
       code: 'FUTURE_FAILURE',
       message: 'minimal future failure',
     });
+    expect(minimal).not.toHaveProperty('retryAfterMs');
   });
 
   it.each([
@@ -168,6 +172,22 @@ describe('negative apply-event contract', () => {
     [
       'wrong-typed failure metadata',
       { ok: false, code: 'FUTURE_FAILURE', message: 'bad status', status: '503' },
+    ],
+    [
+      'wrong-typed retryAfterMs',
+      { ok: false, code: 'FUTURE_FAILURE', message: 'bad retry', retryAfterMs: '19000' },
+    ],
+    [
+      'negative retryAfterMs',
+      { ok: false, code: 'FUTURE_FAILURE', message: 'bad retry', retryAfterMs: -1 },
+    ],
+    [
+      'fractional retryAfterMs',
+      { ok: false, code: 'FUTURE_FAILURE', message: 'bad retry', retryAfterMs: 19.5 },
+    ],
+    [
+      'non-finite retryAfterMs',
+      { ok: false, code: 'FUTURE_FAILURE', message: 'bad retry', retryAfterMs: Infinity },
     ],
     ['missing success fields', { ok: true }],
     ['wrong-typed released hooks', { ok: true, releasedHooks: 'none' }],

--- a/test/apply-event-negative.test.ts
+++ b/test/apply-event-negative.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Negative contract coverage for the complete apply-event path:
+ * storage adapter -> remote client -> HTTP router -> WorkflowRunDO transaction.
+ */
+import {
+  EntityConflictError,
+  HookNotFoundError,
+  RunExpiredError,
+  RunNotSupportedError,
+  TooEarlyError,
+  WorkflowRunNotFoundError,
+  WorkflowWorldError,
+} from '@workflow/errors';
+import { slotToEventId, SPEC_VERSION_CURRENT } from '@workflow/world';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ApplyEventOutcome } from '../src/apply-event.js';
+import { rpcParse, rpcStringify } from '../src/codec.js';
+import { hookIdShardName, hookTokenShardName } from '../src/indexes.js';
+import { createRemoteEnv } from '../src/remote/namespaces.js';
+import { createStorage } from '../src/storage.js';
+import { startHarness, type Harness } from '../src/testing/http-harness.js';
+
+const SECRET = 'apply-event-negative-secret';
+
+type ContractError = Error & {
+  code?: string;
+  status?: number;
+  retryAfter?: number;
+  runSpecVersion?: number;
+  worldSpecVersion?: number;
+};
+
+let harness: Harness;
+
+beforeAll(async () => {
+  harness = await startHarness({ secret: SECRET, virtualClock: true });
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+function remoteEnv(fetchImpl?: typeof fetch) {
+  return createRemoteEnv({
+    fleetUrl: harness.url,
+    secret: SECRET,
+    ...(fetchImpl ? { fetchImpl } : {}),
+  });
+}
+
+function storage(fetchImpl?: typeof fetch) {
+  const env = remoteEnv(fetchImpl);
+  return createStorage({
+    env: { WORKFLOW_DB: env.WORKFLOW_DB, WORKFLOW_INDEX: env.WORKFLOW_INDEX },
+    deploymentId: 'apply-event-negative',
+  });
+}
+
+async function createRun(runId: string) {
+  const result = await storage().events.create(runId, {
+    eventType: 'run_created',
+    eventData: {
+      deploymentId: 'apply-event-negative',
+      workflowName: 'apply-event-negative',
+      input: [],
+    },
+  });
+  return result.run;
+}
+
+function rpc(path: string, body: unknown): Promise<Response> {
+  return fetch(`${harness.url}${path}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${SECRET}`,
+      'content-type': 'application/json',
+    },
+    body: rpcStringify(body),
+  });
+}
+
+async function captureError(promise: Promise<unknown>): Promise<ContractError> {
+  return await promise.then(
+    () => {
+      throw new Error('expected operation to reject');
+    },
+    (error: unknown) => error as ContractError,
+  );
+}
+
+describe('negative apply-event contract', () => {
+  it('rejects malformed schemas and run identity mismatches before dispatch or sequence allocation', async () => {
+    const runId = 'wrun_negative_schema';
+    await createRun(runId);
+    const cell = harness.fleet.cell('runs', runId);
+    const before = structuredClone(cell.storage.data);
+    const beforeAlarm = cell.storage.alarmAt;
+
+    for (const request of [
+      { data: { eventType: 'run_started' } },
+      { runId: '', data: { eventType: 'run_started' } },
+      { runId: 42, data: { eventType: 'run_started' } },
+      { runId, data: { eventType: 'run_started' }, params: { eventCount: '1' } },
+    ]) {
+      const response = await rpc(`/v1/rpc/runs/${runId}/applyEvent`, [request]);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: { name: 'BadRequest' } });
+      expect(cell.storage.data).toEqual(before);
+    }
+
+    const malformedEvents: unknown[] = [
+      { eventType: 'run_exploded', eventData: {} },
+      { eventType: 'run_completed' },
+      {
+        eventType: 'step_created',
+        correlationId: 'bad-step',
+        eventData: { stepName: 42, input: [] },
+      },
+      {
+        eventType: 'hook_created',
+        correlationId: 'bad-hook',
+        eventData: { token: 42 },
+      },
+      {
+        eventType: 'wait_created',
+        correlationId: 'bad-wait',
+        eventData: { resumeAt: 'not-a-date' },
+      },
+      { eventType: 'run_cancelled', eventData: { cancelReason: 42 } },
+    ];
+
+    for (const data of malformedEvents) {
+      const response = await rpc(`/v1/rpc/runs/${runId}/applyEvent`, [{ runId, data }]);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: { name: 'BadRequest' } });
+      expect(cell.storage.data).toEqual(before);
+      expect(cell.storage.alarmAt).toBe(beforeAlarm);
+    }
+
+    const malformedTag = await fetch(`${harness.url}/v1/rpc/runs/${runId}/applyEvent`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${SECRET}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify([
+        {
+          runId,
+          data: {
+            eventType: 'step_created',
+            correlationId: 'bad-tag',
+            eventData: {
+              stepName: 'bad-tag',
+              input: { __type: 'Date', iso: 42 },
+            },
+          },
+        },
+      ]),
+    });
+    expect(malformedTag.status).toBe(400);
+    await expect(malformedTag.json()).resolves.toMatchObject({
+      error: { name: 'BadRequest', message: 'malformed rpc body' },
+    });
+
+    const mismatch = await captureError(
+      remoteEnv()
+        .WORKFLOW_DB.get(remoteEnv().WORKFLOW_DB.idFromName(runId))
+        .applyEvent({
+          runId: 'wrun_wrong_identity',
+          data: { eventType: 'run_started' },
+        }),
+    );
+    expect(mismatch).toMatchObject({ name: 'BadRequest', status: 400 });
+    expect(mismatch.message).toContain('does not match');
+    expect(harness.fleet.cell('runs', 'wrun_wrong_identity').storage.data.size).toBe(0);
+    expect(cell.storage.data).toEqual(before);
+
+    harness.fleet.restartCell('runs', runId);
+    const validResponse = await rpc(`/v1/rpc/runs/${runId}/applyEvent`, [
+      {
+        runId,
+        ignoredEnvelopeField: true,
+        data: {
+          eventType: 'step_created',
+          correlationId: 'valid-after-rejection',
+          ignoredEventField: true,
+          eventData: {
+            stepName: 'valid-after-rejection',
+            input: [],
+            ignoredEventDataField: true,
+          },
+        },
+      },
+    ]);
+    expect(validResponse.status).toBe(200);
+    const valid = rpcParse<ApplyEventOutcome>(await validResponse.text());
+    expect(valid).toMatchObject({
+      ok: true,
+      event: { eventId: slotToEventId(2), eventType: 'step_created' },
+      step: { stepId: 'valid-after-rejection' },
+    });
+    if (!valid.ok || !valid.event || !valid.step) throw new Error('expected valid event outcome');
+    expect(valid.event).not.toHaveProperty('ignoredEventField');
+    expect(valid.event.eventData).not.toHaveProperty('ignoredEventDataField');
+    expect(valid.step).not.toHaveProperty('ignoredEventDataField');
+    expect(cell.storage.data.get('event_sequence')).toBe(2);
+  });
+
+  it('validates canonical event requests before hook-index admission', async () => {
+    const runId = 'wrun_negative_preindex_validation';
+    await createRun(runId);
+    let publicCalls = 0;
+    const countedFetch: typeof fetch = async (input, init) => {
+      publicCalls += 1;
+      return await fetch(input, init);
+    };
+    const eventStorage = storage(countedFetch);
+
+    await expect(
+      eventStorage.events.create(runId, {
+        eventType: 'hook_created',
+        correlationId: 'malformed-before-index',
+        eventData: { token: 'malformed-before-index-token', isWebhook: 'yes' },
+      } as never),
+    ).rejects.toMatchObject({ name: 'ZodError' });
+
+    expect(publicCalls).toBe(0);
+    expect(harness.fleet.cell('runs', runId).storage.data.get('event_sequence')).toBe(1);
+    expect(
+      harness.fleet.cell('hook-tokens', hookTokenShardName('malformed-before-index-token')).storage
+        .data.size,
+    ).toBe(0);
+    expect(
+      harness.fleet.cell('hook-ids', hookIdShardName('malformed-before-index')).storage.data.size,
+    ).toBe(0);
+  });
+
+  it('preserves typed domain codes and details through HTTP outcomes and the storage client', async () => {
+    const runId = 'wrun_negative_domains';
+    await createRun(runId);
+    const env = remoteEnv();
+    const runStub = env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName(runId));
+    const missingStep = {
+      eventType: 'step_completed' as const,
+      correlationId: 'missing-step',
+      eventData: { result: [] },
+    };
+
+    await expect(runStub.applyEvent({ runId, data: missingStep })).resolves.toEqual({
+      ok: false,
+      code: 'STEP_NOT_FOUND',
+      message: 'Step "missing-step" not found',
+    });
+
+    const eventStorage = storage();
+    const stepError = await captureError(eventStorage.events.create(runId, missingStep));
+    expect(stepError).toMatchObject({
+      name: 'WorkflowWorldError',
+      message: 'Step "missing-step" not found',
+      status: 404,
+      code: 'STEP_NOT_FOUND',
+    });
+    expect(WorkflowWorldError.is(stepError)).toBe(true);
+
+    const waitError = await captureError(
+      eventStorage.events.create(runId, {
+        eventType: 'wait_completed',
+        correlationId: 'missing-wait',
+      }),
+    );
+    expect(waitError).toMatchObject({
+      name: 'WorkflowWorldError',
+      message: 'Wait "missing-wait" not found',
+      status: 404,
+      code: 'WAIT_NOT_FOUND',
+    });
+
+    const hookError = await captureError(
+      eventStorage.events.create(runId, {
+        eventType: 'hook_received',
+        correlationId: 'missing-hook',
+        eventData: { payload: [] },
+      }),
+    );
+    expect(HookNotFoundError.is(hookError)).toBe(true);
+    expect(hookError.code).toBe('HOOK_NOT_FOUND');
+
+    const missingRunError = await captureError(
+      eventStorage.events.create('wrun_negative_missing', { eventType: 'run_started' }),
+    );
+    expect(WorkflowRunNotFoundError.is(missingRunError)).toBe(true);
+    expect(missingRunError.code).toBe('RUN_NOT_FOUND');
+
+    expect(harness.fleet.cell('runs', runId).storage.data.get('event_sequence')).toBe(1);
+    const createdStep = await eventStorage.events.create(runId, {
+      eventType: 'step_created',
+      correlationId: 'duplicate-step',
+      eventData: { stepName: 'duplicate-step', input: [] },
+    });
+    expect(createdStep.event?.eventId).toBe(slotToEventId(2));
+    const duplicateError = await captureError(
+      eventStorage.events.create(runId, {
+        eventType: 'step_created',
+        correlationId: 'duplicate-step',
+        eventData: { stepName: 'duplicate-step', input: [] },
+      }),
+    );
+    expect(EntityConflictError.is(duplicateError)).toBe(true);
+    expect(duplicateError.code).toBe('ENTITY_CONFLICT');
+
+    const unsupportedRunId = 'wrun_negative_unsupported';
+    await createRun(unsupportedRunId);
+    const unsupported = await captureError(
+      eventStorage.events.create(unsupportedRunId, {
+        eventType: 'run_started',
+        specVersion: SPEC_VERSION_CURRENT + 1,
+      }),
+    );
+    expect(RunNotSupportedError.is(unsupported)).toBe(true);
+    expect(unsupported).toMatchObject({
+      code: 'RUN_NOT_SUPPORTED',
+      runSpecVersion: SPEC_VERSION_CURRENT + 1,
+      worldSpecVersion: SPEC_VERSION_CURRENT,
+    });
+
+    const retryRunId = 'wrun_negative_too_early';
+    await createRun(retryRunId);
+    await eventStorage.events.create(retryRunId, {
+      eventType: 'step_created',
+      correlationId: 'retry-step',
+      eventData: { stepName: 'retry-step', input: [] },
+    });
+    await eventStorage.events.create(retryRunId, {
+      eventType: 'step_started',
+      correlationId: 'retry-step',
+    });
+    await eventStorage.events.create(retryRunId, {
+      eventType: 'step_retrying',
+      correlationId: 'retry-step',
+      eventData: { error: ['retry'], retryAfter: new Date(harness.fleet.now + 5_000) },
+    });
+    const tooEarly = await captureError(
+      eventStorage.events.create(retryRunId, {
+        eventType: 'step_started',
+        correlationId: 'retry-step',
+      }),
+    );
+    expect(TooEarlyError.is(tooEarly)).toBe(true);
+    expect(tooEarly).toMatchObject({ code: 'TOO_EARLY', retryAfter: 5 });
+    expect(harness.fleet.cell('runs', retryRunId).storage.data.get('event_sequence')).toBe(4);
+    harness.fleet.advance(5_000);
+    const validRetry = await eventStorage.events.create(retryRunId, {
+      eventType: 'step_started',
+      correlationId: 'retry-step',
+    });
+    expect(validRetry.event?.eventId).toBe(slotToEventId(5));
+
+    await eventStorage.events.create(runId, {
+      eventType: 'run_completed',
+      eventData: { output: [] },
+    });
+    const terminal = await captureError(
+      eventStorage.events.create(runId, {
+        eventType: 'run_completed',
+        eventData: { output: [] },
+      }),
+    );
+    expect(EntityConflictError.is(terminal)).toBe(true);
+    expect(terminal.code).toBe('ENTITY_CONFLICT');
+    const expired = await captureError(
+      eventStorage.events.create(runId, { eventType: 'run_started' }),
+    );
+    expect(RunExpiredError.is(expired)).toBe(true);
+    expect(expired.code).toBe('RUN_EXPIRED');
+  });
+
+  it('rolls back staged hook state, resolves cancellation races, and retries densely after restart', async () => {
+    const runId = 'wrun_negative_hook_rollback';
+    await createRun(runId);
+    const eventStorage = storage();
+    const hookId = 'rollback-hook';
+    const token = 'rollback-token';
+    const runCell = harness.fleet.cell('runs', runId);
+    const beforeAlarm = runCell.storage.alarmAt;
+    runCell.storage.failNextMutation(
+      (mutation) => mutation.operation === 'put' && mutation.key.startsWith('event:'),
+      new Error('injected final event write failure'),
+    );
+
+    await expect(
+      eventStorage.events.create(runId, {
+        eventType: 'hook_created',
+        correlationId: hookId,
+        eventData: { token },
+      }),
+    ).rejects.toThrow('injected final event write failure');
+
+    expect(runCell.storage.data.get('event_sequence')).toBe(1);
+    expect(runCell.storage.data.has(`hook:${hookId}`)).toBe(false);
+    expect([...runCell.storage.data.keys()].some((key) => key.startsWith('hookcreated:'))).toBe(
+      false,
+    );
+    expect([...runCell.storage.data.keys()].some((key) => key.startsWith('hookevent:'))).toBe(
+      false,
+    );
+    expect(runCell.storage.alarmAt).toBe(beforeAlarm);
+    expect(harness.fleet.cell('hook-tokens', hookTokenShardName(token)).storage.data.size).toBe(0);
+    expect(harness.fleet.cell('hook-ids', hookIdShardName(hookId)).storage.data.size).toBe(0);
+
+    harness.fleet.restartCell('runs', runId);
+    const retry = await eventStorage.events.create(runId, {
+      eventType: 'hook_created',
+      correlationId: hookId,
+      eventData: { token },
+    });
+    expect(retry.event?.eventId).toBe(slotToEventId(2));
+    await expect(eventStorage.hooks.getByToken(token)).resolves.toMatchObject({ runId, hookId });
+
+    const cancellationRunId = 'wrun_negative_hook_cancellation';
+    await createRun(cancellationRunId);
+    const cancellationHookId = 'cancelled-hook';
+    const cancellationToken = 'cancelled-token';
+    const owner = { runId: cancellationRunId, hookId: cancellationHookId };
+    const env = remoteEnv();
+    const admission = await env.WORKFLOW_INDEX.reserveHook(cancellationToken, owner);
+    if (!admission.admitted) throw new Error('expected initial hook admission');
+    const cancellationRun = env.WORKFLOW_DB.get(env.WORKFLOW_DB.idFromName(cancellationRunId));
+    await expect(
+      cancellationRun.resolveHookTokenClaim({
+        hookId: cancellationHookId,
+        token: cancellationToken,
+        claimId: admission.reservation.claimId,
+      }),
+    ).resolves.toEqual({ committed: false });
+
+    let applyAttempts = 0;
+    const countedFetch: typeof fetch = async (input, init) => {
+      const path = new URL(input instanceof Request ? input.url : String(input)).pathname;
+      if (path.endsWith(`/${cancellationRunId}/applyEvent`)) applyAttempts += 1;
+      return await fetch(input, init);
+    };
+    const cancellationStorage = storage(countedFetch);
+    const cancelled = await captureError(
+      cancellationStorage.events.create(cancellationRunId, {
+        eventType: 'hook_created',
+        correlationId: cancellationHookId,
+        eventData: { token: cancellationToken },
+      }),
+    );
+    expect(cancelled).toMatchObject({
+      name: 'WorkflowWorldError',
+      status: 503,
+      code: 'HOOK_CLAIM_CANCELLED',
+    });
+    expect(applyAttempts).toBe(1);
+    expect(
+      harness.fleet.cell('hook-tokens', hookTokenShardName(cancellationToken)).storage.data.size,
+    ).toBe(0);
+    expect(
+      harness.fleet.cell('hook-ids', hookIdShardName(cancellationHookId)).storage.data.size,
+    ).toBe(0);
+    expect(
+      [...harness.fleet.cell('runs', cancellationRunId).storage.data.keys()].some((key) =>
+        key.startsWith('hook:'),
+      ),
+    ).toBe(false);
+
+    const cancellationRetry = await cancellationStorage.events.create(cancellationRunId, {
+      eventType: 'hook_created',
+      correlationId: cancellationHookId,
+      eventData: { token: cancellationToken },
+    });
+    expect(cancellationRetry.event?.eventId).toBe(slotToEventId(2));
+    await expect(cancellationStorage.hooks.getByToken(cancellationToken)).resolves.toMatchObject({
+      runId: cancellationRunId,
+      hookId: cancellationHookId,
+    });
+  });
+});

--- a/test/apply-event-negative.test.ts
+++ b/test/apply-event-negative.test.ts
@@ -26,8 +26,10 @@ type ContractError = Error & {
   code?: string;
   status?: number;
   retryAfter?: number;
+  retryAfterSeconds?: number;
   runSpecVersion?: number;
   worldSpecVersion?: number;
+  details?: unknown;
 };
 
 let harness: Harness;
@@ -88,7 +90,107 @@ async function captureError(promise: Promise<unknown>): Promise<ContractError> {
   );
 }
 
+function applyOutcomeFetch(outcome: unknown): typeof fetch {
+  return async (input, init) => {
+    const path = new URL(input instanceof Request ? input.url : String(input)).pathname;
+    if (path.endsWith('/applyEvent')) {
+      return new Response(rpcStringify(outcome), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return await fetch(input, init);
+  };
+}
+
 describe('negative apply-event contract', () => {
+  it('reconstructs unknown structured failures without entering the success path', async () => {
+    const details = {
+      reason: 'new server-side failure mode',
+      observedAt: new Date('2026-08-23T20:00:00.000Z'),
+      digest: new Uint8Array([0, 1, 254, 255]),
+      nested: { retryable: true },
+    };
+    const full = await captureError(
+      storage(
+        applyOutcomeFetch({
+          ok: false,
+          code: 'FUTURE_FAILURE',
+          message: 'the server knows more than this client',
+          status: 425,
+          retryAfter: 17,
+          retryAfterSeconds: 19,
+          runSpecVersion: SPEC_VERSION_CURRENT + 2,
+          worldSpecVersion: SPEC_VERSION_CURRENT + 1,
+          details,
+        }),
+      ).events.create('wrun_future_failure_full', { eventType: 'run_started' }),
+    );
+
+    expect(WorkflowWorldError.is(full)).toBe(true);
+    expect(full).toMatchObject({
+      name: 'WorkflowWorldError',
+      code: 'FUTURE_FAILURE',
+      message: 'the server knows more than this client',
+      status: 425,
+      retryAfter: 17,
+      retryAfterSeconds: 19,
+      runSpecVersion: SPEC_VERSION_CURRENT + 2,
+      worldSpecVersion: SPEC_VERSION_CURRENT + 1,
+      details,
+    });
+
+    // Mutation sentinel: removing the unknown-code fallback makes this reach
+    // success-only `releasedHooks` access and changes the error to TypeError.
+    const minimal = await captureError(
+      storage(
+        applyOutcomeFetch({
+          ok: false,
+          code: 'FUTURE_FAILURE',
+          message: 'minimal future failure',
+        }),
+      ).events.create('wrun_future_failure_minimal', { eventType: 'run_started' }),
+    );
+    expect(WorkflowWorldError.is(minimal)).toBe(true);
+    expect(minimal).toMatchObject({
+      name: 'WorkflowWorldError',
+      code: 'FUTURE_FAILURE',
+      message: 'minimal future failure',
+    });
+  });
+
+  it.each([
+    ['missing discriminant', {}],
+    ['missing failure fields', { ok: false }],
+    ['non-string failure code', { ok: false, code: 503, message: 'bad code' }],
+    ['missing failure message', { ok: false, code: 'FUTURE_FAILURE' }],
+    ['non-string failure message', { ok: false, code: 'FUTURE_FAILURE', message: 503 }],
+    [
+      'wrong-typed failure metadata',
+      { ok: false, code: 'FUTURE_FAILURE', message: 'bad status', status: '503' },
+    ],
+    ['missing success fields', { ok: true }],
+    ['wrong-typed released hooks', { ok: true, releasedHooks: 'none' }],
+    ['malformed released hook', { ok: true, releasedHooks: [{ hookId: 'hook-only' }] }],
+    ['malformed success entity', { ok: true, releasedHooks: [], run: 'not-a-run' }],
+    [
+      'wrong-typed success metadata',
+      { ok: true, releasedHooks: [], indexPublicationExpiresAt: 'never' },
+    ],
+    ['missing event pagination', { ok: true, releasedHooks: [], events: [] }],
+  ])('rejects a malformed applyEvent outcome: %s', async (_label, outcome) => {
+    const error = await captureError(
+      storage(applyOutcomeFetch(outcome)).events.create('wrun_malformed_outcome', {
+        eventType: 'run_started',
+      }),
+    );
+
+    expect(error).toMatchObject({
+      name: 'FleetTransportError',
+      message: expect.stringContaining('world-celld: malformed applyEvent outcome:'),
+    });
+  });
+
   it('rejects malformed schemas and run identity mismatches before dispatch or sequence allocation', async () => {
     const runId = 'wrun_negative_schema';
     await createRun(runId);


### PR DESCRIPTION
## Summary

- validate and canonicalize public apply-event requests before hook-index admission, HTTP dispatch, or RunDO transaction and sequence allocation
- validate the untrusted structured applyEvent response before any success-only field or derivative index is used
- reconstruct all nine known failure codes with their existing typed subclasses and semantics
- reconstruct future unknown failure codes as WorkflowWorldError while preserving exact wire code, message, status, retryAfter, retryAfterMs, retryAfterSeconds, runSpecVersion, worldSpecVersion, and structured details

## Production defects fixed

1. Malformed hook events could reserve token and hook-ID claims before canonical event validation.
2. Malformed direct applyEvent RPC values surfaced as HTTP 500, and request and route run identities could disagree before RunDO dispatch.
3. Known structured apply-event codes were discarded while rebuilding typed client errors.
4. Unknown structured failure codes fell through the closed switch into success-only releasedHooks access, producing an incidental TypeError and losing all wire error metadata.
5. The forward-compatible unknown-failure path omitted retryAfterMs from both runtime validation and generic error reconstruction. It now accepts only a nonnegative safe integer and copies the exact value without coercion.

## Contract coverage

- STEP_NOT_FOUND, WAIT_NOT_FOUND, HOOK_NOT_FOUND, RUN_NOT_FOUND, ENTITY_CONFLICT, RUN_EXPIRED, TOO_EARLY, RUN_NOT_SUPPORTED, and HOOK_CLAIM_CANCELLED, including the documented single apply attempt and status 503 cancellation outcome
- FUTURE_FAILURE with every supported optional field and structured tagged values, including exact retryAfterMs 19000 preservation, plus a minimal unknown failure that proves retryAfterMs remains absent
- string, negative, fractional, and non-finite retryAfterMs values deterministically produce FleetTransportError
- malformed outcome discriminants, missing and wrong-typed failure fields and metadata, missing and wrong-typed success fields, malformed released hooks and entities, and missing event pagination
- malformed request discriminants, family fields, tagged JSON, decoded params, run IDs, and route identity mismatches
- unchanged sequence, entity, index, hook, wait, step, and alarm state after rejection; dense valid retry after restart
- rollback of staged hook and index work after an injected final event-write failure; cancellation fencing without orphan claims; deterministic duplicate transitions

## Validation

- focused apply-event, codec, Durable Object, index, router, RPC, storage, ordering, retention, and Workflow 5 suites: 11 files, 208 tests passed
- explicit mutation: routing unknown failure as success makes the future-failure regression fail; restoring the guard passes
- full pnpm check: format, type-aware lint, typecheck, build, 24 files and 540 tests, worker bundle, and package check passed
- integration config: 1 passed, 13 environment-gated cases skipped
- hosted CI at 6e2a860775fff85d53629a67cb0f3e9a2e08fd5a: Node 22 / pnpm, celld v0.3.0 restart smoke, and GitHub Actions security all passed

## Residual limitations

- Unknown codes intentionally receive no invented product-specific subclass or semantics; the generic WorkflowWorldError preserves the server metadata.
- Workflow 5 Zod object schemas strip unknown keys rather than rejecting them. Coverage verifies those fields do not persist.
- Native integration cases without configured services remain skipped locally; the hosted real celld restart smoke passed.
